### PR TITLE
Added failure criteria to SNOW create and query task

### DIFF
--- a/Extensions/ServiceNow/Src/Tasks/CreateAndQueryChangeRequest/CreateAndQueryChangeRequestV2/task.json
+++ b/Extensions/ServiceNow/Src/Tasks/CreateAndQueryChangeRequest/CreateAndQueryChangeRequestV2/task.json
@@ -307,7 +307,7 @@
         "desiredStatus": "Desired status of change request"
       },
       "required": "false",
-      "helpMarkDown": "Choose failure criteria for change request.",
+      "helpMarkDown": "Choose failure criteria for change request. Note: Failure criteria is supported only in YAML Pipelines.",
       "properties": {
          "EditableOptions": "false"
       },
@@ -516,7 +516,7 @@
           },
           "ExecutionOptions": {
             "OutputVariables": "{\"CHANGE_REQUEST_NUMBER\" :  \"jsonpath('$.result.number')[0]\"}",
-            "SkipSectionExpression": "or(eq('$(failureCriteria)', 'desiredStatus'),eq(isNullOrEmpty(variables['CHANGE_SYSTEM_ID']), true))"
+            "SkipSectionExpression": "or(eq(eq('$(system.hosttype)', 'checks'), false),eq('$(failureCriteria)', 'desiredStatus'),eq(isNullOrEmpty(variables['CHANGE_SYSTEM_ID']), true))"
           }
         },
         {
@@ -530,7 +530,7 @@
           },
           "ExecutionOptions": {
             "OutputVariables": "{\"CHANGE_REQUEST_NUMBER\" :  \"jsonpath('$.result.number')[0]\"}",
-            "SkipSectionExpression": "or(eq('$(failureCriteria)', 'advanced'),eq(isNullOrEmpty(variables['CHANGE_SYSTEM_ID']), true))"
+            "SkipSectionExpression": "or(eq(eq('$(system.hosttype)', 'checks'), false),eq('$(failureCriteria)', 'advanced'),eq(isNullOrEmpty(variables['CHANGE_SYSTEM_ID']), true))"
           }
         }
       ]

--- a/Extensions/ServiceNow/Src/Tasks/CreateAndQueryChangeRequest/CreateAndQueryChangeRequestV2/task.json
+++ b/Extensions/ServiceNow/Src/Tasks/CreateAndQueryChangeRequest/CreateAndQueryChangeRequestV2/task.json
@@ -300,8 +300,9 @@
       "name": "failureCriteria",
       "type": "pickList",
       "label": "Failure criteria",
-      "defaultValue": "desiredStatus",
+      "defaultValue": "none",
       "options": {
+        "none": "None",
         "advanced": "Advanced failure criteria",
         "desiredStatus": "Desired status of change request"
       },

--- a/Extensions/ServiceNow/Src/Tasks/CreateAndQueryChangeRequest/CreateAndQueryChangeRequestV2/task.json
+++ b/Extensions/ServiceNow/Src/Tasks/CreateAndQueryChangeRequest/CreateAndQueryChangeRequestV2/task.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": 2,
-    "Minor": 179,
+    "Minor": 182,
     "Patch": 0
   },
   "instanceNameFormat": "ServiceNow change management",
@@ -484,7 +484,7 @@
             "Method": "GET",
             "Headers": "{\"Content-Type\":\"application/json\", \"Accept\":\"application/json\"}",
             "WaitForCompletion": "false",
