### PR TITLE
Provide enough information for a user to diagnose "Invalid Publish Profile" errors

### DIFF
--- a/TaskModules/powershell/TaskModuleSqlUtility/SqlPackageOnTargetMachines.ps1
+++ b/TaskModules/powershell/TaskModuleSqlUtility/SqlPackageOnTargetMachines.ps1
@@ -501,7 +501,7 @@ function Get-SqlPackageCmdArgs
         # validate publish profile
         if ([System.IO.Path]::GetExtension($publishProfile) -ne ".xml")
         {
-            throw "Invalid Publish Profile [ $publishProfile ] provided"
+            throw "Invalid Publish Profile [ $publishProfile ] provided, publish profiles must have a .xml extension"
         }
         $sqlPkgCmdArgs = [string]::Format('{0} /Profile:"{1}"', $sqlPkgCmdArgs, $publishProfile)
     }


### PR DESCRIPTION
Currently the deployment script throws with a vague "Invalid Publish Profile" error, leading the user to believe that there is an error with the contents of the file. 

This patch includes some extra text with the error message which will allow the user to quickly diagnose and rectify the error.