### PR TITLE
Terraform Plan output variable to detect changes

### DIFF
--- a/Extensions/Terraform/Src/Tasks/TerraformTaskV1/src/base-terraform-command-handler.ts
+++ b/Extensions/Terraform/Src/Tasks/TerraformTaskV1/src/base-terraform-command-handler.ts
@@ -118,7 +118,7 @@ export abstract class BaseTerraformCommandHandler {
             "plan",
             tasks.getInput("workingDirectory"),
             tasks.getInput(serviceName, true),
-            tasks.getInput("commandOptions")
+            `${tasks.getInput("commandOptions")} -detailed-exitcode`
         );
         
         let terraformTool;
@@ -196,6 +196,7 @@ export abstract class BaseTerraformCommandHandler {
 
     public async plan(): Promise<number> {
         await this.onlyPlan();
+        tasks.setVariable('changesPresent', exitCode === 2);
         this.setOutputVariableToPlanFilePath();
 
         return Promise.resolve(0);

--- a/Extensions/Terraform/Src/Tasks/TerraformTaskV1/task.json
+++ b/Extensions/Terraform/Src/Tasks/TerraformTaskV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": "0",
         "Minor": "0",
-        "Patch": "140"
+        "Patch": "143"
     },
     "instanceNameFormat": "Terraform : $(provider)",
     "execution": {

--- a/Extensions/Terraform/Src/Tasks/TerraformTaskV1/task.json
+++ b/Extensions/Terraform/Src/Tasks/TerraformTaskV1/task.json
@@ -255,6 +255,10 @@
             "description": "The location of the terraform plan file in JSON format that was created. This file can be used by tasks which are written for tools such as [Open Policy Agent](https://www.openpolicyagent.org/docs/latest/terraform/)<br><br>Note: This variable will only be set if 'command' input is set to 'plan'."
         },
         {
+            "name": "changesPresent",
+            "description": "A boolean indicating if the terraform plan found any changes to apply."
+        },
+        {
             "name": "jsonOutputVariablesPath",
             "description": "The location of the JSON file which contains the output variables set by the user in the terraform config files.<br><br>Note: This variable will only be set if 'command' input is set to 'apply'."
         }


### PR DESCRIPTION
Add an output variable that will be set to true when the Terraform Plan task has found actual changes that need to be applied.
This will enable pipelines to skip a Terraform Apply task when it is not necessary.
See also #768 