### PR TITLE
Fix for azurerm backend arguments and TF 0.15.0

### DIFF
--- a/Extensions/Terraform/Src/Tasks/TerraformTaskV1/Tests/InitTests/Azure/AzureInitFailInvalidWorkingDirectory.ts
+++ b/Extensions/Terraform/Src/Tasks/TerraformTaskV1/Tests/InitTests/Azure/AzureInitFailInvalidWorkingDirectory.ts
@@ -22,7 +22,7 @@ process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServic
 process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
 process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
 
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "terraform": "terraform"
     },
@@ -30,7 +30,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
         "terraform": true
     },
     "exec": {
-        "terraform init -backend-config=storage_account_name=DummyStorageAccount -backend-config=container_name=DummyContainer -backend-config=key=DummyKey -backend-config=resource_group_name=DummyResourceGroup -backend-config=arm_subscription_id=DummmySubscriptionId -backend-config=arm_tenant_id=DummyTenantId -backend-config=arm_client_id=DummyServicePrincipalId -backend-config=arm_client_secret=DummyServicePrincipalKey": {
+        "terraform init -backend-config=storage_account_name=DummyStorageAccount -backend-config=container_name=DummyContainer -backend-config=key=DummyKey -backend-config=resource_group_name=DummyResourceGroup -backend-config=subscription_id=DummmySubscriptionId -backend-config=tenant_id=DummyTenantId -backend-config=client_id=DummyServicePrincipalId -backend-config=client_secret=DummyServicePrincipalKey": {
             "code": 1,
             "stdout": "There are some problems with the configuration, described below.\n\nThe Terraform configuration must be valid before initialization so that Terraform can determine which modules and providers need to be installed."
         }

--- a/Extensions/Terraform/Src/Tasks/TerraformTaskV1/Tests/InitTests/Azure/AzureInitSuccessAdditionalArgs.ts
+++ b/Extensions/Terraform/Src/Tasks/TerraformTaskV1/Tests/InitTests/Azure/AzureInitSuccessAdditionalArgs.ts
@@ -22,7 +22,7 @@ process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServic
 process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
 process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
 
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "terraform": "terraform"
     },
@@ -30,7 +30,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
         "terraform": true
     },
     "exec": {
-        "terraform init -no-color -backend-config=storage_account_name=DummyStorageAccount -backend-config=container_name=DummyContainer -backend-config=key=DummyKey -backend-config=resource_group_name=DummyResourceGroup -backend-config=arm_subscription_id=DummmySubscriptionId -backend-config=arm_tenant_id=DummyTenantId -backend-config=arm_client_id=DummyServicePrincipalId -backend-config=arm_client_secret=DummyServicePrincipalKey": {
+        "terraform init -no-color -backend-config=storage_account_name=DummyStorageAccount -backend-config=container_name=DummyContainer -backend-config=key=DummyKey -backend-config=resource_group_name=DummyResourceGroup -backend-config=subscription_id=DummmySubscriptionId -backend-config=tenant_id=DummyTenantId -backend-config=client_id=DummyServicePrincipalId -backend-config=client_secret=DummyServicePrincipalKey": {
             "code": 0,
             "stdout": "Executed Successfully"
         }

--- a/Extensions/Terraform/Src/Tasks/TerraformTaskV1/Tests/InitTests/Azure/AzureInitSuccessEmptyWorkingDir.ts
+++ b/Extensions/Terraform/Src/Tasks/TerraformTaskV1/Tests/InitTests/Azure/AzureInitSuccessEmptyWorkingDir.ts
@@ -22,7 +22,7 @@ process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServic
 process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
 process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
 
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "terraform": "terraform"
     },
@@ -30,7 +30,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
         "terraform": true
     },
     "exec": {
-        "terraform init -backend-config=storage_account_name=DummyStorageAccount -backend-config=container_name=DummyContainer -backend-config=key=DummyKey -backend-config=resource_group_name=DummyResourceGroup -backend-config=arm_subscription_id=DummmySubscriptionId -backend-config=arm_tenant_id=DummyTenantId -backend-config=arm_client_id=DummyServicePrincipalId -backend-config=arm_client_secret=DummyServicePrincipalKey": {
+        "terraform init -backend-config=storage_account_name=DummyStorageAccount -backend-config=container_name=DummyContainer -backend-config=key=DummyKey -backend-config=resource_group_name=DummyResourceGroup -backend-config=subscription_id=DummmySubscriptionId -backend-config=tenant_id=DummyTenantId -backend-config=client_id=DummyServicePrincipalId -backend-config=client_secret=DummyServicePrincipalKey": {
             "code": 0,
             "stdout": "Executed Successfully"
         }

--- a/Extensions/Terraform/Src/Tasks/TerraformTaskV1/Tests/InitTests/Azure/AzureInitSuccessNoAdditionalArgs.ts
+++ b/Extensions/Terraform/Src/Tasks/TerraformTaskV1/Tests/InitTests/Azure/AzureInitSuccessNoAdditionalArgs.ts
@@ -22,7 +22,7 @@ process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALID'] = 'DummyServic
 process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_SERVICEPRINCIPALKEY'] = 'DummyServicePrincipalKey';
 process.env['ENDPOINT_AUTH_PARAMETER_AzureRM_TENANTID'] = 'DummyTenantId';
 
-let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {
         "terraform": "terraform"
     },
@@ -30,7 +30,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
         "terraform": true
     },
     "exec": {
-        "terraform init -backend-config=storage_account_name=DummyStorageAccount -backend-config=container_name=DummyContainer -backend-config=key=DummyKey -backend-config=resource_group_name=DummyResourceGroup -backend-config=arm_subscription_id=DummmySubscriptionId -backend-config=arm_tenant_id=DummyTenantId -backend-config=arm_client_id=DummyServicePrincipalId -backend-config=arm_client_secret=DummyServicePrincipalKey": {
+        "terraform init -backend-config=storage_account_name=DummyStorageAccount -backend-config=container_name=DummyContainer -backend-config=key=DummyKey -backend-config=resource_group_name=DummyResourceGroup -backend-config=subscription_id=DummmySubscriptionId -backend-config=tenant_id=DummyTenantId -backend-config=client_id=DummyServicePrincipalId -backend-config=client_secret=DummyServicePrincipalKey": {
             "code": 0,
             "stdout": "Executed Successfully"
         }

--- a/Extensions/Terraform/Src/Tasks/TerraformTaskV1/src/azure-terraform-command-handler.ts
+++ b/Extensions/Terraform/Src/Tasks/TerraformTaskV1/src/azure-terraform-command-handler.ts
@@ -1,7 +1,7 @@
 import tasks = require('azure-pipelines-task-lib/task');
-import {ToolRunner} from 'azure-pipelines-task-lib/toolrunner';
-import {TerraformAuthorizationCommandInitializer} from './terraform-commands';
-import {BaseTerraformCommandHandler} from './base-terraform-command-handler';
+import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
+import { TerraformAuthorizationCommandInitializer } from './terraform-commands';
+import { BaseTerraformCommandHandler } from './base-terraform-command-handler';
 
 export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler {
     constructor() {
@@ -14,10 +14,10 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
         this.backendConfig.set('container_name', tasks.getInput("backendAzureRmContainerName", true));
         this.backendConfig.set('key', tasks.getInput("backendAzureRmKey", true));
         this.backendConfig.set('resource_group_name', tasks.getInput("backendAzureRmResourceGroupName", true));
-        this.backendConfig.set('arm_subscription_id', tasks.getEndpointDataParameter(backendServiceName, "subscriptionid", true));
-        this.backendConfig.set('arm_tenant_id', tasks.getEndpointAuthorizationParameter(backendServiceName, "tenantid", true));
-        this.backendConfig.set('arm_client_id', tasks.getEndpointAuthorizationParameter(backendServiceName, "serviceprincipalid", true));
-        this.backendConfig.set('arm_client_secret', tasks.getEndpointAuthorizationParameter(backendServiceName, "serviceprincipalkey", true));
+        this.backendConfig.set('subscription_id', tasks.getEndpointDataParameter(backendServiceName, "subscriptionid", true));
+        this.backendConfig.set('tenant_id', tasks.getEndpointAuthorizationParameter(backendServiceName, "tenantid", true));
+        this.backendConfig.set('client_id', tasks.getEndpointAuthorizationParameter(backendServiceName, "serviceprincipalid", true));
+        this.backendConfig.set('client_secret', tasks.getEndpointAuthorizationParameter(backendServiceName, "serviceprincipalkey", true));
     }
 
     public handleBackend(terraformToolRunner: ToolRunner): void {
@@ -31,10 +31,10 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
 
     public handleProvider(command: TerraformAuthorizationCommandInitializer) {
         if (command.serviceProvidername) {
-            process.env['ARM_SUBSCRIPTION_ID']  = tasks.getEndpointDataParameter(command.serviceProvidername, "subscriptionid", false);
-            process.env['ARM_TENANT_ID']        = tasks.getEndpointAuthorizationParameter(command.serviceProvidername, "tenantid", false);
-            process.env['ARM_CLIENT_ID']        = tasks.getEndpointAuthorizationParameter(command.serviceProvidername, "serviceprincipalid", false);
-            process.env['ARM_CLIENT_SECRET']    = tasks.getEndpointAuthorizationParameter(command.serviceProvidername, "serviceprincipalkey", false);
+            process.env['ARM_SUBSCRIPTION_ID'] = tasks.getEndpointDataParameter(command.serviceProvidername, "subscriptionid", false);
+            process.env['ARM_TENANT_ID'] = tasks.getEndpointAuthorizationParameter(command.serviceProvidername, "tenantid", false);
+            process.env['ARM_CLIENT_ID'] = tasks.getEndpointAuthorizationParameter(command.serviceProvidername, "serviceprincipalid", false);
+            process.env['ARM_CLIENT_SECRET'] = tasks.getEndpointAuthorizationParameter(command.serviceProvidername, "serviceprincipalkey", false);
         }
     }
 }


### PR DESCRIPTION
Due to the latest changes introduced by TF 0.15.0 and following the [Terraform documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs), the allowed backend arguments are:

- subscription_id
- tenant_id
- client_id
- client_secret

They haven't got the `arm_` prefix at the beginning.

In fact, using this extension with ADO + AzureRM Provider 2.55.0 and TF 0.15.0, we can see the errors in our pipeline:
```
Initializing the backend...

Error: Invalid backend configuration argument

The backend configuration argument "arm_subscription_id" given on the command
line is not expected for the selected backend type.


Error: Invalid backend configuration argument

The backend configuration argument "arm_tenant_id" given on the command line
is not expected for the selected backend type.


Error: Invalid backend configuration argument

The backend configuration argument "arm_client_id" given on the command line
is not expected for the selected backend type.


Error: Invalid backend configuration argument

The backend configuration argument "arm_client_secret" given on the command
line is not expected for the selected backend type.
```
