### PR TITLE
Add function for validating artifactEngine transpile errors

### DIFF
--- a/Extensions/ArtifactEngine/package.json
+++ b/Extensions/ArtifactEngine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description:** Added function for validating `artifactEngine` transpile errors on the build step.
Now we can catch transpile errors when running `gulp build` script

**Changes:**
- [x] Version was bumped
- [x] Additional validation to the gulp `build` step was added
