### PR TITLE
Resolve high vulnerabilities by bumping artifacts-common package to v2.256.0

### DIFF
--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
@@ -9,7 +9,7 @@
         "@azure/msal-node": "^2.7.0",
         "azure-devops-node-api": "14.1.0",
         "azure-pipelines-task-lib": "^4.13.0",
-        "azure-pipelines-tasks-artifacts-common": "2.230.0"
+        "azure-pipelines-tasks-artifacts-common": "2.256.0"
       }
     },
     "node_modules/@azure/msal-common": {
@@ -116,48 +116,28 @@
       }
     },
     "node_modules/azure-pipelines-tasks-artifacts-common": {
-      "version": "2.230.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-artifacts-common/-/azure-pipelines-tasks-artifacts-common-2.230.0.tgz",
-      "integrity": "sha1-auvD4xclbRvsWARm36mev2tKJlQ=",
+      "version": "2.256.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-artifacts-common/-/azure-pipelines-tasks-artifacts-common-2.256.0.tgz",
+      "integrity": "sha1-xXPpdL+nOa+4MS/NOk39/N0tPgo=",
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "8.0.0",
         "@types/mocha": "^5.2.6",
         "@types/node": "^16.11.39",
-        "azure-devops-node-api": "12.0.0",
-        "azure-pipelines-task-lib": "^4.2.0",
+        "azure-devops-node-api": "^14.0.2",
+        "azure-pipelines-task-lib": "^4.13.0",
         "fs-extra": "8.1.0",
-        "semver": "6.3.0"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-artifacts-common/node_modules/azure-devops-node-api": {
-      "version": "12.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-12.0.0.tgz",
-      "integrity": "sha1-OLmJL4jobaRiRiGEEZIJI9jdalI=",
-      "license": "MIT",
-      "dependencies": {
-        "tunnel": "0.0.6",
-        "typed-rest-client": "^1.8.4"
+        "node-fetch": "^2.7.0",
+        "semver": "^6.3.1"
       }
     },
     "node_modules/azure-pipelines-tasks-artifacts-common/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+      "version": "6.3.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-artifacts-common/node_modules/typed-rest-client": {
-      "version": "1.8.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
-      "integrity": "sha1-aQbwLjyR6NhRV58lWr8P1ggAoE0=",
-      "license": "MIT",
-      "dependencies": {
-        "qs": "^6.9.1",
-        "tunnel": "0.0.6",
-        "underscore": "^1.12.1"
       }
     },
     "node_modules/balanced-match": {
@@ -678,6 +658,26 @@
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha1-0PD6bj4twdJ+/NitmdVQvalNGH0=",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/nodejs-file-downloader": {
       "version": "4.13.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
@@ -922,6 +922,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "license": "MIT"
+    },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -984,6 +990,22 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/wrappy": {

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
@@ -5,6 +5,6 @@
     "@azure/msal-node": "^2.7.0",
     "azure-devops-node-api": "14.1.0",
     "azure-pipelines-task-lib": "^4.13.0",
-    "azure-pipelines-tasks-artifacts-common": "2.230.0"
+    "azure-pipelines-tasks-artifacts-common": "2.256.0"
   }
 }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
@@ -13,7 +13,7 @@
   "demands": [],
   "version": {
     "Major": 15,
-    "Minor": 254,
+    "Minor": 261,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
@@ -10,7 +10,7 @@
         "artifact-engine": "^1.5.0",
         "azure-devops-node-api": "14.1.0",
         "azure-pipelines-task-lib": "^4.13.0",
-        "azure-pipelines-tasks-artifacts-common": "2.230.0"
+        "azure-pipelines-tasks-artifacts-common": "2.256.0"
       },
       "devDependencies": {
         "typescript": "^4.5"
@@ -153,57 +153,28 @@
       }
     },
     "node_modules/azure-pipelines-tasks-artifacts-common": {
-      "version": "2.230.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-artifacts-common/-/azure-pipelines-tasks-artifacts-common-2.230.0.tgz",
-      "integrity": "sha1-auvD4xclbRvsWARm36mev2tKJlQ=",
+      "version": "2.256.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-artifacts-common/-/azure-pipelines-tasks-artifacts-common-2.256.0.tgz",
+      "integrity": "sha1-xXPpdL+nOa+4MS/NOk39/N0tPgo=",
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "8.0.0",
         "@types/mocha": "^5.2.6",
         "@types/node": "^16.11.39",
-        "azure-devops-node-api": "12.0.0",
-        "azure-pipelines-task-lib": "^4.2.0",
+        "azure-devops-node-api": "^14.0.2",
+        "azure-pipelines-task-lib": "^4.13.0",
         "fs-extra": "8.1.0",
-        "semver": "6.3.0"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-artifacts-common/node_modules/azure-devops-node-api": {
-      "version": "12.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-12.0.0.tgz",
-      "integrity": "sha1-OLmJL4jobaRiRiGEEZIJI9jdalI=",
-      "license": "MIT",
-      "dependencies": {
-        "tunnel": "0.0.6",
-        "typed-rest-client": "^1.8.4"
+        "node-fetch": "^2.7.0",
+        "semver": "^6.3.1"
       }
     },
     "node_modules/azure-pipelines-tasks-artifacts-common/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+      "version": "6.3.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-artifacts-common/node_modules/tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-artifacts-common/node_modules/typed-rest-client": {
