### PR TITLE
Bump expiration date for WinRM certificate

### DIFF
--- a/TaskModules/powershell/WinRM/WinRM-Http-Https-With-Makecert/ConfigureWinRM.ps1
+++ b/TaskModules/powershell/WinRM/WinRM-Http-Https-With-Makecert/ConfigureWinRM.ps1
@@ -91,7 +91,7 @@ function Configure-WinRMHttpsListener
             throw "File not found: makecert.exe"
         }
 
-        .\makecert -r -pe -n CN=$hostname -b 01/01/2012 -e 01/01/2022 -eku 1.3.6.1.5.5.7.3.1 -ss my -sr localmachine -sky exchange -sp "Microsoft RSA SChannel Cryptographic Provider" -sy 12
+        .\makecert -r -pe -n CN=$hostname -b 01/01/2012 -e 01/01/2032 -eku 1.3.6.1.5.5.7.3.1 -ss my -sr localmachine -sky exchange -sp "Microsoft RSA SChannel Cryptographic Provider" -sy 12
         $thumbprint=(Get-ChildItem cert:\Localmachine\my | Where-Object { $_.Subject -eq "CN=" + $hostname } | Select-Object -Last 1).Thumbprint
 
         if(-not $thumbprint)


### PR DESCRIPTION
Current date is 1 Jan 2022 so the script is generating expired certificates and WinRM connection can't be established.