### PR TITLE
Improve additional arguments validation to allow array of parameters

### DIFF
--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppDeploy/IISWebAppDeployV1/MsDeployOnTargetMachines.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppDeploy/IISWebAppDeployV1/MsDeployOnTargetMachines.ps1
@@ -61,8 +61,11 @@ function Get-MsDeployLocation
 
 function Get-ValidatedAdditionalArguments([string]$msDeployCmdArgs, [string]$additionalArguments)
 {
-    if($additionalArguments -match "[&;|]")
-    {
+    # Remove content within double quotes
+    $noQuotesContent = $additionalArguments -replace '"[^"]*"', ''
+
+    # Check if forbidden characters exist in the remaining content
+    if ($noQuotesContent -match "[&;|]") {
         $additionalArgumentsValidationErrorMessage = "Additional arguments can't include separator characters '&', ';' and '|'. Please verify input. To learn more about argument validation, please check https://aka.ms/azdo-task-argument-validation"
         throw $additionalArgumentsValidationErrorMessage
     }

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppDeploy/IISWebAppDeployV1/task.json
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppDeploy/IISWebAppDeployV1/task.json
@@ -7,7 +7,7 @@
   "version": {
     "Major": 1,
     "Minor": 5,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
   ],

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppDeploy/IISWebAppDeployV2/MsDeployOnTargetMachines.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppDeploy/IISWebAppDeployV2/MsDeployOnTargetMachines.ps1
@@ -61,8 +61,11 @@ function Get-MsDeployLocation
 
 function Get-ValidatedAdditionalArguments([string]$msDeployCmdArgs, [string]$additionalArguments)
 {
-    if($additionalArguments -match "[&;|]")
-    {
+    # Remove content within double quotes
+    $noQuotesContent = $additionalArguments -replace '"[^"]*"', ''
+
+    # Check if forbidden characters exist in the remaining content
+    if ($noQuotesContent -match "[&;|]") {
         $additionalArgumentsValidationErrorMessage = "Additional arguments can't include separator characters '&', ';' and '|'. Please verify input. To learn more about argument validation, please check https://aka.ms/azdo-task-argument-validation"
         throw $additionalArgumentsValidationErrorMessage
     }

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppDeploy/IISWebAppDeployV2/task.json
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppDeploy/IISWebAppDeployV2/task.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 2,
     "Minor": 1,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
   ],

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV1/ManageIISWebApp.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV1/ManageIISWebApp.ps1
@@ -85,11 +85,14 @@ function Escape-SpecialChars
 
 function Validate-AdditionalArguments([string]$additionalArguments)
 {
-    if($additionalArguments -match "[&;|]")
-    {
+    # Remove content within double quotes
+    $noQuotesContent = $additionalArguments -replace '"[^"]*"', ''
+
+    # Check if forbidden characters exist in the remaining content
+    if ($noQuotesContent -match "[&;|]") {
         $additionalArgumentsValidationErrorMessage = "Additional arguments can't include separator characters '&', ';' and '|'. Please verify input. To learn more about argument validation, please check https://aka.ms/azdo-task-argument-validation"
         throw $additionalArgumentsValidationErrorMessage
-    }    
+    }
 }
 
 function Get-ScriptToRun

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV1/task.json
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV1/task.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 4,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
   ],

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV2/Utility.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV2/Utility.ps1
@@ -323,11 +323,14 @@ function Validate-Bindings {
 
 function Validate-AdditionalArguments([string]$additionalArguments)
 {
-    if($additionalArguments -match "[&;|]")
-    {
+    # Remove content within double quotes
+    $noQuotesContent = $additionalArguments -replace '"[^"]*"', ''
+
+    # Check if forbidden characters exist in the remaining content
+    if ($noQuotesContent -match "[&;|]") {
         $additionalArgumentsValidationErrorMessage = "Additional arguments can't include separator characters '&', ';' and '|'. Please verify input. To learn more about argument validation, please check https://aka.ms/azdo-task-argument-validation"
         throw $additionalArgumentsValidationErrorMessage
-    }    
+    }
 }
 
 function Escape-SpecialChars

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV2/task.json
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV2/task.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 2,
     "Minor": 2,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
   ],

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV3/Utility.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV3/Utility.ps1
@@ -323,11 +323,14 @@ function Validate-Bindings {
 
 function Validate-AdditionalArguments([string]$additionalArguments)
 {
-    if($additionalArguments -match "[&;|]")
-    {
+    # Remove content within double quotes
+    $noQuotesContent = $additionalArguments -replace '"[^"]*"', ''
+
+    # Check if forbidden characters exist in the remaining content
+    if ($noQuotesContent -match "[&;|]") {
         $additionalArgumentsValidationErrorMessage = "Additional arguments can't include separator characters '&', ';' and '|'. Please verify input. To learn more about argument validation, please check https://aka.ms/azdo-task-argument-validation"
         throw $additionalArgumentsValidationErrorMessage
-    }     
+    }
 }
 
 function Escape-SpecialChars

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV3/task.json
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV3/task.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 3,
     "Minor": 1,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
   ],

--- a/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV1/DeployToSqlServer.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV1/DeployToSqlServer.ps1
@@ -24,11 +24,14 @@ function TrimInputs([ref]$adminUserName, [ref]$sqlUsername, [ref]$dacpacFile, [r
 
 function Validate-AdditionalArguments([string]$additionalArguments)
 {
-    if($additionalArguments -match "[&;|]")
-    {
+    # Remove content within double quotes
+    $noQuotesContent = $additionalArguments -replace '"[^"]*"', ''
+
+    # Check if forbidden characters exist in the remaining content
+    if ($noQuotesContent -match "[&;|]") {
         $additionalArgumentsValidationErrorMessage = "Additional arguments can't include separator characters '&', ';' and '|'. Please verify input. To learn more about argument validation, please check https://aka.ms/azdo-task-argument-validation"
         throw $additionalArgumentsValidationErrorMessage
-    }    
+    }
 }
 
 function RunRemoteDeployment

--- a/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV1/DeployToSqlServer.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV1/DeployToSqlServer.ps1
@@ -221,7 +221,7 @@ function Main
     Write-Verbose "inlineSql = $inlineSql"
 
     TrimInputs -adminUserName([ref]$adminUserName) -sqlUsername ([ref]$sqlUsername) -dacpacFile ([ref]$dacpacFile) -publishProfile ([ref]$publishProfile) -sqlFile ([ref]$sqlFile)
-    # Validate-AdditionalArguments $additionalArguments
+    Validate-AdditionalArguments $additionalArguments
 
     $scriptBuilderArgs = @{
         dacpacFile=$dacpacFile 

--- a/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV1/task.json
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV1/task.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 4,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
   ],

--- a/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV2/DeployToSqlServer.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV2/DeployToSqlServer.ps1
@@ -24,11 +24,14 @@ function TrimInputs([ref]$adminUserName, [ref]$sqlUsername, [ref]$dacpacFile, [r
 
 function Validate-AdditionalArguments([string]$additionalArguments)
 {
-    if($additionalArguments -match "[&;|]")
-    {
+    # Remove content within double quotes
+    $noQuotesContent = $additionalArguments -replace '"[^"]*"', ''
+
+    # Check if forbidden characters exist in the remaining content
+    if ($noQuotesContent -match "[&;|]") {
         $additionalArgumentsValidationErrorMessage = "Additional arguments can't include separator characters '&', ';' and '|'. Please verify input. To learn more about argument validation, please check https://aka.ms/azdo-task-argument-validation"
         throw $additionalArgumentsValidationErrorMessage
-    }    
+    }
 }
 
 function RunRemoteDeployment

--- a/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV2/DeployToSqlServer.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV2/DeployToSqlServer.ps1
@@ -221,7 +221,7 @@ function Main
     Write-Verbose "inlineSql = $inlineSql"
 
     TrimInputs -adminUserName([ref]$adminUserName) -sqlUsername ([ref]$sqlUsername) -dacpacFile ([ref]$dacpacFile) -publishProfile ([ref]$publishProfile) -sqlFile ([ref]$sqlFile)
-    # Validate-AdditionalArguments $additionalArguments
+    Validate-AdditionalArguments $additionalArguments
 
     $scriptBuilderArgs = @{
         dacpacFile=$dacpacFile 

--- a/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV2/task.json
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV2/task.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 2,
     "Minor": 1,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
   ],

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Tests/Tasks/IISWebAppDeploy/IISWebAppDeployV1/L0ValidateAdditionalArguments.ps1
+++ b/Extensions/IISWebAppDeploy/Tests/Tasks/IISWebAppDeploy/IISWebAppDeployV1/L0ValidateAdditionalArguments.ps1
@@ -10,19 +10,27 @@ param()
 $invalidAdditionalArgumentsWithSemicolon = "echo 123 ; start notepad.exe"
 $invalidAdditionalArgumentsWithAmpersand = "echo 123 & start notepad.exe"
 $invalidAdditionalArgumentsWithVerticalBar = "echo 123 | start notepad.exe"
+$validAdditionalArgumentsWithArrayOfParameters = '/p:CreateNewDatabase=false /p:DoNotDropObjectTypes="RoleMembership;ServerRoleMembership"'
+$invalidAdditionalArgumentsWithArrayOfParameters = '/p:CreateNewDatabase=false ; start notepad.exe /p:DoNotDropObjectTypes="RoleMembership;ServerRoleMembership"'
 
 $additionalArgumentsValidationErrorMessage = "Additional arguments can't include separator characters '&', ';' and '|'. Please verify input. To learn more about argument validation, please check https://aka.ms/azdo-task-argument-validation"
 
 # Assert
 
 Assert-Throws {
-   Get-ValidatedAdditionalArguments -msDeployCmdArgs "" -additionalArguments $invalidAdditionalArgumentsWithSemicolon
+  Get-ValidatedAdditionalArguments -msDeployCmdArgs "" -additionalArguments $invalidAdditionalArgumentsWithSemicolon
  } -Message $additionalArgumentsValidationErrorMessage
  
 Assert-Throws {
-   Get-ValidatedAdditionalArguments -msDeployCmdArgs "" -additionalArguments $invalidAdditionalArgumentsWithAmpersand
-  } -Message $additionalArgumentsValidationErrorMessage
+  Get-ValidatedAdditionalArguments -msDeployCmdArgs "" -additionalArguments $invalidAdditionalArgumentsWithAmpersand
+} -Message $additionalArgumentsValidationErrorMessage
 
 Assert-Throws {
-   Get-ValidatedAdditionalArguments -msDeployCmdArgs "" -additionalArguments $invalidAdditionalArgumentsWithVerticalBar
- } -Message $additionalArgumentsValidationErrorMessage
+  Get-ValidatedAdditionalArguments -msDeployCmdArgs "" -additionalArguments $invalidAdditionalArgumentsWithVerticalBar
+} -Message $additionalArgumentsValidationErrorMessage
+
+Assert-Throws {
+  Get-ValidatedAdditionalArguments -msDeployCmdArgs "" -additionalArguments $invalidAdditionalArgumentsWithArrayOfParameters
+} -Message $additionalArgumentsValidationErrorMessage
+
+Get-ValidatedAdditionalArguments -msDeployCmdArgs "" -additionalArguments $validAdditionalArgumentsWithArrayOfParameters

--- a/Extensions/IISWebAppDeploy/Tests/Tasks/IISWebAppDeploy/IISWebAppDeployV2/L0ValidateAdditionalArguments.ps1
+++ b/Extensions/IISWebAppDeploy/Tests/Tasks/IISWebAppDeploy/IISWebAppDeployV2/L0ValidateAdditionalArguments.ps1
@@ -10,19 +10,27 @@ param()
 $invalidAdditionalArgumentsWithSemicolon = "echo 123 ; start notepad.exe"
 $invalidAdditionalArgumentsWithAmpersand = "echo 123 & start notepad.exe"
 $invalidAdditionalArgumentsWithVerticalBar = "echo 123 | start notepad.exe"
+$validAdditionalArgumentsWithArrayOfParameters = '/p:CreateNewDatabase=false /p:DoNotDropObjectTypes="RoleMembership;ServerRoleMembership"'
+$invalidAdditionalArgumentsWithArrayOfParameters = '/p:CreateNewDatabase=false ; start notepad.exe /p:DoNotDropObjectTypes="RoleMembership;ServerRoleMembership"'
 
 $additionalArgumentsValidationErrorMessage = "Additional arguments can't include separator characters '&', ';' and '|'. Please verify input. To learn more about argument validation, please check https://aka.ms/azdo-task-argument-validation"
 
 # Assert
 
 Assert-Throws {
-   Get-ValidatedAdditionalArguments -msDeployCmdArgs "" -additionalArguments $invalidAdditionalArgumentsWithSemicolon
+  Get-ValidatedAdditionalArguments -msDeployCmdArgs "" -additionalArguments $invalidAdditionalArgumentsWithSemicolon
  } -Message $additionalArgumentsValidationErrorMessage
  
 Assert-Throws {
-   Get-ValidatedAdditionalArguments -msDeployCmdArgs "" -additionalArguments $invalidAdditionalArgumentsWithAmpersand
-  } -Message $additionalArgumentsValidationErrorMessage
+  Get-ValidatedAdditionalArguments -msDeployCmdArgs "" -additionalArguments $invalidAdditionalArgumentsWithAmpersand
+} -Message $additionalArgumentsValidationErrorMessage
 
 Assert-Throws {
-   Get-ValidatedAdditionalArguments -msDeployCmdArgs "" -additionalArguments $invalidAdditionalArgumentsWithVerticalBar
- } -Message $additionalArgumentsValidationErrorMessage
+  Get-ValidatedAdditionalArguments -msDeployCmdArgs "" -additionalArguments $invalidAdditionalArgumentsWithVerticalBar
+} -Message $additionalArgumentsValidationErrorMessage
+
+Assert-Throws {
+  Get-ValidatedAdditionalArguments -msDeployCmdArgs "" -additionalArguments $invalidAdditionalArgumentsWithArrayOfParameters
+} -Message $additionalArgumentsValidationErrorMessage
+
+Get-ValidatedAdditionalArguments -msDeployCmdArgs "" -additionalArguments $validAdditionalArgumentsWithArrayOfParameters

--- a/Extensions/IISWebAppDeploy/Tests/Tasks/IISWebAppMgmt/IISWebAppMgmtV1/L0ValidateAdditionalArguments.ps1
+++ b/Extensions/IISWebAppDeploy/Tests/Tasks/IISWebAppMgmt/IISWebAppMgmtV1/L0ValidateAdditionalArguments.ps1
@@ -10,19 +10,27 @@ param()
 $invalidAdditionalArgumentsWithSemicolon = "echo 123 ; start notepad.exe"
 $invalidAdditionalArgumentsWithAmpersand = "echo 123 & start notepad.exe"
 $invalidAdditionalArgumentsWithVerticalBar = "echo 123 | start notepad.exe"
+$validAdditionalArgumentsWithArrayOfParameters = '/p:CreateNewDatabase=false /p:DoNotDropObjectTypes="RoleMembership;ServerRoleMembership"'
+$invalidAdditionalArgumentsWithArrayOfParameters = '/p:CreateNewDatabase=false ; start notepad.exe /p:DoNotDropObjectTypes="RoleMembership;ServerRoleMembership"'
 
 $additionalArgumentsValidationErrorMessage = "Additional arguments can't include separator characters '&', ';' and '|'. Please verify input. To learn more about argument validation, please check https://aka.ms/azdo-task-argument-validation"
 
 # Assert
 
 Assert-Throws {
-    Validate-AdditionalArguments $invalidAdditionalArgumentsWithSemicolon
- } -Message $additionalArgumentsValidationErrorMessage
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithSemicolon
+} -Message $additionalArgumentsValidationErrorMessage
  
 Assert-Throws {
-     Validate-AdditionalArguments $invalidAdditionalArgumentsWithAmpersand
-  } -Message $additionalArgumentsValidationErrorMessage
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithAmpersand
+} -Message $additionalArgumentsValidationErrorMessage
 
 Assert-Throws {
-    Validate-AdditionalArguments $invalidAdditionalArgumentsWithVerticalBar
- } -Message $additionalArgumentsValidationErrorMessage
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithVerticalBar
+} -Message $additionalArgumentsValidationErrorMessage
+
+Assert-Throws {
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithArrayOfParameters
+} -Message $additionalArgumentsValidationErrorMessage
+
+Validate-AdditionalArguments $validAdditionalArgumentsWithArrayOfParameters

