### PR TITLE
Remove distributed-task feeds call during console logging

### DIFF
--- a/ServerTaskHelper/AzureFunctionAdvancedHandler/README.md
+++ b/ServerTaskHelper/AzureFunctionAdvancedHandler/README.md
@@ -6,6 +6,13 @@ Use the [`Invoke Azure Function` check](https://learn.microsoft.com/azure/devops
 
 To successfully run this example, you need to have an Azure Boards work item, an Azure Repo, and a YAML pipeline.
 
+# Requirements
+
+To run this example, you need the following:
+
+- .NET 6 SDK and .NET 6 Runtime
+- Visual Studio 2022 (previous versions don't support .NET 6)
+
 # Structure
 
 The Azure Function goes through the following steps:

--- a/ServerTaskHelper/AzureFunctionBasicHandler/CmdLineTaskHandler.cs
+++ b/ServerTaskHelper/AzureFunctionBasicHandler/CmdLineTaskHandler.cs
@@ -10,13 +10,13 @@ using Microsoft.VisualStudio.Services.Common;
 
 namespace AzureFunctionBasicHandler
 {
-    public class WorkItemStatusHandler
+    public class CmdLineTaskHandler
     {
 
         private readonly TaskProperties _taskProperties;
         private TaskLogger _taskLogger;
 
-        public WorkItemStatusHandler(TaskProperties taskProperties)
+        public CmdLineTaskHandler(TaskProperties taskProperties)
         {
             _taskProperties = taskProperties;
         }

--- a/ServerTaskHelper/AzureFunctionBasicHandler/MyBasicFunction.cs
+++ b/ServerTaskHelper/AzureFunctionBasicHandler/MyBasicFunction.cs
@@ -34,7 +34,7 @@ namespace AzureFunctionBasicHandler
             // Created task execution handler
             Task.Run(() =>
             {
-                var executionHandler = new WorkItemStatusHandler(taskProperties);
+                var executionHandler = new CmdLineTaskHandler(taskProperties);
                 _ = executionHandler.Execute(log, CancellationToken.None).Result;
             });
 

--- a/ServerTaskHelper/AzureFunctionBasicHandler/README.md
+++ b/ServerTaskHelper/AzureFunctionBasicHandler/README.md
@@ -6,6 +6,13 @@ You should use this Azure Function in an [`Invoke Azure Function` check](https:/
 
 To successfully run this example, your pipeline needs to have at least two stages: a first stage that executes at least one [`CmdLine` task](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/cmd-line-v2), and a second stage that uses a resource on which you configured the `Invoke Azure Function` check.
 
+# Requirements
+
+To run this example, you need the following:
+
+- .NET 6 SDK and .NET 6 Runtime
+- Visual Studio 2022 (previous versions don't support .NET 6)
+
 # Steps 
 
 The Azure Function goes through the following steps:

--- a/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/TaskProgress/TaskClient.cs
+++ b/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/TaskProgress/TaskClient.cs
@@ -41,7 +41,7 @@ namespace DistributedTask.ServerTask.Remote.Common.TaskProgress
         {
             var jobId = await GetJobId(this.TaskProperties.HubName, this.TaskProperties.JobId, taskId);
             taskId = await GetTaskId(this.TaskProperties.HubName, taskId);
-            
+
             var startedEvent = new TaskStartedEvent(jobId, taskId);
             await taskClient.RaisePlanEventAsync(this.TaskProperties.ProjectId, this.TaskProperties.HubName, this.TaskProperties.PlanId, startedEvent, cancellationToken).ConfigureAwait(false);
         }
@@ -59,7 +59,7 @@ namespace DistributedTask.ServerTask.Remote.Common.TaskProgress
         {
             var jobId = await GetJobId(this.TaskProperties.HubName, this.TaskProperties.JobId, taskId);
             taskId = await GetTaskId(this.TaskProperties.HubName, taskId);
-            
+
             var completedEvent = new TaskCompletedEvent(jobId, taskId, result);
             await taskClient.RaisePlanEventAsync(this.TaskProperties.ProjectId, this.TaskProperties.HubName, this.TaskProperties.PlanId, completedEvent, cancellationToken).ConfigureAwait(false);
         }
@@ -77,11 +77,6 @@ namespace DistributedTask.ServerTask.Remote.Common.TaskProgress
         public async Task<TaskLog> AppendLogContentAsync(int logId, Stream uploadStream)
         {
             return await taskClient.AppendLogContentAsync(this.TaskProperties.ProjectId, this.TaskProperties.HubName, this.TaskProperties.PlanId, logId, uploadStream).ConfigureAwait(false);
-        }
-
-        public async Task AppendTimelineRecordFeedAsync(IEnumerable<string> lines)
-        {
-            await taskClient.AppendTimelineRecordFeedAsync(this.TaskProperties.ProjectId, this.TaskProperties.HubName, this.TaskProperties.PlanId, this.TaskProperties.TimelineId, this.TaskProperties.JobId, lines).ConfigureAwait(false);
         }
 
         public async Task SetTaskVariable(Guid taskId, string name, string value, bool isSecret, CancellationToken cancellationToken)

--- a/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/TaskProgress/TaskLogger.cs
+++ b/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/TaskProgress/TaskLogger.cs
@@ -42,7 +42,6 @@ namespace DistributedTask.ServerTask.Remote.Common.TaskProgress
             }
 
             var line = $"{DateTime.UtcNow:O} {message}";
-            await taskClient.AppendTimelineRecordFeedAsync(new List<string> {line}).ConfigureAwait(false);
             await LogPage(line).ConfigureAwait(false);
         }
 
@@ -107,7 +106,7 @@ namespace DistributedTask.ServerTask.Remote.Common.TaskProgress
 
                 // Create a new record and only set the Log field
                 var attachmentUpdataRecord = new TimelineRecord { Id = taskProperties.TaskInstanceId, Log = taskLog };
-                await taskClient.UpdateTimelineRecordsAsync(attachmentUpdataRecord, default(CancellationToken)).ConfigureAwait(false);
+                await taskClient.UpdateTimelineRecordsAsync(attachmentUpdataRecord, default).ConfigureAwait(false);
             }
         }
         public async Task CreateTaskTimelineRecordIfRequired(TaskClient taskClient, CancellationToken cancellationToken)


### PR DESCRIPTION
Remove AppendTimelineRecordFeedAsync call when logging data to pipeline's console.