### PR TITLE
Recover 'Copy Stage variable to Release variable' extension #2

### DIFF
--- a/Extensions/CopyStageVariableToReleaseVariable/Src/Tasks/CopyAgentJobVariableToReleaseVariable/task.json
+++ b/Extensions/CopyStageVariableToReleaseVariable/Src/Tasks/CopyAgentJobVariableToReleaseVariable/task.json
@@ -1,5 +1,5 @@
 {
-    "id": "493A03D9-7E56-4DB8-87F3-68C94C075038",
+    "id": "ea576333-29e1-4161-9ee7-9e1e937824c9",
     "name": "CopyAgentJobVariableToReleaseVariable",
     "friendlyName": "Copy agent job variable to release",
     "description": "Assigns the value of a agent job variable to a new release variable",
@@ -14,7 +14,7 @@
     ],
     "version": {
         "Major": 0,
-        "Minor": 260,
+        "Minor": 262,
         "Patch": 0
     },
     "instanceNameFormat": "Create a release variable ",

--- a/Extensions/CopyStageVariableToReleaseVariable/Src/vss-extension.json
+++ b/Extensions/CopyStageVariableToReleaseVariable/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-copystagevariabletoreleasevariable",
   "name": "Copy Stage variable to Release variable",
   "publisher": "ms-vscs-rm",
-  "version": "1.262.3",
+  "version": "1.262.4",
   "public": true,
   "description": "Assigns the value of a Agent/Agentless job variable to a new release variable",
   "categories": [

--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ While updating an extension or its tasks it is important to ensure that:
 
     - For any changed task, we need to update the version number for both, the changed task (in `task.json` file) and extension itself (in `vss-extension.json` file).
     - If only logic around the extension is changed, update the version number for extension only (in `vss-extension.json` file).
-    - The version number consist of three parts (major, minor, patch). Be aware that minor number should reflect [the current sprint](https://whatsprintis.it/) of Azure DevOps team in which change is being made.
+    - The version number consist of three parts (major, minor, patch). Be aware that minor number should reflect [the current sprint](https://whatsprintis.it/) of Azure DevOps team in which change is being made. Patch number starts from 0 for the initial version, and increments for every change.
 
 2. The affected extension is published to [Marketplace](https://marketplace.visualstudio.com/azuredevops/).
    It is not enough to only merge change to `master` branch, without properly testing the current version and publishing it to all customers.
+
+3. Delete your branch after pull request is merged.
 
 ## Contact Information
 


### PR DESCRIPTION
**Description**: 'Copy Stage variable to Release variable' extension is not available in Marketplace because task id for agent job is mistakenly reused by another publisher. This is follow-up work from [the PR](https://github.com/microsoft/azure-pipelines-extensions/pull/1285) that changed task id for agentless job as well.

**Documentation changes required:** N
**Added unit tests:** N

**Attached related issue:** ADO#2311744

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
