### PR TITLE
Adding Guid to the dynamic inventory temp file

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleCommandLineInterface.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleCommandLineInterface.ts
@@ -4,6 +4,7 @@ import * as ansibleUtils from './ansibleUtils';
 import { RemoteCommandOptions } from './ansibleUtils'
 import { ansibleTaskParameters } from './ansibleTaskParameters';
 
+var guid = require('guid-typescript');
 var os = require('os');
 var shell = require('shelljs');
 
@@ -130,7 +131,7 @@ export class ansibleCommandLineInterface extends ansibleInterface {
 
         return new Promise<string>(async (resolve, reject) => {
             try {
-                let remoteInventory = '/tmp/' + 'inventory.ini';
+                let remoteInventory = '/tmp/' + guid.Guid.create().toString() + 'inventory.ini';
                 let remoteInventoryPath = '"' + remoteInventory + '"';
                 tl.debug('RemoteInventoryPath = ' + remoteInventoryPath);
 

--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleCommandLineInterface.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleCommandLineInterface.ts
@@ -4,7 +4,7 @@ import * as ansibleUtils from './ansibleUtils';
 import { RemoteCommandOptions } from './ansibleUtils'
 import { ansibleTaskParameters } from './ansibleTaskParameters';
 
-var guid = require('guid-typescript');
+var uuid = require('uuid/v4'); //randomly generated uid
 var os = require('os');
 var shell = require('shelljs');
 
@@ -131,7 +131,7 @@ export class ansibleCommandLineInterface extends ansibleInterface {
 
         return new Promise<string>(async (resolve, reject) => {
             try {
-                let remoteInventory = '/tmp/' + guid.Guid.create().toString() + 'inventory.ini';
+                let remoteInventory = '/tmp/' + uuid() + 'inventory.ini';
                 let remoteInventoryPath = '"' + remoteInventory + '"';
                 tl.debug('RemoteInventoryPath = ' + remoteInventoryPath);
 

--- a/Extensions/Ansible/Src/Tasks/Ansible/package.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package.json
@@ -6,10 +6,10 @@
   "author": "Microsoft",
   "license": "ISC",
   "dependencies": {
-    "guid-typescript": "^1.0.9",
     "scp2": "^0.5.0",
     "shelljs": "^0.6.0",
     "ssh2": "^0.5.5",
+    "uuid": "^3.3.2",
     "vso-node-api": "6.0.1-preview ",
     "vsts-task-lib": "2.0.5"
   },

--- a/Extensions/Ansible/Src/Tasks/Ansible/package.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package.json
@@ -6,11 +6,12 @@
   "author": "Microsoft",
   "license": "ISC",
   "dependencies": {
+    "guid-typescript": "^1.0.9",
     "scp2": "^0.5.0",
-    "ssh2": "^0.5.5",
     "shelljs": "^0.6.0",
+    "ssh2": "^0.5.5",
     "vso-node-api": "6.0.1-preview ",
-    "vsts-task-lib" : "2.0.5"
+    "vsts-task-lib": "2.0.5"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
The temp file that is created when using a dynamic inventory has a kind of race condition when running multiple ansible playbook tasks on the same hosted vm concurrently

Adding a GUID to the name should make the file name unique allowing for concurrent jobs to be run