### PR TITLE
fix-missing-dependency-for-ArtifactEngine

### DIFF
--- a/Extensions/ArtifactEngine/npm-shrinkwrap.json
+++ b/Extensions/ArtifactEngine/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2523,6 +2523,11 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.3.tgz",
       "integrity": "sha512-otIc7O9LyxpUcQoXzj2hL4LPWKklO6LJWoJUzNa8A17Xgi4fOeDC8FBDOLHnC/Slo1CQgsZMcM6as0M76BZaig==",
       "optional": true
+    },
+    "underscore": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "util": {
       "version": "0.10.3",

--- a/Extensions/ArtifactEngine/package.json
+++ b/Extensions/ArtifactEngine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",
@@ -16,10 +16,11 @@
     "email": "omeshp@microsoft.com"
   },
   "dependencies": {
+    "azure-pipelines-task-lib": "^3.1.0",
     "handlebars": "4.7.7",
     "minimatch": "3.0.2",
-    "azure-pipelines-task-lib": "^3.1.0",
-    "tunnel": "0.0.4"
+    "tunnel": "0.0.4",
+    "underscore": "^1.13.6"
   },
   "devDependencies": {
     "@types/minimatch": "^2.0.29",


### PR DESCRIPTION
Added an "underscore" dependency to the dependencies list since it will throw an exception in cases if the underscore is not present in node_modules. 
underscore is imported and used in Extensions\ArtifactEngine\Providers\typed-rest-client\handlers\ntlm.ts file