### PR TITLE
Fix CODEQL SM03781 warning in MyApp.cs to prevent SSRF attacks

### DIFF
--- a/ServerTaskHelper/HttpRequestSampleWithoutHandler/HttpRequestSampleWithoutHandler.csproj
+++ b/ServerTaskHelper/HttpRequestSampleWithoutHandler/HttpRequestSampleWithoutHandler.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+	<PackageReference Include="Microsoft.Internal.AntiSSRF" Version="1.2.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
**Description**: 
Fixing security warning about SSRF vulnerability in sample project code in ServerHelperTask project

**Documentation changes required:** 
No

**Added unit tests:** 
No

**Attached related issue:** (Y/N) 
There is no github issue but this is done according to Liquid issue.
https://liquid.microsoft.com/codeql/issues/779ffab1-5ffb-4061-b0b9-822e550fbdf4
And WI link:
https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2277398

**Checklist**:
- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