-            "Expression": "$(AdvancedSuccessCriteria)"
+            "Expression": "or($(AdvancedSuccessCriteria), and($(AdvancedSuccessCriteria), ne($(AdvancedFailureCriteria))))"
           },
           "ExecutionOptions": {
             "OutputVariables": "{\"CHANGE_REQUEST_NUMBER\" :  \"jsonpath('$.result.number')[0]\"}",
@@ -498,39 +498,11 @@
             "Method": "GET",
             "Headers": "{\"Content-Type\":\"application/json\", \"Accept\":\"application/json\"}",
             "WaitForCompletion": "false",
-            "Expression": "eq(jsonpath('$.result.state')[0],'$(DesiredExitStatus)')"
+            "Expression": "or(eq(jsonpath('$.result.state')[0],'$(DesiredExitStatus)'), and(eq(jsonpath('$.result.state')[0],'$(DesiredExitStatus)'), ne(jsonpath('$.result.state')[0],'$(DesiredFailureExitStatus)')))"
           },
           "ExecutionOptions": {
             "OutputVariables": "{\"CHANGE_REQUEST_NUMBER\" :  \"jsonpath('$.result.number')[0]\"}",
             "SkipSectionExpression": "or(eq('$(successCriteria)', 'advanced'),eq(isNullOrEmpty(variables['CHANGE_SYSTEM_ID']), true))"
-          }
-        },
-        {
-          "RequestInputs": {
-            "EndpointId": "$(ServiceNowConnection)",
-            "EndpointUrl": "$(endpoint.url)/api/now/table/change_request/$(CHANGE_SYSTEM_ID)?sysparm_display_value=true",
-            "Method": "GET",
-            "Headers": "{\"Content-Type\":\"application/json\", \"Accept\":\"application/json\"}",
-            "WaitForCompletion": "false",
-            "Expression": "$(AdvancedFailureCriteria)"
-          },
-          "ExecutionOptions": {
-            "OutputVariables": "{\"CHANGE_REQUEST_NUMBER\" :  \"jsonpath('$.result.number')[0]\"}",
-            "SkipSectionExpression": "or(eq(eq('$(system.hosttype)', 'checks'), false),eq('$(failureCriteria)', 'desiredStatus'),eq(isNullOrEmpty(variables['CHANGE_SYSTEM_ID']), true))"
-          }
-        },
-        {
-          "RequestInputs": {
-            "EndpointId": "$(ServiceNowConnection)",
-            "EndpointUrl": "$(endpoint.url)/api/now/table/change_request/$(CHANGE_SYSTEM_ID)?sysparm_fields=state,number",
-            "Method": "GET",
-            "Headers": "{\"Content-Type\":\"application/json\", \"Accept\":\"application/json\"}",
-            "WaitForCompletion": "false",
-            "Expression": "not(eq(jsonpath('$.result.state')[0],'$(DesiredFailureExitStatus)'))"
-          },
-          "ExecutionOptions": {
-            "OutputVariables": "{\"CHANGE_REQUEST_NUMBER\" :  \"jsonpath('$.result.number')[0]\"}",
-            "SkipSectionExpression": "or(eq(eq('$(system.hosttype)', 'checks'), false),eq('$(failureCriteria)', 'advanced'),eq(isNullOrEmpty(variables['CHANGE_SYSTEM_ID']), true))"
           }
         }
       ]

--- a/Extensions/ServiceNow/Src/Tasks/CreateAndQueryChangeRequest/CreateAndQueryChangeRequestV2/task.json
+++ b/Extensions/ServiceNow/Src/Tasks/CreateAndQueryChangeRequest/CreateAndQueryChangeRequestV2/task.json
@@ -14,7 +14,7 @@
   ],
   "version": {
     "Major": 2,
-    "Minor": 176,
+    "Minor": 179,
     "Patch": 0
   },
   "instanceNameFormat": "ServiceNow change management",
@@ -38,6 +38,11 @@
     {
       "name": "completionOptions",
       "displayName": "Success criteria",
+      "isExpanded": true
+    },
+    {
+      "name": "rejectionOptions",
+      "displayName": "Failure criteria",
       "isExpanded": true
     }
   ],
@@ -290,6 +295,43 @@
       "groupName": "completionOptions",
       "helpMarkDown": "Type complex expression for success criteria.",
       "visibleRule": "successCriteria = advanced"
