### PR TITLE
Output variable updated and dataSource of impact changed

### DIFF
--- a/Extensions/ServiceNow/Src/Tasks/CreateAndQueryChangeRequest/task.json
+++ b/Extensions/ServiceNow/Src/Tasks/CreateAndQueryChangeRequest/task.json
@@ -215,7 +215,7 @@
             "Expression": "eq(jsonpath('$.result[0].status')[0], 'inserted')"
           },
           "ExecutionOptions": {
-            "OutputVariables": "{\"CHANGE_SYSTEM_ID\" :  \"jsonpath('$.result[0].sys_id')[0]\", \"CHANGE_REQUEST_NUMBER\" :  \"jsonpath('$.result[0].display_value')[0]\"}",
+            "OutputVariables": "{\"CHANGE_SYSTEM_ID\" :  \"jsonpath('$.result[0].sys_id')[0]\"}",
             "SkipSectionExpression": "eq(isNullOrEmpty(variables['CHANGE_SYSTEM_ID']), false)"
           }
         },
@@ -229,6 +229,7 @@
             "Expression": "eq(jsonpath('$.result.state')[0], '$(DesiredExitStatus)')"
           },
           "ExecutionOptions": {
+            "OutputVariables": "{\"CHANGE_REQUEST_NUMBER\" :  \"jsonpath('$.result.number')[0]\"}",
             "SkipSectionExpression": "eq(isNullOrEmpty(variables['CHANGE_SYSTEM_ID']), true)"
           }
         }

--- a/Extensions/ServiceNow/Src/Tasks/UpdateChangeRequest/task.json
+++ b/Extensions/ServiceNow/Src/Tasks/UpdateChangeRequest/task.json
@@ -105,7 +105,7 @@
         {
           "RequestInputs": {
             "EndpointId": "$(ServiceNowConnection)",
-            "EndpointUrl": "$(endpoint.url)/api/now/table/change_request?sysparm_query=number=$(ChangeRequestNumber)&sysparm_fields=correlation_id,number",
+            "EndpointUrl": "$(endpoint.url)/api/now/table/change_request?sysparm_query=number=$(ChangeRequestNumber)^ORDERBYDESCsys_created_on&sysparm_fields=sys_created_on,correlation_id,number",
             "Method": "GET",
             "Headers": "{\"Content-Type\":\"application/json\", \"Accept\":\"application/json\"}",
             "WaitForCompletion": "false",

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -106,8 +106,11 @@
           },
           {
             "name": "Impact",
-            "endpointUrl": "{{endpoint.url}}/api/now/table/sys_choice?sysparm_query=element=Impact^ORDERBYDESCvalue&sysparm_fields=label",
-            "resultSelector": "jsonpath:$.result[*].label"
+            "endpointUrl": "{{endpoint.url}}/api/now/table/sys_choice?sysparm_query=element=Impact^name={{table}}^ORDERBYDESCvalue&sysparm_fields=label",
+            "resultSelector": "jsonpath:$.result[*].label",
+            "callbackContextTemplate": "{\"table\": \"task\"}",
+            "callbackRequiredTemplate": "{{#equals table \"change_request\"}}{{isEqualNumber result.count 0}}{{else}}false{{/equals}}",
+            "initialContextTemplate": "{\"table\": \"change_request\"}"
           },
           {
             "name": "Category",


### PR DESCRIPTION
- Datasource for **Impact** changed to query for **change_request** filter if no records found, then query for **Task** table.
- Dependency on display column removed, Getting **CHANGE_REQUEST_NUMBER** output variable from Get change request by system Id API response.
- **Orderby** on **sys_created_on** field added for **Update CR task**, to pick the latest change request in case of multiple results.