### PR TITLE
Add api token support to bitbucket auth

### DIFF
--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
@@ -8,6 +8,8 @@ var shell = require("shelljs");
 var scw = require('./sourcecontrolwrapper.js');
 var https = require("https");
 
+var BITBUCKET_API_TOKEN_AUTH_USERNAME = 'x-bitbucket-api-token-auth';
+
 var repositoryId = tl.getInput("definition");
 var branch = tl.getInput("branch");
 var commitId = tl.getInput("version");
@@ -62,8 +64,8 @@ https.request(options, function (rs) {
         // encodes projects and repo names with spaces
         var repoUrl = url.parse(remoteUrl);
         if (bitbucketEndpoint.Token) {
-            // For token authentication, use the token as password with 'x-bitbucket-api-token-auth' as username
-            repoUrl.auth = 'x-bitbucket-api-token-auth:' + bitbucketEndpoint.Token;
+            // For token authentication, use the token as password with API token auth username
+            repoUrl.auth = BITBUCKET_API_TOKEN_AUTH_USERNAME + ':' + bitbucketEndpoint.Token;
         } else if (bitbucketEndpoint.Username && bitbucketEndpoint.Password) {
             repoUrl.auth = bitbucketEndpoint.Username + ':' + bitbucketEndpoint.Password;
         }
@@ -83,7 +85,7 @@ https.request(options, function (rs) {
             debugOutput: this.debugOutput
         };
         if (bitbucketEndpoint.Token) {
-            sch.username = 'x-bitbucket-api-token-auth';
+            sch.username = BITBUCKET_API_TOKEN_AUTH_USERNAME;
             sch.password = bitbucketEndpoint.Token;
         } else {
             sch.username = bitbucketEndpoint.Username;

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
@@ -123,7 +123,7 @@ function getEndpointDetails(inputFieldName) {
             "Token": token,
             "Username": username
         };
-    } else if (scheme === "usernamepassword") {
+    } else {
         var hostUsername = getAuthParameter(bitbucketEndpoint, 'username');
         var hostPassword = getAuthParameter(bitbucketEndpoint, 'password');
         tl.debug('hostUsername: ' + hostUsername);
@@ -132,8 +132,6 @@ function getEndpointDetails(inputFieldName) {
             "Username": hostUsername,
             "Password": hostPassword
         };
-    } else {
-        throw new Error("The authorization scheme " + auth.scheme + " is not supported for a bitbucket endpoint. Please use either 'usernamepassword' or 'token'.");
     }
 }
 

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 15,
     "Minor": 264,
-    "Patch": 1
+    "Patch": 0
   },
   "minimumAgentVersion": "1.99.0",
   "instanceNameFormat": "Download Artifacts - Bitbucket",

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
@@ -13,7 +13,7 @@
   "demands": [],
   "version": {
     "Major": 15,
-    "Minor": 263,
+    "Minor": 264,
     "Patch": 1
   },
   "minimumAgentVersion": "1.99.0",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.264.1",
+  "version": "15.264.0",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.263.1",
+  "version": "15.264.1",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",


### PR DESCRIPTION
**Description**: Add support of bitbucket api token authentication 

**Documentation changes required:** Y

**Added unit tests:** N

**Attached related issue:** [Bug 2315852](https://mseng.visualstudio.com/AzureDevOps/_workitems/edit/2315852): DownloadArtifactsBitbucket pipeline task doesn't support Bitbucket API Tokens

**Checklist**:
- [X] Version was bumped - please check that version of the extension, task or library has been bumped.
- [X] Checked that applied changes work as expected.
