### PR TITLE
Update Ansible ssh2 from 0.5.5 to 0.8.9

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/package.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "scp2": "^0.5.0",
     "shelljs": "^0.6.0",
-    "ssh2": "^0.5.5",
+    "ssh2": "^0.8.9",
     "uuid": "^3.3.2",
     "vso-node-api": "6.0.1-preview ",
     "vsts-task-lib": "2.0.5"

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 0,
-        "Patch": 5
+        "Patch": 6
     },
     "demands": [],
     "instanceNameFormat": "Run playbook",


### PR DESCRIPTION
The Ansible task relies on an old version of ssh2, which has issues parsing private keys generated using newer tools.  For example, a simple rsa key generated on Windows 10 using the ssh-keygen included with a recent Git for Windows will experience the following error in Azure Pipelines when used in the SSH service connection:

##[error]Failed to connect to Ansible machine. Verify the SSH endpoint details. Error: Error: Cannot parse privateKey: Unsupported key format.

Testing locally with nodejs, you can install the same version of ssh2 and recreate the error using the same private key, but upon upgrading to the latest version (0.8.9 at time of this writing), the connection is successful.