### PR TITLE
add default version input in custom artifacts

### DIFF
--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.136.1",
+  "version": "15.141.0",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",
@@ -194,6 +194,33 @@
                   "dataType": "string",
                   "maxLength": 300
               }
+          },
+          {
+            "id": "defaultVersionType",
+            "name": "i18n:Default version",
+            "description": "i18n:The default version will be deployed when new releases are created. The version can be changed for manually created releases at the time of release creation",
+            "inputMode": "Combo",
+            "isConfidential": false,
+            "hasDynamicValueInformation": false,
+            "values": {
+              "inputId": "defaultVersionType",
+              "defaultValue": "i18n:Latest",
+              "possibleValues": [
+                {
+                  "value": "latestType",
+                  "displayValue": "i18n:Latest"
+                },
+                {
+                  "value": "selectDuringReleaseCreationType",
+                  "displayValue": "i18n:Specify at the time of release creation"
+                }
+              ],
+              "isLimitedToPossibleValues": true
+            },
+            "validation": {
+              "isRequired": true,
+              "dataType": "string"
+            }
           }
         ],
         "dataSourceBindings": [

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -203,8 +203,8 @@
             "isConfidential": false,
             "hasDynamicValueInformation": false,
             "values": {
-              "inputId": "defaultVersionType",
-              "defaultValue": "i18n:Latest",
+              "inputId": "defaultVersionTypeValues",
+              "defaultValue": "latestType",
               "possibleValues": [
                 {
                   "value": "latestType",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -197,22 +197,22 @@
           },
           {
             "id": "defaultVersionType",
-            "name": "i18n:Default version",
-            "description": "i18n:The default version will be deployed when new releases are created. The version can be changed for manually created releases at the time of release creation",
+            "name": "Default version",
+            "description": "The default version will be deployed when new releases are created. The version can be changed for manually created releases at the time of release creation",
             "inputMode": "Combo",
             "isConfidential": false,
             "hasDynamicValueInformation": false,
             "values": {
               "inputId": "defaultVersionTypeValues",
-              "defaultValue": "latestType",
+              "defaultValue": "latestFromBranchType",
               "possibleValues": [
                 {
-                  "value": "latestType",
-                  "displayValue": "i18n:Latest"
+                  "value": "latestFromBranchType",
+                  "displayValue": "Latest from the default branch"
                 },
                 {
                   "value": "selectDuringReleaseCreationType",
-                  "displayValue": "i18n:Specify at the time of release creation"
+                  "displayValue": "Specify at the time of release creation"
                 }
               ],
               "isLimitedToPossibleValues": true

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -295,8 +295,8 @@
             "isConfidential": false,
             "hasDynamicValueInformation": false,
             "values": {
-              "inputId": "defaultVersionType",
-              "defaultValue": "i18n:Latest",
+              "inputId": "defaultVersionTypeValues",
+              "defaultValue": "latestType",
               "possibleValues": [
                 {
                   "value": "latestType",
@@ -466,8 +466,8 @@
                   "isConfidential": false,
                   "hasDynamicValueInformation": false,
                   "values": {
-                    "inputId": "defaultVersionType",
-                    "defaultValue": "i18n:Latest",
+                    "inputId": "defaultVersionTypeValues",
+                    "defaultValue": "latestType",
                     "possibleValues": [
                       {
                         "value": "latestType",
@@ -638,8 +638,8 @@
               "isConfidential": false,
               "hasDynamicValueInformation": false,
               "values": {
-                "inputId": "defaultVersionType",
-                "defaultValue": "i18n:Latest",
+                "inputId": "defaultVersionTypeValues",
+                "defaultValue": "latestType",
                 "possibleValues": [
                   {
                     "value": "latestType",
@@ -797,8 +797,8 @@
             "isConfidential": false,
             "hasDynamicValueInformation": false,
             "values": {
-              "inputId": "defaultVersionType",
-              "defaultValue": "i18n:Latest",
+              "inputId": "defaultVersionTypeValues",
+              "defaultValue": "latestType",
               "possibleValues": [
                 {
                   "value": "latestType",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 ﻿{
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "15.138.1",
+  "version": "15.141.0",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ VS-Team-Services artifacts using Release Management",
@@ -288,6 +288,33 @@
             }
           },
           {
+            "id": "defaultVersionType",
+            "name": "i18n:Default version",
+            "description": "i18n:The default version will be deployed when new releases are created. The version can be changed for manually created releases at the time of release creation",
+            "inputMode": "Combo",
+            "isConfidential": false,
+            "hasDynamicValueInformation": false,
+            "values": {
+              "inputId": "defaultVersionType",
+              "defaultValue": "i18n:Latest",
+              "possibleValues": [
+                {
+                  "value": "latestType",
+                  "displayValue": "i18n:Latest"
+                },
+                {
+                  "value": "selectDuringReleaseCreationType",
+                  "displayValue": "i18n:Specify at the time of release creation"
+                }
+              ],
+              "isLimitedToPossibleValues": true
+            },
+            "validation": {
+              "isRequired": true,
+              "dataType": "string"
+            }
+          },
+          {
             "id": "artifacts",
             "name": "Artifacts",
             "description": "Build artifacts",
@@ -430,6 +457,33 @@
                         "dataType": "string",
                         "maxLength": 300
                     }
+                },
+                {
+                  "id": "defaultVersionType",
+                  "name": "i18n:Default version",
+                  "description": "i18n:The default version will be deployed when new releases are created. The version can be changed for manually created releases at the time of release creation",
+                  "inputMode": "Combo",
+                  "isConfidential": false,
+                  "hasDynamicValueInformation": false,
+                  "values": {
+                    "inputId": "defaultVersionType",
+                    "defaultValue": "i18n:Latest",
+                    "possibleValues": [
+                      {
+                        "value": "latestType",
+                        "displayValue": "i18n:Latest"
+                      },
+                      {
+                        "value": "selectDuringReleaseCreationType",
+                        "displayValue": "i18n:Specify at the time of release creation"
+                      }
+                    ],
+                    "isLimitedToPossibleValues": true
+                  },
+                  "validation": {
+                    "isRequired": true,
+                    "dataType": "string"
+                  }
                 },
                 {
                     "id": "artifacts",
@@ -577,6 +631,33 @@
                 }
             },
             {
+              "id": "defaultVersionType",
+              "name": "i18n:Default version",
+              "description": "i18n:The default version will be deployed when new releases are created. The version can be changed for manually created releases at the time of release creation",
+              "inputMode": "Combo",
+              "isConfidential": false,
+              "hasDynamicValueInformation": false,
+              "values": {
+                "inputId": "defaultVersionType",
+                "defaultValue": "i18n:Latest",
+                "possibleValues": [
+                  {
+                    "value": "latestType",
+                    "displayValue": "i18n:Latest"
+                  },
+                  {
+                    "value": "selectDuringReleaseCreationType",
+                    "displayValue": "i18n:Specify at the time of release creation"
+                  }
+                ],
+                "isLimitedToPossibleValues": true
+              },
+              "validation": {
+                "isRequired": true,
+                "dataType": "string"
+              }
+            },
+            {
                 "id": "artifacts",
                 "name": "Artifacts",
                 "description": "Source Artifacts",
@@ -706,6 +787,33 @@
               "isRequired": true,
               "dataType": "string",
               "maxLength": 300
+            }
+          },
+          {
+            "id": "defaultVersionType",
+            "name": "i18n:Default version",
+            "description": "i18n:The default version will be deployed when new releases are created. The version can be changed for manually created releases at the time of release creation",
+            "inputMode": "Combo",
+            "isConfidential": false,
+            "hasDynamicValueInformation": false,
+            "values": {
+              "inputId": "defaultVersionType",
+              "defaultValue": "i18n:Latest",
+              "possibleValues": [
+                {
+                  "value": "latestType",
+                  "displayValue": "i18n:Latest"
+                },
+                {
+                  "value": "selectDuringReleaseCreationType",
+                  "displayValue": "i18n:Specify at the time of release creation"
+                }
+              ],
+              "isLimitedToPossibleValues": true
+            },
+            "validation": {
+              "isRequired": true,
+              "dataType": "string"
             }
           },
           {

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -289,8 +289,8 @@
           },
           {
             "id": "defaultVersionType",
-            "name": "i18n:Default version",
-            "description": "i18n:The default version will be deployed when new releases are created. The version can be changed for manually created releases at the time of release creation",
+            "name": "Default version",
+            "description": "The default version will be deployed when new releases are created. The version can be changed for manually created releases at the time of release creation",
             "inputMode": "Combo",
             "isConfidential": false,
             "hasDynamicValueInformation": false,
@@ -300,11 +300,11 @@
               "possibleValues": [
                 {
                   "value": "latestType",
-                  "displayValue": "i18n:Latest"
+                  "displayValue": "Latest"
                 },
                 {
                   "value": "selectDuringReleaseCreationType",
-                  "displayValue": "i18n:Specify at the time of release creation"
+                  "displayValue": "Specify at the time of release creation"
                 }
               ],
               "isLimitedToPossibleValues": true
@@ -460,8 +460,8 @@
                 },
                 {
                   "id": "defaultVersionType",
-                  "name": "i18n:Default version",
-                  "description": "i18n:The default version will be deployed when new releases are created. The version can be changed for manually created releases at the time of release creation",
+                  "name": "Default version",
+                  "description": "The default version will be deployed when new releases are created. The version can be changed for manually created releases at the time of release creation",
                   "inputMode": "Combo",
                   "isConfidential": false,
                   "hasDynamicValueInformation": false,
@@ -471,11 +471,11 @@
                     "possibleValues": [
                       {
                         "value": "latestType",
-                        "displayValue": "i18n:Latest"
+                        "displayValue": "Latest"
                       },
                       {
                         "value": "selectDuringReleaseCreationType",
-                        "displayValue": "i18n:Specify at the time of release creation"
+                        "displayValue": "Specify at the time of release creation"
                       }
                     ],
                     "isLimitedToPossibleValues": true
@@ -632,22 +632,22 @@
             },
             {
               "id": "defaultVersionType",
-              "name": "i18n:Default version",
-              "description": "i18n:The default version will be deployed when new releases are created. The version can be changed for manually created releases at the time of release creation",
+              "name": "Default version",
+              "description": "The default version will be deployed when new releases are created. The version can be changed for manually created releases at the time of release creation",
               "inputMode": "Combo",
               "isConfidential": false,
               "hasDynamicValueInformation": false,
               "values": {
                 "inputId": "defaultVersionTypeValues",
-                "defaultValue": "latestType",
+                "defaultValue": "latestFromBranchType",
                 "possibleValues": [
                   {
-                    "value": "latestType",
-                    "displayValue": "i18n:Latest"
+                    "value": "latestFromBranchType",
+                    "displayValue": "Latest from the default branch"
                   },
                   {
                     "value": "selectDuringReleaseCreationType",
-                    "displayValue": "i18n:Specify at the time of release creation"
+                    "displayValue": "Specify at the time of release creation"
                   }
                 ],
                 "isLimitedToPossibleValues": true
@@ -791,8 +791,8 @@
           },
           {
             "id": "defaultVersionType",
-            "name": "i18n:Default version",
-            "description": "i18n:The default version will be deployed when new releases are created. The version can be changed for manually created releases at the time of release creation",
+            "name": "Default version",
+            "description": "The default version will be deployed when new releases are created. The version can be changed for manually created releases at the time of release creation",
             "inputMode": "Combo",
             "isConfidential": false,
             "hasDynamicValueInformation": false,
@@ -802,11 +802,11 @@
               "possibleValues": [
                 {
                   "value": "latestType",
-                  "displayValue": "i18n:Latest"
+                  "displayValue": "Latest"
                 },
                 {
                   "value": "selectDuringReleaseCreationType",
-                  "displayValue": "i18n:Specify at the time of release creation"
+                  "displayValue": "Specify at the time of release creation"
                 }
               ],
               "isLimitedToPossibleValues": true

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.136.0",
+  "version": "15.141.0",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",
@@ -174,6 +174,33 @@
               "isRequired": true,
               "dataType": "string",
               "maxLength": 300
+            }
+          },
+          {
+            "id": "defaultVersionType",
+            "name": "i18n:Default version",
+            "description": "i18n:The default version will be deployed when new releases are created. The version can be changed for manually created releases at the time of release creation",
+            "inputMode": "Combo",
+            "isConfidential": false,
+            "hasDynamicValueInformation": false,
+            "values": {
+              "inputId": "defaultVersionType",
+              "defaultValue": "i18n:Latest",
+              "possibleValues": [
+                {
+                  "value": "latestType",
+                  "displayValue": "i18n:Latest"
+                },
+                {
+                  "value": "selectDuringReleaseCreationType",
+                  "displayValue": "i18n:Specify at the time of release creation"
+                }
+              ],
+              "isLimitedToPossibleValues": true
+            },
+            "validation": {
+              "isRequired": true,
+              "dataType": "string"
             }
           },
           {

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -178,8 +178,8 @@
           },
           {
             "id": "defaultVersionType",
-            "name": "i18n:Default version",
-            "description": "i18n:The default version will be deployed when new releases are created. The version can be changed for manually created releases at the time of release creation",
+            "name": "Default version",
+            "description": "The default version will be deployed when new releases are created. The version can be changed for manually created releases at the time of release creation",
             "inputMode": "Combo",
             "isConfidential": false,
             "hasDynamicValueInformation": false,
@@ -189,11 +189,11 @@
               "possibleValues": [
                 {
                   "value": "latestType",
-                  "displayValue": "i18n:Latest"
+                  "displayValue": "Latest"
                 },
                 {
                   "value": "selectDuringReleaseCreationType",
-                  "displayValue": "i18n:Specify at the time of release creation"
+                  "displayValue": "Specify at the time of release creation"
                 }
               ],
               "isLimitedToPossibleValues": true

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -184,8 +184,8 @@
             "isConfidential": false,
             "hasDynamicValueInformation": false,
             "values": {
-              "inputId": "defaultVersionType",
-              "defaultValue": "i18n:Latest",
+              "inputId": "defaultVersionTypeValues",
+              "defaultValue": "latestType",
               "possibleValues": [
                 {
                   "value": "latestType",


### PR DESCRIPTION
add default version input in custom artifacts (bitbucket, teamcity and external tfs artifacts) with latest and select during release creation type as options.