--- a/Extensions/IISWebAppDeploy/Tests/Tasks/IISWebAppMgmt/IISWebAppMgmtV2/L0ValidateAdditionalArguments.ps1
+++ b/Extensions/IISWebAppDeploy/Tests/Tasks/IISWebAppMgmt/IISWebAppMgmtV2/L0ValidateAdditionalArguments.ps1
@@ -10,19 +10,27 @@ param()
 $invalidAdditionalArgumentsWithSemicolon = "echo 123 ; start notepad.exe"
 $invalidAdditionalArgumentsWithAmpersand = "echo 123 & start notepad.exe"
 $invalidAdditionalArgumentsWithVerticalBar = "echo 123 | start notepad.exe"
+$validAdditionalArgumentsWithArrayOfParameters = '/p:CreateNewDatabase=false /p:DoNotDropObjectTypes="RoleMembership;ServerRoleMembership"'
+$invalidAdditionalArgumentsWithArrayOfParameters = '/p:CreateNewDatabase=false ; start notepad.exe /p:DoNotDropObjectTypes="RoleMembership;ServerRoleMembership"'
 
 $additionalArgumentsValidationErrorMessage = "Additional arguments can't include separator characters '&', ';' and '|'. Please verify input. To learn more about argument validation, please check https://aka.ms/azdo-task-argument-validation"
 
 # Assert
 
 Assert-Throws {
-    Validate-AdditionalArguments $invalidAdditionalArgumentsWithSemicolon
- } -Message $additionalArgumentsValidationErrorMessage
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithSemicolon
+} -Message $additionalArgumentsValidationErrorMessage
  
 Assert-Throws {
-     Validate-AdditionalArguments $invalidAdditionalArgumentsWithAmpersand
-  } -Message $additionalArgumentsValidationErrorMessage
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithAmpersand
+} -Message $additionalArgumentsValidationErrorMessage
 
 Assert-Throws {
-    Validate-AdditionalArguments $invalidAdditionalArgumentsWithVerticalBar
- } -Message $additionalArgumentsValidationErrorMessage
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithVerticalBar
+} -Message $additionalArgumentsValidationErrorMessage
+
+Assert-Throws {
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithArrayOfParameters
+} -Message $additionalArgumentsValidationErrorMessage
+
+Validate-AdditionalArguments $validAdditionalArgumentsWithArrayOfParameters

