### PR TITLE
Missing curly brackets

### DIFF
--- a/docs/authoring/endpoints/dataSources.md
+++ b/docs/authoring/endpoints/dataSources.md
@@ -267,9 +267,9 @@ For e.g. below is a dataSourceBinding for querying alert rules defined in Micros
 	{
 		"target": "alertRules",
 		"endpointId": "$(connectedServiceNameARM)",
-		"endpointUrl": "{{endpoint.url}}subscriptions/{{endpoint.subscriptionId}}/resourcegroups/$(ResourceGroupName)/providers/microsoft.insights/alertrules?api-version=2016-03-01&$filter=targetResourceUri eq /subscriptions/{{endpoint.subscriptionId}}/resourceGroups/$(ResourceGroupName)/providers/$(ResourceType)/$(resourceName)",
+		"endpointUrl": "{{{endpoint.url}}}subscriptions/{{{endpoint.subscriptionId}}}/resourcegroups/$(ResourceGroupName)/providers/microsoft.insights/alertrules?api-version=2016-03-01&$filter=targetResourceUri eq /subscriptions/{{{endpoint.subscriptionId}}}/resourceGroups/$(ResourceGroupName)/providers/$(ResourceType)/$(resourceName)",
 		"resultSelector": "jsonpath:$.value[?(@.properties.isEnabled == true)]",
-		"resultTemplate": "{ \"Value\" : \"{{name}}\", \"DisplayValue\":\"{{name}}\"}"
+		"resultTemplate": "{ \"Value\" : \"{{{name}}}\", \"DisplayValue\":\"{{{name}}}\"}"
 	}
 ]
 ```


### PR DESCRIPTION
The template variables for data source endpoints etc. require three curly brackets, not just two. (See also e.g. the `AzureResourceGroups` data source in https://docs.microsoft.com/en-us/rest/api/vsts/serviceendpoint/types/list?view=vsts-rest-4.1#examples ).