### PR TITLE
Remove deprecated arm_ prefix from terraform backend

### DIFF
--- a/Extensions/Terraform/Src/Tasks/TerraformTaskV1/Tests/InitTests/Azure/AzureInitFailInvalidWorkingDirectory.ts
+++ b/Extensions/Terraform/Src/Tasks/TerraformTaskV1/Tests/InitTests/Azure/AzureInitFailInvalidWorkingDirectory.ts
@@ -30,7 +30,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
         "terraform": true
     },
     "exec": {
-        "terraform init -backend-config=storage_account_name=DummyStorageAccount -backend-config=container_name=DummyContainer -backend-config=key=DummyKey -backend-config=resource_group_name=DummyResourceGroup -backend-config=arm_subscription_id=DummmySubscriptionId -backend-config=arm_tenant_id=DummyTenantId -backend-config=arm_client_id=DummyServicePrincipalId -backend-config=arm_client_secret=DummyServicePrincipalKey": {
+        "terraform init -backend-config=storage_account_name=DummyStorageAccount -backend-config=container_name=DummyContainer -backend-config=key=DummyKey -backend-config=resource_group_name=DummyResourceGroup -backend-config=subscription_id=DummmySubscriptionId -backend-config=tenant_id=DummyTenantId -backend-config=client_id=DummyServicePrincipalId -backend-config=client_secret=DummyServicePrincipalKey": {
             "code": 1,
             "stdout": "There are some problems with the configuration, described below.\n\nThe Terraform configuration must be valid before initialization so that Terraform can determine which modules and providers need to be installed."
         }

--- a/Extensions/Terraform/Src/Tasks/TerraformTaskV1/Tests/InitTests/Azure/AzureInitSuccessAdditionalArgs.ts
+++ b/Extensions/Terraform/Src/Tasks/TerraformTaskV1/Tests/InitTests/Azure/AzureInitSuccessAdditionalArgs.ts
@@ -30,7 +30,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
         "terraform": true
     },
     "exec": {
-        "terraform init -no-color -backend-config=storage_account_name=DummyStorageAccount -backend-config=container_name=DummyContainer -backend-config=key=DummyKey -backend-config=resource_group_name=DummyResourceGroup -backend-config=arm_subscription_id=DummmySubscriptionId -backend-config=arm_tenant_id=DummyTenantId -backend-config=arm_client_id=DummyServicePrincipalId -backend-config=arm_client_secret=DummyServicePrincipalKey": {
+        "terraform init -no-color -backend-config=storage_account_name=DummyStorageAccount -backend-config=container_name=DummyContainer -backend-config=key=DummyKey -backend-config=resource_group_name=DummyResourceGroup -backend-config=subscription_id=DummmySubscriptionId -backend-config=tenant_id=DummyTenantId -backend-config=client_id=DummyServicePrincipalId -backend-config=client_secret=DummyServicePrincipalKey": {
             "code": 0,
             "stdout": "Executed Successfully"
         }

--- a/Extensions/Terraform/Src/Tasks/TerraformTaskV1/Tests/InitTests/Azure/AzureInitSuccessEmptyWorkingDir.ts
+++ b/Extensions/Terraform/Src/Tasks/TerraformTaskV1/Tests/InitTests/Azure/AzureInitSuccessEmptyWorkingDir.ts
@@ -30,7 +30,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
         "terraform": true
     },
     "exec": {
-        "terraform init -backend-config=storage_account_name=DummyStorageAccount -backend-config=container_name=DummyContainer -backend-config=key=DummyKey -backend-config=resource_group_name=DummyResourceGroup -backend-config=arm_subscription_id=DummmySubscriptionId -backend-config=arm_tenant_id=DummyTenantId -backend-config=arm_client_id=DummyServicePrincipalId -backend-config=arm_client_secret=DummyServicePrincipalKey": {
+        "terraform init -backend-config=storage_account_name=DummyStorageAccount -backend-config=container_name=DummyContainer -backend-config=key=DummyKey -backend-config=resource_group_name=DummyResourceGroup -backend-config=subscription_id=DummmySubscriptionId -backend-config=tenant_id=DummyTenantId -backend-config=client_id=DummyServicePrincipalId -backend-config=client_secret=DummyServicePrincipalKey": {
             "code": 0,
             "stdout": "Executed Successfully"
         }

--- a/Extensions/Terraform/Src/Tasks/TerraformTaskV1/Tests/InitTests/Azure/AzureInitSuccessNoAdditionalArgs.ts
+++ b/Extensions/Terraform/Src/Tasks/TerraformTaskV1/Tests/InitTests/Azure/AzureInitSuccessNoAdditionalArgs.ts
@@ -30,7 +30,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
         "terraform": true
     },
     "exec": {
-        "terraform init -backend-config=storage_account_name=DummyStorageAccount -backend-config=container_name=DummyContainer -backend-config=key=DummyKey -backend-config=resource_group_name=DummyResourceGroup -backend-config=arm_subscription_id=DummmySubscriptionId -backend-config=arm_tenant_id=DummyTenantId -backend-config=arm_client_id=DummyServicePrincipalId -backend-config=arm_client_secret=DummyServicePrincipalKey": {
+        "terraform init -backend-config=storage_account_name=DummyStorageAccount -backend-config=container_name=DummyContainer -backend-config=key=DummyKey -backend-config=resource_group_name=DummyResourceGroup -backend-config=subscription_id=DummmySubscriptionId -backend-config=tenant_id=DummyTenantId -backend-config=client_id=DummyServicePrincipalId -backend-config=client_secret=DummyServicePrincipalKey": {
             "code": 0,
             "stdout": "Executed Successfully"
         }

--- a/Extensions/Terraform/Src/Tasks/TerraformTaskV1/src/azure-terraform-command-handler.ts
+++ b/Extensions/Terraform/Src/Tasks/TerraformTaskV1/src/azure-terraform-command-handler.ts
@@ -14,10 +14,10 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
         this.backendConfig.set('container_name', tasks.getInput("backendAzureRmContainerName", true));
         this.backendConfig.set('key', tasks.getInput("backendAzureRmKey", true));
         this.backendConfig.set('resource_group_name', tasks.getInput("backendAzureRmResourceGroupName", true));
-        this.backendConfig.set('arm_subscription_id', tasks.getEndpointDataParameter(backendServiceName, "subscriptionid", true));
-        this.backendConfig.set('arm_tenant_id', tasks.getEndpointAuthorizationParameter(backendServiceName, "tenantid", true));
-        this.backendConfig.set('arm_client_id', tasks.getEndpointAuthorizationParameter(backendServiceName, "serviceprincipalid", true));
-        this.backendConfig.set('arm_client_secret', tasks.getEndpointAuthorizationParameter(backendServiceName, "serviceprincipalkey", true));
+        this.backendConfig.set('subscription_id', tasks.getEndpointDataParameter(backendServiceName, "subscriptionid", true));
+        this.backendConfig.set('tenant_id', tasks.getEndpointAuthorizationParameter(backendServiceName, "tenantid", true));
+        this.backendConfig.set('client_id', tasks.getEndpointAuthorizationParameter(backendServiceName, "serviceprincipalid", true));
+        this.backendConfig.set('client_secret', tasks.getEndpointAuthorizationParameter(backendServiceName, "serviceprincipalkey", true));
     }
 
     public handleBackend(terraformToolRunner: ToolRunner): void {
@@ -31,10 +31,10 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
 
     public handleProvider(command: TerraformAuthorizationCommandInitializer) {
         if (command.serviceProvidername) {
-            process.env['ARM_SUBSCRIPTION_ID']  = tasks.getEndpointDataParameter(command.serviceProvidername, "subscriptionid", false);
-            process.env['ARM_TENANT_ID']        = tasks.getEndpointAuthorizationParameter(command.serviceProvidername, "tenantid", false);
-            process.env['ARM_CLIENT_ID']        = tasks.getEndpointAuthorizationParameter(command.serviceProvidername, "serviceprincipalid", false);
-            process.env['ARM_CLIENT_SECRET']    = tasks.getEndpointAuthorizationParameter(command.serviceProvidername, "serviceprincipalkey", false);
+            process.env['ARM_SUBSCRIPTION_ID'] = tasks.getEndpointDataParameter(command.serviceProvidername, "subscriptionid", false);
+            process.env['ARM_TENANT_ID']       = tasks.getEndpointAuthorizationParameter(command.serviceProvidername, "tenantid", false);
+            process.env['ARM_CLIENT_ID']       = tasks.getEndpointAuthorizationParameter(command.serviceProvidername, "serviceprincipalid", false);
+            process.env['ARM_CLIENT_SECRET']   = tasks.getEndpointAuthorizationParameter(command.serviceProvidername, "serviceprincipalkey", false);
         }
     }
 }


### PR DESCRIPTION
The `arm_` prefix on backend configurations has been deprecated back in 2018 ([see pr for it here](https://github.com/hashicorp/terraform/pull/19448)) and released with terraform `v0.12`. Updated to match latest [documentation](https://www.terraform.io/docs/providers/azurerm/index.html#argument-reference) from terraform which lists current configuration for terraform `v0.12` and `v0.13`.

This is a continuation of PR #770, but with updated tests as well. Hopefully those will go through with success now.

Related issues:
- fixes #786
- #738