### PR TITLE
Fixed  readme issue in service now

### DIFF
--- a/Extensions/ServiceNow/Src/readme.md
+++ b/Extensions/ServiceNow/Src/readme.md
@@ -121,7 +121,6 @@ If you plan to use OAuth to connect to your ServiceNow instance from Azure DevOp
 1. Navigate to **System OAuth > Application Registry** and then click **New**.
 2. On the interceptor page, click **Create an OAuth API endpoint for external clients** and then fill in the form. For the **Redirect URL**, use the following pattern to construct the URL.
 `{Azure DevOps Services Organization URL}/_admin/oauth2/callback`.
-For example: http://dev.azure.com/fabrikam/_admin/oauth2/callback
 3. Click **Submit**.
 4. Upon submission, you will see a page provides the **Client ID** and **Client secret** for your registered OAuth application.
 

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.159.0",
+  "version": "4.159.1",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.159.1",
+  "version": "4.159.0",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [


### PR DESCRIPTION
The change was causing tests to fail.
We can't have https://dev.azure.com hardcoded 