### PR TITLE
Rollback SQL Dacpac arguments validation

### DIFF
--- a/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV1/DeployToSqlServer.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV1/DeployToSqlServer.ps1
@@ -218,7 +218,7 @@ function Main
     Write-Verbose "inlineSql = $inlineSql"
 
     TrimInputs -adminUserName([ref]$adminUserName) -sqlUsername ([ref]$sqlUsername) -dacpacFile ([ref]$dacpacFile) -publishProfile ([ref]$publishProfile) -sqlFile ([ref]$sqlFile)
-    Validate-AdditionalArguments $additionalArguments
+    # Validate-AdditionalArguments $additionalArguments
 
     $scriptBuilderArgs = @{
         dacpacFile=$dacpacFile 

--- a/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV1/task.json
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV1/task.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 4,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
   ],

--- a/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV2/DeployToSqlServer.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV2/DeployToSqlServer.ps1
@@ -218,7 +218,7 @@ function Main
     Write-Verbose "inlineSql = $inlineSql"
 
     TrimInputs -adminUserName([ref]$adminUserName) -sqlUsername ([ref]$sqlUsername) -dacpacFile ([ref]$dacpacFile) -publishProfile ([ref]$publishProfile) -sqlFile ([ref]$sqlFile)
-    Validate-AdditionalArguments $additionalArguments
+    # Validate-AdditionalArguments $additionalArguments
 
     $scriptBuilderArgs = @{
         dacpacFile=$dacpacFile 

--- a/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV2/task.json
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV2/task.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 2,
     "Minor": 1,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
   ],

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,


### PR DESCRIPTION
Extension name: **IISWebAppDeploy**

Tasks:

- SqlDacpacDeployV1
- SqlDacpacDeployV2

Description: Temporary disable SQL Dacpac additional arguments validation because of unexpected behavior (Some arguments can accept an array divided by semicolons)

Documentation changes required: No