### PR TITLE
Data sources for state and priority updated

### DIFF
--- a/Extensions/ServiceNow/Src/Tasks/CreateAndQueryChangeRequest/task.json
+++ b/Extensions/ServiceNow/Src/Tasks/CreateAndQueryChangeRequest/task.json
@@ -156,7 +156,6 @@
       "name": "DesiredExitStatus",
       "type": "pickList",
       "label": "Desired status of change request",
-      "defaultValue": "New",
       "required": "true",
       "groupName": "completionOptions",
       "helpMarkDown": "Choose or type status of change request that indicates the change request is ready to be implemented. Gate would succeed when the the change request status is same as the provided value.",

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [
@@ -88,13 +88,19 @@
         "dataSources": [
           {
             "name": "Priority",
-            "endpointUrl": "{{endpoint.url}}/api/now/table/sys_choice?sysparm_query=element=priority^name=change_request&sysparm_fields=label",
-            "resultSelector": "jsonpath:$.result[*].label"
+            "endpointUrl": "{{endpoint.url}}/api/now/table/sys_choice?sysparm_query=element=priority^name={{table}}&sysparm_fields=label",
+            "resultSelector": "jsonpath:$.result[*].label",
+            "callbackContextTemplate": "{\"table\": \"task\"}",
+            "callbackRequiredTemplate": "{{#equals table \"change_request\"}}{{isEqualNumber result.count 0}}{{else}}false{{/equals}}",
+            "initialContextTemplate": "{\"table\": \"change_request\"}"
           },
           {
             "name": "State",
-            "endpointUrl": "{{endpoint.url}}/api/now/table/sys_choice?sysparm_query=element=state^name=change_request&sysparm_fields=label",
-            "resultSelector": "jsonpath:$.result[*].label"
+            "endpointUrl": "{{endpoint.url}}/api/now/table/sys_choice?sysparm_query=element=state^name={{table}}&sysparm_fields=label",
+            "resultSelector": "jsonpath:$.result[*].label",
+            "callbackContextTemplate": "{\"table\": \"task\"}",
+            "callbackRequiredTemplate": "{{#equals table \"change_request\"}}{{isEqualNumber result.count 0}}{{else}}false{{/equals}}",
+            "initialContextTemplate": "{\"table\": \"change_request\"}"
           },
           {
             "name": "Risk",


### PR DESCRIPTION
- Callback added for 'state' and 'priority' property  - to query Task table if results are not returned for change_request table.
- Default value for state is removed. Since for older change management system, state labels are different, Hard coding default is wrong. 