### PR TITLE
Update SqlPackageOnTargetMachines.ps1

### DIFF
--- a/TaskModules/powershell/TaskModuleSqlUtility/SqlPackageOnTargetMachines.ps1
+++ b/TaskModules/powershell/TaskModuleSqlUtility/SqlPackageOnTargetMachines.ps1
@@ -551,7 +551,7 @@ function ExecuteCommand
     {
         $ErrorActionPreference = 'SilentlyContinue'
         $result = ""
-        Invoke-Expression "& '$FileName' --% $Arguments"  -ErrorVariable errors | ForEach-Object {
+        Invoke-Expression "& '$FileName' $Arguments"  -ErrorVariable errors | ForEach-Object {
             $result +=  ("$_ " + [Environment]::NewLine)
         }
 


### PR DESCRIPTION
Remove --% simple parsing directive. This causes Illegal characters in path errors from sqlpackage when used via Invoke-Command. Removing --% appears to alleviate the problem and continues to work in ps5 + pscore.

Don't know all of the use cases for this, so feel free to nuke this PR if this will break something known, but I've tried with and without spaces, it appears to work in both PS5 and PS Core (7.3.8 specifically)