### PR TITLE
Adding in MSI and fixing missing command argument

### DIFF
--- a/Extensions/Terraform/Src/Tasks/TerraformTask/TerraformTaskV2/src/azure-terraform-command-handler.ts
+++ b/Extensions/Terraform/Src/Tasks/TerraformTask/TerraformTaskV2/src/azure-terraform-command-handler.ts
@@ -10,14 +10,22 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
     }
 
     private setupBackend(backendServiceName: string) {
+        var serviceprincipalid = tasks.getEndpointAuthorizationParameter(backendServiceName, "serviceprincipalid", true);
+        var serviceprincipalkey = tasks.getEndpointAuthorizationParameter(backendServiceName, "serviceprincipalkey", true);
+        
         this.backendConfig.set('storage_account_name', tasks.getInput("backendAzureRmStorageAccountName", true));
         this.backendConfig.set('container_name', tasks.getInput("backendAzureRmContainerName", true));
         this.backendConfig.set('key', tasks.getInput("backendAzureRmKey", true));
         this.backendConfig.set('resource_group_name', tasks.getInput("backendAzureRmResourceGroupName", true));
         this.backendConfig.set('subscription_id', tasks.getEndpointDataParameter(backendServiceName, "subscriptionid", true));
         this.backendConfig.set('tenant_id', tasks.getEndpointAuthorizationParameter(backendServiceName, "tenantid", true));
-        this.backendConfig.set('client_id', tasks.getEndpointAuthorizationParameter(backendServiceName, "serviceprincipalid", true));
-        this.backendConfig.set('client_secret', tasks.getEndpointAuthorizationParameter(backendServiceName, "serviceprincipalkey", true));
+
+        if(serviceprincipalid && serviceprincipalkey) {
+            this.backendConfig.set('client_id', serviceprincipalid);
+            this.backendConfig.set('client_secret', serviceprincipalkey);
+        } else {
+            this.backendConfig.set('use_msi', 'true');
+        }
     }
 
     public handleBackend(terraformToolRunner: ToolRunner): void {
@@ -31,10 +39,19 @@ export class TerraformCommandHandlerAzureRM extends BaseTerraformCommandHandler 
 
     public handleProvider(command: TerraformAuthorizationCommandInitializer) {
         if (command.serviceProvidername) {
+            var serviceprincipalid = tasks.getEndpointAuthorizationParameter(command.serviceProvidername, "serviceprincipalid", true);
+            var serviceprincipalkey = tasks.getEndpointAuthorizationParameter(command.serviceProvidername, "serviceprincipalkey", true);
+        
+
             process.env['ARM_SUBSCRIPTION_ID']  = tasks.getEndpointDataParameter(command.serviceProvidername, "subscriptionid", false);
             process.env['ARM_TENANT_ID']        = tasks.getEndpointAuthorizationParameter(command.serviceProvidername, "tenantid", false);
-            process.env['ARM_CLIENT_ID']        = tasks.getEndpointAuthorizationParameter(command.serviceProvidername, "serviceprincipalid", false);
-            process.env['ARM_CLIENT_SECRET']    = tasks.getEndpointAuthorizationParameter(command.serviceProvidername, "serviceprincipalkey", false);
+
+            if(serviceprincipalid && serviceprincipalkey) {
+                process.env['ARM_CLIENT_ID']        = tasks.getEndpointAuthorizationParameter(command.serviceProvidername, "serviceprincipalid", true);
+                process.env['ARM_CLIENT_SECRET']    = tasks.getEndpointAuthorizationParameter(command.serviceProvidername, "serviceprincipalkey", true); 
+            } else {
+                process.env['ARM_USE_MSI'] = 'true';
+            }
         }
     }
 }

--- a/Extensions/Terraform/Src/Tasks/TerraformTask/TerraformTaskV2/src/base-terraform-command-handler.ts
+++ b/Extensions/Terraform/Src/Tasks/TerraformTask/TerraformTaskV2/src/base-terraform-command-handler.ts
@@ -147,7 +147,7 @@ export abstract class BaseTerraformCommandHandler {
                 "plan",
                 tasks.getInput("workingDirectory"),
                 tasks.getInput(serviceName, true),
-                `${tasks.getInput("commandOptions")} -out=${binaryPlanFilePath}`
+                `${tasks.getInput("commandOptions") || ''} -out=${binaryPlanFilePath}`
             );
             terraformTool = this.terraformToolHandler.createToolRunner(planCommand);
             this.handleProvider(planCommand);


### PR DESCRIPTION
**Changes Made**

- I added in the ability to utilize a managed system identity for the build agent when credentials are not provided in the service connections
- Fixed a bug where commandArguments were passing in undefined into the terraform executable causing and error: "Too many command line arguments"