### PR TITLE
Add-Type fails on large environment variables

### DIFF
--- a/TaskModules/powershell/TaskModuleIISManageUtility/TaskModuleIISManageUtility.psm1
+++ b/TaskModules/powershell/TaskModuleIISManageUtility/TaskModuleIISManageUtility.psm1
@@ -22,13 +22,13 @@ Export-ModuleMember -Function @(
 # Special internal exception type to control the flow. Not currently intended
 # for public usage and subject to change. If the type has already
 # been loaded once, then it is not loaded again.
-Write-Verbose "Adding exceptions types."
-Add-Type -WarningAction SilentlyContinue -Debug:$false -TypeDefinition @'
-namespace TaskModuleIISManageUtility
-{
-    public class TerminationException : System.Exception
-    {
-        public TerminationException(System.String message) : base(message) { }
-    }
-}
-'@
+#Write-Verbose "Adding exceptions types."
+#Add-Type -WarningAction SilentlyContinue -Debug:$false -TypeDefinition @'
+#namespace TaskModuleIISManageUtility
+#{
+#    public class TerminationException : System.Exception
+#    {
+#        public TerminationException(System.String message) : base(message) { }
+#    }
+#}
+#'@


### PR DESCRIPTION
remove Add-Type in IIS psm to pass in definitions using large amount of environment variables