### PR TITLE
Fix check for multiple providers

### DIFF
--- a/Extensions/Terraform/Src/Tasks/TerraformTaskV1/Tests/L0.ts
+++ b/Extensions/Terraform/Src/Tasks/TerraformTaskV1/Tests/L0.ts
@@ -1183,7 +1183,7 @@ describe('Terraform Test Suite', () => {
             assert(tr.invokedToolCount === 1, 'should have invoked tool one time. actual: ' + tr.invokedToolCount);
             assert(tr.errorIssues.length === 0, 'should have no errors');
             assert(tr.warningIssues.length === 1, 'should have one warning');  
-            assert(tr.createdWarningIssue('Multiple provider blocks specified in the .tf files in the current working drectory.'), 'Should have created warning: Multiple provider blocks specified in the .tf files in the current working drectory.');  
+            assert(tr.createdWarningIssue('Multiple provider blocks specified in the .tf files in the current working directory.'), 'Should have created warning: Multiple provider blocks specified in the .tf files in the current working directory.');
 
             done();
         } catch(error) {

--- a/Extensions/Terraform/Src/Tasks/TerraformTaskV1/src/base-terraform-command-handler.ts
+++ b/Extensions/Terraform/Src/Tasks/TerraformTaskV1/src/base-terraform-command-handler.ts
@@ -53,7 +53,7 @@ export abstract class BaseTerraformCommandHandler {
             cwd: tasks.getInput("workingDirectory")
         });
 
-        let countProviders = (commandOutput.stdout.match(/provider/g) || []).length;
+        let countProviders = ["aws", "azurerm", "google"].filter(provider => commandOutput.stdout.includes(provider)).length
         tasks.debug(countProviders.toString());
         if (countProviders > 1) {
             tasks.warning("Multiple provider blocks specified in the .tf files in the current working drectory.");

--- a/Extensions/Terraform/Src/Tasks/TerraformTaskV1/src/base-terraform-command-handler.ts
+++ b/Extensions/Terraform/Src/Tasks/TerraformTaskV1/src/base-terraform-command-handler.ts
@@ -56,7 +56,7 @@ export abstract class BaseTerraformCommandHandler {
         let countProviders = ["aws", "azurerm", "google"].filter(provider => commandOutput.stdout.includes(provider)).length
         tasks.debug(countProviders.toString());
         if (countProviders > 1) {
-            tasks.warning("Multiple provider blocks specified in the .tf files in the current working drectory.");
+            tasks.warning("Multiple provider blocks specified in the .tf files in the current working directory.");
         }
     }
 


### PR DESCRIPTION
This solution outputs a warning only if two or more of the following providers are used: `aws`, `azurerm`, and `google`, and will thereby significantly reduce the amount of unnecessary warnings.

Resolves #667 
Resolves #748 
Resolves #781 
Resolves #824