### PR TITLE
Migrate Ansible Extension to Node 16

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleCommandLineInterface.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleCommandLineInterface.ts
@@ -1,4 +1,4 @@
-import tl = require("vsts-task-lib/task");
+import tl = require("azure-pipelines-task-lib/task");
 import { ansibleInterface } from './ansibleInterface';
 import * as ansibleUtils from './ansibleUtils';
 import { RemoteCommandOptions } from './ansibleUtils'

--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleRemoteMachineInterface.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleRemoteMachineInterface.ts
@@ -1,4 +1,4 @@
-import tl = require("vsts-task-lib/task");
+import tl = require("azure-pipelines-task-lib/task");
 import path = require("path");
 import * as ansibleUtils from './ansibleUtils';
 import { RemoteCommandOptions } from './ansibleUtils'

--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleTaskParameters.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleTaskParameters.ts
@@ -1,4 +1,4 @@
-import tl = require("vsts-task-lib/task");
+import tl = require("azure-pipelines-task-lib/task");
 
 export class ansibleTaskParameters {
     

--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleTowerInterface.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleTowerInterface.ts
@@ -1,4 +1,4 @@
-import tl = require("vsts-task-lib/task");
+import tl = require("azure-pipelines-task-lib/task");
 import path = require("path");
 import querystring = require('querystring');
 import util = require("util");

--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
@@ -1,10 +1,10 @@
-import tl = require("vsts-task-lib/task");
+import tl = require("azure-pipelines-task-lib/task");
 import Q = require("q");
 import util = require("util");
 import querystring = require('querystring');
 
 var uuid = require('uuid/v4');
-var httpClient = require('vso-node-api/HttpClient');
+var httpClient = require('azure-devops-node-api/HttpClient');
 var httpObj = new httpClient.HttpCallbackClient(tl.getVariable("AZURE_HTTP_USER_AGENT"));
 
 var os = require('os');

--- a/Extensions/Ansible/Src/Tasks/Ansible/main.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/main.ts
@@ -1,5 +1,5 @@
 import path = require("path");
-import tl = require("vsts-task-lib/task");
+import tl = require("azure-pipelines-task-lib/task");
 import {ansibleInterface}  from './ansibleInterface';
 import {ansibleCommandLineInterface} from './ansibleCommandLineInterface';
 import {ansibleRemoteMachineInterface} from './ansibleRemoteMachineInterface';

--- a/Extensions/Ansible/Src/Tasks/Ansible/package.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package.json
@@ -6,12 +6,12 @@
   "author": "Microsoft",
   "license": "ISC",
   "dependencies": {
+    "azure-devops-node-api" : "^11.2.0",
+    "azure-pipelines-task-lib" : "^4.2.0",
     "scp2": "^0.5.0",
     "shelljs": "^0.8.5",
     "ssh2": "^1.10.0",
-    "uuid": "^3.3.2",
-    "vso-node-api": "6.0.1-preview",
-    "vsts-task-lib": "2.0.5"
+    "uuid": "^3.3.2"
   },
   "devDependencies": {},
   "scripts": {

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -21,6 +21,7 @@
     },
     "demands": [],
     "instanceNameFormat": "Run playbook",
+    "minimumAgentVersion": "2.144.0",
     "groups": [
         {
             "name": "playbookRemoteMachine",
@@ -325,6 +326,14 @@
     ],
     "execution": {
         "Node": {
+            "target": "main.js",
+            "argumentFormat": ""
+        },
+        "Node10": {
+            "target": "main.js",
+            "argumentFormat": ""
+        },
+        "Node16": {
             "target": "main.js",
             "argumentFormat": ""
         }


### PR DESCRIPTION
Reviewers and contributors, please follow the migration to node16 guide we have for in-the-box ADO tasks:
https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/migrateNode16.md

This PR is not ready to be merged, it is just a starting point to help contributors start.

The Node 16 migration guide is created keeping in mind that the in-the-box ADO tasks were already migrated to Node 10. In order to ensure smooth migration to Node 16, we need to ensure that the task can be run using a Node 10 handler as well. Please refer to the following guide for the same:
https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/migrateNode10.md

Since vsts-task-lib is deprecated, it should be replaced by azure-pipelines-task-lib. Similarly vso-node-api should be replaced with azure-devops-node-api.

Please be sure to retest all tasks on node 10 and16 thoroughly.