### PR TITLE
Fix ArtifactEngine type error with Logger.logMessage

### DIFF
--- a/Extensions/ArtifactEngine/Providers/webProvider.ts
+++ b/Extensions/ArtifactEngine/Providers/webProvider.ts
@@ -73,7 +73,7 @@ export class WebProvider implements IArtifactProvider {
                 res.message.on('error', (error) => {
                     if (zipStream) {
                         zipStream.destroy(error);
-                        Logger.logMessage(error);
+                        Logger.logMessage(error.toString());
                     }
                     reject(error);
                 });


### PR DESCRIPTION
Fixed type error argument with **Logger.logMessage**