### PR TITLE
TeamCity versions datasource binding with pagination and larger page size

### DIFF
--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -78,11 +78,6 @@
             "resultSelector": "jsonpath:$.buildType[*]"
           },
           {
-            "name": "Builds",
-            "endpointUrl": "{{endpoint.url}}httpAuth/app/rest/buildTypes/{{definition}}/builds/?locator=branch:default:any",
-            "resultSelector": "jsonpath:$.build[?(@.status=='SUCCESS')]"
-          },
-          {
             "name": "LatestBuild",
             "endpointUrl": "{{endpoint.url}}httpAuth/app/rest/buildTypes/{{definition}}/builds?locator=branch:default:any&count=1&status=success",
             "resultSelector": "jsonpath:$.build[*]"
@@ -208,8 +203,12 @@
           },
           {
             "target": "versions",
-            "dataSourceName": "Builds",
-            "resultTemplate": "{ Value : \"{{id}}\", DisplayValue : \"{{{number}}}\" }"
+            "endpointUrl": "{{endpoint.url}}httpAuth/app/rest/buildTypes/{{definition}}/builds/?locator=branch:default:any,count:2000,start:0{{skip}}",
+            "resultSelector": "jsonpath:$.build[?(@.status=='SUCCESS')]",
+            "resultTemplate": "{ Value : \"{{id}}\", DisplayValue : \"{{{number}}}\" }",
+            "callbackContextTemplate": "{\"skip\": \"{{add skip 2000}}\"}",
+            "callbackRequiredTemplate": "{{ result.nextHref }}",
+            "initialContextTemplate": "{\"skip\": \"0\"}"
           },
           {
             "target": "latestversion",


### PR DESCRIPTION
This was an optimistic change, which doesn't quite work as I'd hoped - I want all of my TeamCity builds listed, because 

It looks like the 'versions' endpoint ignores the pagination when fetching, and I don't think there's anything I can do about that, but I'd love to be wrong!

The default number of builds returned by TeamCity is 100 so this is still an improvement, and maybe one day the pagination will be supported.