### PR TITLE
Issue 1225

### DIFF
--- a/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV1/task.json
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV1/task.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 1,
     "Minor": 5,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
   ],

--- a/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV2/task.json
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV2/task.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 2,
     "Minor": 2,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
   ],

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/TaskModules/powershell/TaskModuleSqlUtility/TaskModuleSqlUtility.psd1
+++ b/TaskModules/powershell/TaskModuleSqlUtility/TaskModuleSqlUtility.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'TaskModuleSqlUtility.psm1'
-    ModuleVersion = '0.1.3'
+    ModuleVersion = '0.1.4'
     GUID = 'd997c6dd-33ad-481c-859b-01120229b91f'
     Author = 'Microsoft'
     CompanyName = 'Microsoft'


### PR DESCRIPTION
fixes #1225 

**Description**: Look for SqlPackage.exe presence and version in the Visual Studio DAC folder introduced in later VS versions

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** #1225 

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.


Verified with

```powershell
. "$PSScriptRoot/SqlPackageOnTargetMachines.ps1"
Get-SqlPackageOnTargetMachine
```