### PR TITLE
Update AppCmdOnTargetMachines.ps1

### DIFF
--- a/TaskModules/powershell/TaskModuleIISManageUtility/AppCmdOnTargetMachines.ps1
+++ b/TaskModules/powershell/TaskModuleIISManageUtility/AppCmdOnTargetMachines.ps1
@@ -184,8 +184,8 @@ function Add-SslCert
 
         $result = Invoke-VstsTool -Filename "netsh" -Arguments $showCertCmd
         $bindingPattern = "Hostname:port\s*:\s*([^:\s]+):(\d+)"
-        $certHashPattern = "Certificate Hash\s*:\s*([a-fA-F0-9]+)"
-        
+        $certHashPattern = "(Certificate Hash|Zertifikathash)\s*:\s*([a-fA-F0-9]+)"
+
         $resultText = $result -join "`n"
         
         if($resultText -match $bindingPattern)
@@ -896,4 +896,5 @@ function Invoke-Main
 
     Invoke-AdditionalCommand -additionalCommands $AppCmdCommands
     Write-Verbose "Exiting Execute-Main function"
+
 }


### PR DESCRIPTION
#1278 Would solve this painful bug for us. Only the solution for German Servers, but we don't want to wait.

**Description**:  Adjusted the regex pattern to also recognize the German output of netsh (Zertifikathash) in addition to the English Certificate Hash.
This ensures the SSL certificate binding check works correctly on German Windows servers.

**Documentation changes required:** N

**Added unit tests:** N

Attached related issue: Y
Linked to issue #1278. (https://github.com/microsoft/azure-pipelines-extensions/issues/1278)

**Checklist**:
- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.
- [ ] Checked that applied changes work as expected.
