### PR TITLE
invoke appcmd with encoding 1252

### DIFF
--- a/TaskModules/powershell/TaskModuleIISManageUtility/AppCmdOnTargetMachines.ps1
+++ b/TaskModules/powershell/TaskModuleIISManageUtility/AppCmdOnTargetMachines.ps1
@@ -43,7 +43,7 @@ function Test-WebsiteExist
     $command = "`"$appCmdPath`" $appCmdArgs"
     Write-Verbose "Checking website exists. Running command : $command"
 
-    $website = Invoke-VstsTool -Filename $appCmdPath -Arguments $appCmdArgs
+    $website = Invoke-VstsTool -Filename $appCmdPath -Arguments $appCmdArgs -Encoding ([System.Text.Encoding]::GetEncoding(1252))
 
     if($null -ne $website -and $website -like "*`"$siteName`"*")
     {
@@ -71,7 +71,7 @@ function Test-BindingExist
 
     Write-Verbose "Checking binding exists for website (`"$siteName`"). Running command : $command"
 
-    $sites = Invoke-VstsTool -Filename $appCmdPath -Arguments $appCmdArgs
+    $sites = Invoke-VstsTool -Filename $appCmdPath -Arguments $appCmdArgs -Encoding ([System.Text.Encoding]::GetEncoding(1252))
 
     $binding = [string]::Format("{0}/{1}:{2}:{3},", $protocol, $ipAddress, $port, $hostname)
 
@@ -107,7 +107,7 @@ function Test-AppPoolExist
 
     Write-Verbose "Checking application pool exists. Running command : $command"
 
-    $appPool = Invoke-VstsTool -Filename $appCmdPath -Arguments $appCmdArgs
+    $appPool = Invoke-VstsTool -Filename $appCmdPath -Arguments $appCmdArgs -Encoding ([System.Text.Encoding]::GetEncoding(1252))
 
     $appPoolName = $appPoolName.Replace('`', '``').Replace('"', '`"').Replace('$', '`$')
     if($null -ne $appPool -and $appPool -like "*`"$appPoolName`"*")


### PR DESCRIPTION
Having a website with matching appool and bindings with names that contains foreign characters (in my case a danish "æ"), causes subsequent deploys to fail as the existing apppool, website and bindings are not detected and so the task tries to create these again.

It works for me by adding -Encoding ([System.Text.Encoding]::GetEncoding(1252)) to all Invoke-VstsTool calls in AppCmdOnTargetMachines.ps1.
Not sure if that solution is safe world-wide. I guess that depends on how appcmd.exe is constructed.

Bug filed as #851 