### PR TITLE
Add request compression option for downloads

### DIFF
--- a/Extensions/ArtifactEngine/Providers/typed-rest-client/Interfaces.ts
+++ b/Extensions/ArtifactEngine/Providers/typed-rest-client/Interfaces.ts
@@ -24,7 +24,8 @@ export interface IRequestOptions {
     allowRedirects?: boolean, 
     maxRedirects?: number,
     maxSockets?: number,
-    keepAlive?: boolean
+    keepAlive?: boolean,
+    requestCompressionForDownloads?: boolean
 }
 
 export interface IProxyConfiguration {

--- a/Extensions/ArtifactEngine/Providers/webProvider.ts
+++ b/Extensions/ArtifactEngine/Providers/webProvider.ts
@@ -25,6 +25,7 @@ export class WebProvider implements IArtifactProvider {
         this.templateFile = templateFile;
         this.webClient = WebClientFactory.getClient([handler], requestOptions);
         this.variables = variables;
+        this.requestCompressionForDownloads = requestOptions ? requestOptions.requestCompressionForDownloads : false;
     }
 
     getRootItems(): Promise<ArtifactItem[]> {
@@ -52,7 +53,17 @@ export class WebProvider implements IArtifactProvider {
             var itemUrl: string = artifactItem.metadata['downloadUrl'];
             var zipStream = null;
             itemUrl = itemUrl.replace(/([^:]\/)\/+/g, "$1");
-            this.webClient.get(itemUrl, contentType ? { 'Accept': contentType } : undefined).then((res: HttpClientResponse) => {
+
+            const additionalHeaders = {};
+            if (contentType) {
+                additionalHeaders['Accept'] = contentType
+            }
+
+            if (this.requestCompressionForDownloads) {
+                additionalHeaders['Accept-Encoding'] = "gzip"
+            }
+
+            this.webClient.get(itemUrl, additionalHeaders).then((res: HttpClientResponse) => {
                 res.message.on('data', (chunk) => {
                     downloadSize += chunk.length;
                 });
@@ -145,5 +156,6 @@ export class WebProvider implements IArtifactProvider {
     private rootItemsLocation: string;
     private templateFile: string;
     private variables: string;
+    private requestCompressionForDownloads: boolean;
     public webClient: WebClient;
 }


### PR DESCRIPTION
This is a follow-up PR after [Follow redirects from ADO to stitch content in external service #18987](https://github.com/microsoft/azure-pipelines-tasks/pull/18987) which allows to follow the redirect and request compressed content.