### PR TITLE
[Artifact engine] Removed handlebars from npm-shwrinkwrap

### DIFF
--- a/Extensions/ArtifactEngine/npm-shrinkwrap.json
+++ b/Extensions/ArtifactEngine/npm-shrinkwrap.json
@@ -736,8 +736,6 @@
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -746,8 +744,7 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -804,8 +801,7 @@
         },
         "async": {
           "version": "1.5.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "atob": {
           "version": "2.1.1",
@@ -1039,15 +1035,11 @@
         },
         "camelcase": {
           "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "center-align": {
           "version": "0.1.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "align-text": "^0.1.3",
             "lazy-cache": "^1.0.3"
@@ -1094,8 +1086,6 @@
         "cliui": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "center-align": "^0.1.1",
             "right-align": "^0.1.1",
@@ -1104,9 +1094,7 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -1178,8 +1166,7 @@
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
@@ -1512,27 +1499,6 @@
           "bundled": true,
           "dev": true
         },
-        "handlebars": {
-          "version": "4.0.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "async": "^1.4.0",
-            "optimist": "^0.6.1",
-            "source-map": "^0.4.4",
-            "uglify-js": "^2.6"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.4.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
-            }
-          }
-        },
         "has-ansi": {
           "version": "2.0.0",
           "bundled": true,
@@ -1652,8 +1618,7 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -1865,16 +1830,13 @@
         "kind-of": {
           "version": "3.2.2",
           "bundled": true,
-          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
         },
         "lazy-cache": {
           "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "lcid": {
           "version": "1.0.0",
@@ -1919,9 +1881,7 @@
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "loose-envify": {
           "version": "1.3.1",
@@ -2031,8 +1991,7 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "mixin-deep": {
           "version": "1.3.1",
@@ -2192,7 +2151,6 @@
         "optimist": {
           "version": "0.6.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "minimist": "~0.0.1",
             "wordwrap": "~0.0.2"
@@ -2383,8 +2341,7 @@
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "repeating": {
           "version": "2.0.1",
@@ -2422,8 +2379,6 @@
         "right-align": {
           "version": "0.1.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "align-text": "^0.1.1"
           }
@@ -2597,8 +2552,7 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "source-map-resolve": {
           "version": "0.5.1",
@@ -3048,8 +3002,6 @@
         "uglify-js": {
           "version": "2.8.29",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "source-map": "~0.5.1",
             "uglify-to-browserify": "~1.0.0",
@@ -3059,8 +3011,6 @@
             "yargs": {
               "version": "3.10.0",
               "bundled": true,
-              "dev": true,
-              "optional": true,
               "requires": {
                 "camelcase": "^1.0.2",
                 "cliui": "^2.1.0",
@@ -3073,7 +3023,6 @@
         "uglify-to-browserify": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "union-value": {
@@ -3193,14 +3142,11 @@
         },
         "window-size": {
           "version": "0.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "wrap-ansi": {
           "version": "2.1.0",

--- a/Extensions/ArtifactEngine/npm-shrinkwrap.json
+++ b/Extensions/ArtifactEngine/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Extensions/ArtifactEngine/package.json
+++ b/Extensions/ArtifactEngine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Removed handlebars from npm-shwrinkwrap for artifact engine - since it causes vulnerability check alert and there is no such dependency for nyc package at the moment.