### PR TITLE
Added image references

### DIFF
--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.176.0",
+  "version": "4.176.1",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [
@@ -89,7 +89,19 @@
     {
       "path": "images/oauth_servicenow_connection.png",
       "addressable": true
-    },  
+    },
+    {
+      "path": "images/check_create.png",
+      "addressable": true
+    },
+    {
+      "path": "images/yaml_pipeline.png",
+      "addressable": true
+    },
+    {
+      "path": "images/resulting_pipeline.png",
+      "addressable": true
+    },
     {
       "path": "Tasks/CreateAndQueryChangeRequest"
     },


### PR DESCRIPTION
What?
Added image references for marketplace description.
https://marketplace.visualstudio.com/items?itemName=ms-vscs-rm.vss-services-servicenowchangerequestmanagement

Why?

For the images to be included in the `vsix` file, we need to add a reference for the image path  in the `vss-extension.json.`

Also, updated the version number 'cos `4.176.0` is already in the marketplace.

Image from VSIX Viewer:

![files](https://user-images.githubusercontent.com/4750389/96546275-973bc280-12c7-11eb-93a7-9a91163a6618.JPG)
