### PR TITLE
Add release pipeline for IIS Web App Deployment Using WinRM

### DIFF
--- a/.github/workflows/release-iiswebapp.yml
+++ b/.github/workflows/release-iiswebapp.yml
@@ -1,0 +1,84 @@
+name: Publish IIS Web App Deployment Using WinRM
+
+on:
+  release:
+    types:
+      - published
+
+env:
+  node-version: 10
+  extension-name: ms-vscs-rm.iiswebapp-${{ github.event.release.tag_name }}.vsix # Tag name is the extension version.
+
+jobs:
+
+  build:
+
+    name: Build
+    runs-on: windows-latest
+    permissions:
+      contents: write # Permissions to attcach the artifact to release assets.
+    
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.release.target_commitish }} # Checkout the commit that used in the release.
+
+    - name: Install Node.js ${{ env.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ env.node-version }}
+
+    - name: Install Node Modules
+      run: npm install
+
+    - name: Install TFX CLI
+      run: npm install -g tfx-cli
+
+    - name: Build with Gulp
+      run: gulp build
+
+    - name: Package with Gulp
+      run: gulp package
+
+    - name: Upload Extension as Release Asset
+      uses: shogo82148/actions-upload-release-asset@v1
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: _package/IISWebAppDeploy/${{ env.extension-name }}
+        asset_name: ${{ env.extension-name }}
+        asset_content_type: application/octet-stream
+        
+    - name: Upload Extension as Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: IISWebAppDeploy Extension Artifact
+        path: _package/IISWebAppDeploy/${{ env.extension-name }}
+
+  publish:
+
+    name: Publish
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download a Build Artifact
+      uses: actions/download-artifact@v2.1.1
+      with:
+        name: IISWebAppDeploy Extension Artifact
+        path: ./artifacts/extensions/IISWebAppDeploy/
+
+    - name: Use Node.js ${{ env.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ env.node-version }}
+
+    - name: Install TFX CLI
+      run: npm install -g tfx-cli
+
+    - name: Publish Extension
+      run: |
+        tfx extension publish --vsix ./artifacts/extensions/IISWebAppDeploy/${{ env.extension-name }} \
+        --service-url https://marketplace.visualstudio.com \
+        --no-prompt \
+        --auth-type pat \
+        --token ${{ secrets.AZURE_DEVOPS_EXTENSIONS_PAT }}

--- a/.github/workflows/release-iiswebapp.yml
+++ b/.github/workflows/release-iiswebapp.yml
@@ -1,9 +1,9 @@
 name: Publish IIS Web App Deployment Using WinRM
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - 'iiswebapp-*'
 
 env:
   node-version: 10

--- a/.github/workflows/release-iiswebapp.yml
+++ b/.github/workflows/release-iiswebapp.yml
@@ -81,4 +81,4 @@ jobs:
         --service-url https://marketplace.visualstudio.com \
         --no-prompt \
         --auth-type pat \
-        --token ${{ secrets.AZURE_DEVOPS_EXTENSIONS_PAT }}
+        --token ${{ secrets.AZURE_DEVOPS_MARKETPLACE_PAT }}


### PR DESCRIPTION
Added release pipeline to automate delivery of the **IIS Web App Deployment Using WinRM** extension.
This action triggers on new tags which starts with: `iiswebapp-`
To start the delivery, just create a new release with tag `iiswebapp-x.x.x` where `x.x.x` is the version of the extension.
Like this: `iiswebapp-1.6.6`

Binaries after the build would be attached as release asset:
![image](https://github.com/microsoft/azure-pipelines-extensions/assets/50652041/e6e6fb4f-7473-4ea2-b66d-780d95d1f818)

