### PR TITLE
Add zipStream destroy call when response is aborted

### DIFF
--- a/Extensions/ArtifactEngine/npm-shrinkwrap.json
+++ b/Extensions/ArtifactEngine/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Extensions/ArtifactEngine/package.json
+++ b/Extensions/ArtifactEngine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added zipStream [destroy](https://nodejs.org/api/stream.html#writabledestroyerror) call when the response is aborted.

This is needed when there is a network problem HTTP request can be aborted and [reject](https://github.com/microsoft/azure-pipelines-extensions/blob/6a88be69558834409269219991150a62ea27c4e7/Extensions/ArtifactEngine/Providers/webProvider.ts#L62) can't be handled in `on("error")` [listener](https://github.com/microsoft/azure-pipelines-extensions/blob/6a88be69558834409269219991150a62ea27c4e7/Extensions/ArtifactEngine/Providers/filesystemProvider.ts#L77)

The `destroy` method is added so it can emit an 'error' event