-      "version": "1.8.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
-      "integrity": "sha1-aQbwLjyR6NhRV58lWr8P1ggAoE0=",
-      "license": "MIT",
-      "dependencies": {
-        "qs": "^6.9.1",
-        "tunnel": "0.0.6",
-        "underscore": "^1.12.1"
       }
     },
     "node_modules/balanced-match": {
@@ -748,6 +719,26 @@
       "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha1-0PD6bj4twdJ+/NitmdVQvalNGH0=",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/nodejs-file-downloader": {
       "version": "4.13.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
@@ -1001,6 +992,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "license": "MIT"
+    },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -1099,6 +1096,22 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/wordwrap": {

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
@@ -6,7 +6,7 @@
     "artifact-engine": "^1.5.0",
     "azure-devops-node-api": "14.1.0",
     "azure-pipelines-task-lib": "^4.13.0",
-    "azure-pipelines-tasks-artifacts-common": "2.230.0"
+    "azure-pipelines-tasks-artifacts-common": "2.256.0"
   },
   "devDependencies": {
     "typescript": "^4.5"

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
@@ -8,7 +8,7 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 15,
-    "Minor": 254,
+    "Minor": 261,
     "Patch": 0
   },
   "demands": [],

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.loc.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.loc.json
@@ -9,7 +9,7 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 15,
-    "Minor": 254,
+    "Minor": 261,
     "Patch": 0
   },
   "demands": [],

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 ﻿﻿{
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "15.254.0",
+  "version": "15.261.0",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",
@@ -29,9 +29,9 @@
       "path": "images/screen3.png"
     }
   ],
-  "content": { 
-      "details": { 
-        "path": "readme.md" 
+  "content": {
+      "details": {
+        "path": "readme.md"
       },
       "license": {
         "path": "mp_terms.md"
@@ -67,7 +67,7 @@
   "branding": {
       "color": "#5C2D91",
       "theme": "dark"
-  },  
+  },
   "contributions": [
     {
       "id": "externalTFSBuild-release-artifact-type",
@@ -242,7 +242,7 @@
       "properties": {
         "name": "Tasks/DownloadExternalBuildArtifacts"
         }
-    }, 
+    },
     {
         "id": "externalTFVC-release-artifact-type",
         "description": "External TFS Version Control",
@@ -386,7 +386,7 @@
                 "source": "artifactItems"
             }
         }
-    },      
+    },
     {
       "id": "externalTfvc-task",
       "type": "ms.vss-distributed-task.task",
@@ -396,7 +396,7 @@
       "properties": {
         "name": "Tasks/DownloadArtifactsTfsVersionControl"
         }
-    },      
+    },
     {
       "id": "externalTfGit-release-artifact-type",
       "description": "External TFS Git",
@@ -574,7 +574,7 @@
       "properties": {
         "name": "Tasks/DownloadArtifactsTfsGit"
       }
-    },    
+    },
     {
       "id": "externalTFSXamlBuild-release-artifact-type",
       "description": "External TFS XAML Build Artifact",


### PR DESCRIPTION
**Description**: This PR updates the dependencies in artifacts-common for DownloadExternalBuildArtifacts and DownloadArtifactsTfsGit tasks in ExternalTfs extension to address high vulnerabilities

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [ ] Checked that applied changes work as expected.