--- a/Extensions/IISWebAppDeploy/Tests/Tasks/IISWebAppMgmt/IISWebAppMgmtV3/L0ValidateAdditionalArguments.ps1
+++ b/Extensions/IISWebAppDeploy/Tests/Tasks/IISWebAppMgmt/IISWebAppMgmtV3/L0ValidateAdditionalArguments.ps1
@@ -10,19 +10,27 @@ param()
 $invalidAdditionalArgumentsWithSemicolon = "echo 123 ; start notepad.exe"
 $invalidAdditionalArgumentsWithAmpersand = "echo 123 & start notepad.exe"
 $invalidAdditionalArgumentsWithVerticalBar = "echo 123 | start notepad.exe"
+$validAdditionalArgumentsWithArrayOfParameters = '/p:CreateNewDatabase=false /p:DoNotDropObjectTypes="RoleMembership;ServerRoleMembership"'
+$invalidAdditionalArgumentsWithArrayOfParameters = '/p:CreateNewDatabase=false ; start notepad.exe /p:DoNotDropObjectTypes="RoleMembership;ServerRoleMembership"'
 
 $additionalArgumentsValidationErrorMessage = "Additional arguments can't include separator characters '&', ';' and '|'. Please verify input. To learn more about argument validation, please check https://aka.ms/azdo-task-argument-validation"
 
 # Assert
 
 Assert-Throws {
-    Validate-AdditionalArguments $invalidAdditionalArgumentsWithSemicolon
- } -Message $additionalArgumentsValidationErrorMessage
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithSemicolon
+} -Message $additionalArgumentsValidationErrorMessage
  
 Assert-Throws {
-     Validate-AdditionalArguments $invalidAdditionalArgumentsWithAmpersand
-  } -Message $additionalArgumentsValidationErrorMessage
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithAmpersand
+} -Message $additionalArgumentsValidationErrorMessage
 
 Assert-Throws {
-    Validate-AdditionalArguments $invalidAdditionalArgumentsWithVerticalBar
- } -Message $additionalArgumentsValidationErrorMessage
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithVerticalBar
+} -Message $additionalArgumentsValidationErrorMessage
+
+Assert-Throws {
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithArrayOfParameters
+} -Message $additionalArgumentsValidationErrorMessage
+
+Validate-AdditionalArguments $validAdditionalArgumentsWithArrayOfParameters

