### PR TITLE
2023646 DTS: Re-release extension manifest, up versions

### DIFF
--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.157.0",
+  "version": "15.157.1",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",


### PR DESCRIPTION
DTS: https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2023646
Extension: https://marketplace.visualstudio.com/items?itemName=ms-vscs-rm.vss-services-bitbucket

I've found that extension manifest still has "old" value for the `endpointTypeId` field (which must be equal to "bitbucket" now, but it equals to "bitbucket:UsernamePassword"):
https://ms-vscs-rm.gallery-assets.vsts.me/_apis/public/gallery/publisher/ms-vscs-rm/extension/vss-services-bitbucket/15.157.0/assetbyname/Microsoft.VisualStudio.Services.Manifest 

We request manifest data this way from backend and expect it to be up-to-date.

So the idea of this PR is to bump extension versions and re-release it to update manifest values here [https://ms-vscs-rm.gallery-assets.vsts.me/_apis/public/gallery/publisher/ms-vscs-rm/extension/vss-services-bitbucket/15.157.0](https://ms-vscs-rm.gallery-assets.vsts.me/_apis/public/gallery/publisher/ms-vscs-rm/extension/vss-services-bitbucket/15.157.0/assetbyname/Microsoft.VisualStudio.Services.Manifest%C2%A0). **There is no need to change something in extension manifest.**