### PR TITLE
Terraform task: propogate no-color to validate command when using validate+apply

### DIFF
--- a/Extensions/Terraform/Src/Tasks/TerraformTask/TerraformTaskV2/src/base-terraform-command-handler.ts
+++ b/Extensions/Terraform/Src/Tasks/TerraformTask/TerraformTaskV2/src/base-terraform-command-handler.ts
@@ -205,12 +205,7 @@ export abstract class BaseTerraformCommandHandler {
     public async onlyApply(): Promise<number> {
         let terraformTool;
         this.warnIfMultipleProviders();
-        let validateCommand = new TerraformBaseCommandInitializer("validate", tasks.getInput("workingDirectory"), '');
-        terraformTool = this.terraformToolHandler.createToolRunner(validateCommand);
-        await terraformTool.exec(<IExecOptions> {
-            cwd: validateCommand.workingDirectory
-        });
-        
+
         let serviceName = `environmentServiceName${this.getServiceProviderNameFromProviderInput()}`;
         let autoApprove: string = '-auto-approve';
         let additionalArgs: string = tasks.getInput("commandOptions") || autoApprove;
@@ -219,6 +214,20 @@ export abstract class BaseTerraformCommandHandler {
             additionalArgs = `${autoApprove} ${additionalArgs}`;
         }
 
+        let noColor: string = '-no-color';
+        let validateCommandArgs;
+        if (additionalArgs.includes(noColor) === true) {
+            validateCommandArgs = noColor;
+        } else {
+            validateCommandArgs = ''
+        }
+
+        let validateCommand = new TerraformBaseCommandInitializer("validate", tasks.getInput("workingDirectory"), validateCommandArgs);
+        terraformTool = this.terraformToolHandler.createToolRunner(validateCommand);
+        await terraformTool.exec(<IExecOptions> {
+            cwd: validateCommand.workingDirectory
+        });
+        
         let applyCommand = new TerraformAuthorizationCommandInitializer(
             "apply",
             tasks.getInput("workingDirectory"),


### PR DESCRIPTION
When using the apply command in the TF task, it actually performs a validate+apply

However, when you pass in `-no-color` as an additional argument, this is only consumed by the apply command and not by the validate command.

This change will pass in `-no-color`  to the validate command when it is specified for the apply command