### PR TITLE
Unsafe shell command constructed from library input

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleCommandLineInterface.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleCommandLineInterface.ts
@@ -3,7 +3,7 @@ import { ansibleInterface } from './ansibleInterface';
 import * as ansibleUtils from './ansibleUtils';
 import { RemoteCommandOptions } from './ansibleUtils'
 import { ansibleTaskParameters } from './ansibleTaskParameters';
-import quote from 'shell-quote/quote';
+import { quote } from 'shell-quote';
 
 var os = require('os');
 var shell = require('shelljs');
@@ -125,7 +125,7 @@ export class ansibleCommandLineInterface extends ansibleInterface {
     }
 
     protected async createAndGetInventoryPathForInline(): Promise<string> {
-        let content = quote([this._taskParameters.inventoryInline.trim()]);
+        let content = this._taskParameters.inventoryInline.trim();
         let dynamicInventory: boolean = this._taskParameters.inventoryDynamic;
         var __this = this;
 
@@ -135,7 +135,7 @@ export class ansibleCommandLineInterface extends ansibleInterface {
                 let remoteInventoryPath = '"' + remoteInventory + '"';
                 tl.debug('RemoteInventoryPath = ' + remoteInventoryPath);
 
-                let inventoryCmd: string = 'echo ' + '"' + content + '"' + ' > ' + remoteInventory;
+                let inventoryCmd: string = 'echo ' + quote([content]) + ' > ' + remoteInventory;
                 await __this.executeCommand(inventoryCmd);
                 if (dynamicInventory == true) {
                     await __this.executeCommand('chmod +x ' + remoteInventory);

--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleCommandLineInterface.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleCommandLineInterface.ts
@@ -3,6 +3,7 @@ import { ansibleInterface } from './ansibleInterface';
 import * as ansibleUtils from './ansibleUtils';
 import { RemoteCommandOptions } from './ansibleUtils'
 import { ansibleTaskParameters } from './ansibleTaskParameters';
+import quote from 'shell-quote/quote';
 
 var os = require('os');
 var shell = require('shelljs');
@@ -124,7 +125,7 @@ export class ansibleCommandLineInterface extends ansibleInterface {
     }
 
     protected async createAndGetInventoryPathForInline(): Promise<string> {
-        let content = this._taskParameters.inventoryInline.trim();
+        let content = quote([this._taskParameters.inventoryInline.trim()]);
         let dynamicInventory: boolean = this._taskParameters.inventoryDynamic;
         var __this = this;
 

--- a/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
@@ -464,6 +464,11 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
     },
+    "shell-quote": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
+      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA=="
+    },
     "shelljs": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",

--- a/Extensions/Ansible/Src/Tasks/Ansible/package.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package.json
@@ -8,9 +8,10 @@
   "dependencies": {
     "@types/ssh2-sftp-client": "5.2.0",
     "azure-pipelines-task-lib": "^4.2.0",
-    "ssh2-sftp-client": "^8.1.0",
+    "shell-quote": "^1.8.2",
     "shelljs": "^0.8.5",
     "ssh2": "1.4.0",
+    "ssh2-sftp-client": "^8.1.0",
     "uuid": "^3.3.2",
     "vso-node-api": "6.0.1-preview"
   },

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 228,
+        "Minor": 251,
         "Patch": 0
     },
     "demands": [],

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.228.0",
+  "version": "0.251.0",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6683,6 +6683,11 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shell-quote": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
+      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA=="
+    },
     "shelljs": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "yargs": "^4.7.1"
   },
   "dependencies": {
-    "natives": "^1.1.6"
+    "natives": "^1.1.6",
+    "shell-quote": "^1.8.2"
   }
 }


### PR DESCRIPTION
**Description**:  In the existing code we used to form the command by concat the strings which is not safe. So as a fix added a shell-quote package to escape the input before forming the command.

**Documentation changes required:** (Y/N) <N>

**Added unit tests:** (Y/N) <N>

**Attached related issue:** (Y/N) <Y> #https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2236220

**Checklist**:
- [X] Version was bumped - please check that version of the extension, task or library has been bumped.
- [X] Checked that applied changes work as expected.
