### PR TITLE
Added '-products *' argument to vswhere command

### DIFF
--- a/TaskModules/powershell/TaskModuleSqlUtility/SqlPackageOnTargetMachines.ps1
+++ b/TaskModules/powershell/TaskModuleSqlUtility/SqlPackageOnTargetMachines.ps1
@@ -372,7 +372,7 @@ function LocateLatestVSVersionUsingVSWhere {
     [CmdletBinding()]
     Param ([string] $VSWherePath)
     Remove-Item variable:\LASTEXITCODE -ErrorAction 'SilentlyContinue'
-    $vsInstallations = & $VSWherePath "-legacy" "-prerelease" "-format" "json"
+    $vsInstallations = & $VSWherePath "-legacy" "-prerelease" "-products" "*" "-format" "json"
     $vsInstallations = $($vsInstallations -join '').Trim()
     if ($LASTEXITCODE -ne 0) {
         # if lastexitcode is not 0, then vsinstallations variable will contain the error string


### PR DESCRIPTION
I have a self-hosted DevOps agent running on a server with an installation of Visual Studio Build Tools 2019 that includes the "Microsoft.VisualStudio.Component.SQL.SSDTBuildSku" component. Despite the fact that SqlPackage is listed as a capability on the agent, whenever a job with the SqlDacpacDeploymentOnMachineGroupV0 task (link to task repo: https://github.com/microsoft/azure-pipelines-tasks/tree/master/Tasks/SqlDacpacDeploymentOnMachineGroupV0) is run on this agent, the task fails with the error "Unable to find the location of Dac Framework (SqlPackage.exe) from registry on machine <Machine Name>".

I traced this issue to the vswhere command changed in this PR. Since VS Build Tools doesn't show up in the list of VS Installations by default when using vswhere, the SqlPacakge.exe included in the "Microsoft.VisualStudio.Component.SQL.SSDTBuildSku" component installed on Visual Studio Build Tools 2019 is never found. The addition of the "-products *" argument will list all installed Visual Studio products including installations of VS Build Tools.

This issue appears to be related, they're using SSDT as well although it's not clear if it's through a VS Build Tools installation: https://github.com/microsoft/azure-pipelines-extensions/issues/534