### PR TITLE
use https when downloading nuget exe

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -760,7 +760,7 @@ gulp.task('nuget-download', function(done) {
         return done();
     }
     console.log("> Downloading nuget.exe");
-    return request.get('http://nuget.org/nuget.exe')
+    return request.get('https://nuget.org/nuget.exe')
         .pipe(fs.createWriteStream('nuget.exe'));
 });
 


### PR DESCRIPTION
**Description**: use HTTPS when downloading nuget exe file

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** NA

**Checklist**:
- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
