### PR TITLE
Fixing multiple binding issue in IISWebAppManagementOnMachineGroupV0

### DIFF
--- a/TaskModules/powershell/TaskModuleIISManageUtility/TaskModuleIISManageUtility.psd1
+++ b/TaskModules/powershell/TaskModuleIISManageUtility/TaskModuleIISManageUtility.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'TaskModuleIISManageUtility.psm1'
-    ModuleVersion = '0.1.8'
+    ModuleVersion = '0.1.9'
     GUID = '61fa1dac-d205-4cc7-a24f-502a8f461576'
     Author = 'Microsoft'
     CompanyName = 'Microsoft'


### PR DESCRIPTION
**Description**: In the IISWebAppManagementOnMachineGroupV0 task, we encountered a failure when attempting to add multiple SSL bindings on an agent running Windows Server 2022.
The issue was due to a hardcoded value in the code, which prevented the task from retrieving the correct configuration for this OS version.We resolved the issue by updating the code to fetch the required value dynamically. 

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2275871

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