--- a/Extensions/IISWebAppDeploy/Tests/Tasks/SqlDacpacDeploy/SqlDacpacDeployV1/L0ValidateAdditionalArguments.ps1
+++ b/Extensions/IISWebAppDeploy/Tests/Tasks/SqlDacpacDeploy/SqlDacpacDeployV1/L0ValidateAdditionalArguments.ps1
@@ -9,19 +9,27 @@ param()
 $invalidAdditionalArgumentsWithSemicolon = "echo 123 ; start notepad.exe"
 $invalidAdditionalArgumentsWithAmpersand = "echo 123 & start notepad.exe"
 $invalidAdditionalArgumentsWithVerticalBar = "echo 123 | start notepad.exe"
+$validAdditionalArgumentsWithArrayOfParameters = '/p:CreateNewDatabase=false /p:DoNotDropObjectTypes="RoleMembership;ServerRoleMembership"'
+$invalidAdditionalArgumentsWithArrayOfParameters = '/p:CreateNewDatabase=false ; start notepad.exe /p:DoNotDropObjectTypes="RoleMembership;ServerRoleMembership"'
 
 $additionalArgumentsValidationErrorMessage = "Additional arguments can't include separator characters '&', ';' and '|'. Please verify input. To learn more about argument validation, please check https://aka.ms/azdo-task-argument-validation"
 
 # Assert
 
 Assert-Throws {
-    Validate-AdditionalArguments $invalidAdditionalArgumentsWithSemicolon
- } -Message $additionalArgumentsValidationErrorMessage
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithSemicolon
+} -Message $additionalArgumentsValidationErrorMessage
  
 Assert-Throws {
-     Validate-AdditionalArguments $invalidAdditionalArgumentsWithAmpersand
-  } -Message $additionalArgumentsValidationErrorMessage
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithAmpersand
+} -Message $additionalArgumentsValidationErrorMessage
 
 Assert-Throws {
-    Validate-AdditionalArguments $invalidAdditionalArgumentsWithVerticalBar
- } -Message $additionalArgumentsValidationErrorMessage
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithVerticalBar
+} -Message $additionalArgumentsValidationErrorMessage
+
+Assert-Throws {
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithArrayOfParameters
+} -Message $additionalArgumentsValidationErrorMessage
+
+Validate-AdditionalArguments $validAdditionalArgumentsWithArrayOfParameters