+    },
+    {
+      "name": "failureCriteria",
+      "type": "pickList",
+      "label": "Failure criteria",
+      "defaultValue": "desiredStatus",
+      "options": {
+        "advanced": "Advanced failure criteria",
+        "desiredStatus": "Desired status of change request"
+      },
+      "required": "false",
+      "helpMarkDown": "Choose failure criteria for change request.",
+      "properties": {
+         "EditableOptions": "false"
+      },
+      "groupName": "rejectionOptions"
+    },
+    {
+      "name": "DesiredFailureExitStatus",
+      "type": "pickList",
+      "label": "Desired status of change request",
+      "required": "true",
+      "groupName": "rejectionOptions",
+      "helpMarkDown": "Choose or type status of change request that indicates the change request can be rejected. Gate would fail immediately when the the change request status is same as the provided value.",
+      "properties": {
+        "EditableOptions": "True"
+      },
+      "visibleRule": "failureCriteria = desiredStatus"
+    },
+    {
+      "name": "AdvancedFailureCriteria",
+      "type": "string",
+      "label": "Advanced failure criteria.",
+      "required": "false",
+      "groupName": "rejectionOptions",
+      "helpMarkDown": "Type complex expression for failure criteria.",
+      "visibleRule": "failureCriteria = advanced"
     }
   ],
   "dataSourceBindings": [{
@@ -337,6 +379,12 @@
       "target": "assignmentgroup",
       "endpointId": "$(ServiceNowConnection)",
       "dataSourceName": "Assignment Group"
+    },
+    {
+      "target": "DesiredFailureExitStatus",
+      "endpointId": "$(ServiceNowConnection)",
+      "dataSourceName": "State",
+      "resultTemplate": "{ \"Value\" : \"{{value}}\", \"DisplayValue\" : \"{{label}}\" }"
     }
   ],
   "execution": {
@@ -454,6 +502,34 @@
           "ExecutionOptions": {
             "OutputVariables": "{\"CHANGE_REQUEST_NUMBER\" :  \"jsonpath('$.result.number')[0]\"}",
             "SkipSectionExpression": "or(eq('$(successCriteria)', 'advanced'),eq(isNullOrEmpty(variables['CHANGE_SYSTEM_ID']), true))"
+          }
+        },
+        {
+          "RequestInputs": {
+            "EndpointId": "$(ServiceNowConnection)",
+            "EndpointUrl": "$(endpoint.url)/api/now/table/change_request/$(CHANGE_SYSTEM_ID)?sysparm_display_value=true",
+            "Method": "GET",
+            "Headers": "{\"Content-Type\":\"application/json\", \"Accept\":\"application/json\"}",
+            "WaitForCompletion": "false",
+            "Expression": "$(AdvancedFailureCriteria)"
+          },
+          "ExecutionOptions": {
+            "OutputVariables": "{\"CHANGE_REQUEST_NUMBER\" :  \"jsonpath('$.result.number')[0]\"}",
+            "SkipSectionExpression": "or(eq('$(failureCriteria)', 'desiredStatus'),eq(isNullOrEmpty(variables['CHANGE_SYSTEM_ID']), true))"
+          }
+        },
+        {
+          "RequestInputs": {
+            "EndpointId": "$(ServiceNowConnection)",
+            "EndpointUrl": "$(endpoint.url)/api/now/table/change_request/$(CHANGE_SYSTEM_ID)?sysparm_fields=state,number",
+            "Method": "GET",
+            "Headers": "{\"Content-Type\":\"application/json\", \"Accept\":\"application/json\"}",
+            "WaitForCompletion": "false",
+            "Expression": "not(eq(jsonpath('$.result.state')[0],'$(DesiredFailureExitStatus)'))"
+          },
+          "ExecutionOptions": {
+            "OutputVariables": "{\"CHANGE_REQUEST_NUMBER\" :  \"jsonpath('$.result.number')[0]\"}",
+            "SkipSectionExpression": "or(eq('$(failureCriteria)', 'advanced'),eq(isNullOrEmpty(variables['CHANGE_SYSTEM_ID']), true))"
           }
         }
       ]

--- a/Extensions/ServiceNow/Src/readme.md
+++ b/Extensions/ServiceNow/Src/readme.md
@@ -128,6 +128,8 @@ Example: We’re configuring the check on Environment named “Latest”.
 
 The check configuration details remain the same as the gate in designer release pipelines. Refer to [this](#configure-a-designer-release-pipeline-for-servicenow-change-management).
 
+We also support **Failure Criteria** in YAML pipelines, the parameters similar to **Success Criteria** except the check fails immediately without any further retries.
+
 #### **Add the task to update change request in the YAML Pipeline**
 In a  server job, add the update change request task to send work notes etc. to ServiceNow.
 

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.179.0",
+  "version": "4.182.0",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.176.1",
+  "version": "4.179.0",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [


### PR DESCRIPTION
What?
Added failure criteria (similar to success criteria) 

The SNOW check will be failed immediately if the failure criterion is matched. 

- [x] Default criteria as `None`.
- [ ] Only for YAML checks.
   * This is not possible due to UI reasons, hence kept a note that it's valid only in YAML Checks
- [x] Run failure criteria only when success criteria didn't meet.
- [x] Fail the check and don't retry if the failure criteria is met.