### PR TITLE
commandOptions is not passed to setOutputVariableToPlanFilePath()

### DIFF
--- a/Extensions/Terraform/Src/Tasks/TerraformTaskV1/src/base-terraform-command-handler.ts
+++ b/Extensions/Terraform/Src/Tasks/TerraformTaskV1/src/base-terraform-command-handler.ts
@@ -145,7 +145,7 @@ export abstract class BaseTerraformCommandHandler {
                 "plan",
                 tasks.getInput("workingDirectory"),
                 tasks.getInput(serviceName, true),
-                `-out=${binaryPlanFilePath}`
+                `${tasks.getInput("commandOptions")} -out=${binaryPlanFilePath}`
             );
             terraformTool = this.terraformToolHandler.createToolRunner(planCommand);
             this.handleProvider(planCommand);


### PR DESCRIPTION
Hey friends,

I've encountered an issue when using -var-file with TerraFormTaskV1. The `commandOptions` is passed to terraform in `.onlyPlan()`, but not in `setOutputVariableToPlanFilePath()`. This should be solved by prepending `${tasks.getInput("commandOptions")}` to the execution parameters.

Terraform will use the last applied parameter, so by setting the `-out=` parameter last here it will be set even though it's already provided in `commandOptions`.

Keep up the good work!

Related issues: #686, #691, #729.