--- a/Extensions/IISWebAppDeploy/Tests/Tasks/SqlDacpacDeploy/SqlDacpacDeployV2/L0ValidateAdditionalArguments.ps1
+++ b/Extensions/IISWebAppDeploy/Tests/Tasks/SqlDacpacDeploy/SqlDacpacDeployV2/L0ValidateAdditionalArguments.ps1
@@ -10,19 +10,27 @@ param()
 $invalidAdditionalArgumentsWithSemicolon = "echo 123 ; start notepad.exe"
 $invalidAdditionalArgumentsWithAmpersand = "echo 123 & start notepad.exe"
 $invalidAdditionalArgumentsWithVerticalBar = "echo 123 | start notepad.exe"
+$validAdditionalArgumentsWithArrayOfParameters = '/p:CreateNewDatabase=false /p:DoNotDropObjectTypes="RoleMembership;ServerRoleMembership;Permissions;Users;Filegroups;ApplicationRoles;DatabaseRoles;ServerRoles;LinkedServers;Assemblies"'
+$invalidAdditionalArgumentsWithArrayOfParameters = '/p:CreateNewDatabase=false ; start notepad.exe /p:DoNotDropObjectTypes="RoleMembership;ServerRoleMembership;Permissions;Users;Filegroups;ApplicationRoles;DatabaseRoles;ServerRoles;LinkedServers;Assemblies"'
 
 $additionalArgumentsValidationErrorMessage = "Additional arguments can't include separator characters '&', ';' and '|'. Please verify input. To learn more about argument validation, please check https://aka.ms/azdo-task-argument-validation"
 
 # Assert
 
 Assert-Throws {
-    Validate-AdditionalArguments $invalidAdditionalArgumentsWithSemicolon
- } -Message $additionalArgumentsValidationErrorMessage
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithSemicolon
+} -Message $additionalArgumentsValidationErrorMessage
  
 Assert-Throws {
-     Validate-AdditionalArguments $invalidAdditionalArgumentsWithAmpersand
-  } -Message $additionalArgumentsValidationErrorMessage
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithAmpersand
+} -Message $additionalArgumentsValidationErrorMessage
 
 Assert-Throws {
-    Validate-AdditionalArguments $invalidAdditionalArgumentsWithVerticalBar
- } -Message $additionalArgumentsValidationErrorMessage
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithVerticalBar
+} -Message $additionalArgumentsValidationErrorMessage
+
+Assert-Throws {
+   Validate-AdditionalArguments $invalidAdditionalArgumentsWithArrayOfParameters
+} -Message $additionalArgumentsValidationErrorMessage
+
+Validate-AdditionalArguments $validAdditionalArgumentsWithArrayOfParameters


### PR DESCRIPTION
**Extension name**:  IISWebAppDeploy

**Tasks**:
- IISWebAppDeployV1
- IISWebAppDeployV2
- IISWebAppMgmtV1
- IISWebAppMgmtV2
- IISWebAppMgmtV3
- SqlDacpacDeployV1
- SqlDacpacDeployV2

**Description**: 
Before, during the additional arguments validation we just looked for the forbidden characters, like this:
```ps
if($additionalArguments -match "[&;|]")
```

But there is some cases, when we have to pass some array of values as a parameter argument, like this:
```ps
/p:DoNotDropObjectTypes="RoleMembership;ServerRoleMembership"
```

This PR improves validation, by skipping the content in quotes.

**Documentation changes required:** No

**Added unit tests:** Yes

**Attached related issues:**

- https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2033403

**Checklist**:
- [x] Extension version was bumped
- [x] Tasks version was bumped
- [x] Checked that applied changes work as expected