### PR TITLE
Fix qs vulnerability across extensions and fix build error for missing files

### DIFF
--- a/Extensions/ArtifactEngine/package-lock.json
+++ b/Extensions/ArtifactEngine/package-lock.json
@@ -75,7 +75,6 @@
       "integrity": "sha1-VdrYCNW/NEWhCO78iOo/3wNHSaQ=",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -467,9 +466,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
+      "version": "3.14.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha1-d0hc4d1/M8Bh/RsW7OojtV/LBLA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -902,7 +901,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -2281,9 +2279,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI=",
+      "version": "4.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha1-hUwpJGdwW2mUduGi3swMijRYgGs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2350,9 +2348,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
+      "version": "4.17.23",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha1-8ROwN4OGEDvk9okziMc9C95/LFo=",
       "dev": true,
       "license": "MIT"
     },
@@ -3369,9 +3367,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha1-xj+kBoDSxclBQSoOiZyJr2DAqTA=",
+      "version": "6.14.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha1-pB2FudOQLzHSeGF5BQYpSIGHEVk=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
@@ -1491,9 +1491,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha1-xj+kBoDSxclBQSoOiZyJr2DAqTA=",
+      "version": "6.14.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha1-pB2FudOQLzHSeGF5BQYpSIGHEVk=",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
@@ -13,8 +13,8 @@
   "demands": [],
   "version": {
     "Major": 16,
-    "Minor": 267,
-    "Patch": 1
+    "Minor": 269,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "Download Artifacts - External TFS Git",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/package-lock.json
@@ -1,111 +1,170 @@
 {
   "name": "DownloadArtifactsTfsVersionControl",
+  "lockfileVersion": 3,
   "requires": true,
-  "lockfileVersion": 1,
-  "dependencies": {
-    "@isaacs/balanced-match": {
+  "packages": {
+    "": {
+      "name": "DownloadArtifactsTfsVersionControl",
+      "dependencies": {
+        "@types/shelljs": "^0.8.17",
+        "azure-devops-node-api": "11.2.0",
+        "azure-pipelines-task-lib": "^5.2.3",
+        "shelljs": "^0.10.0"
+      }
+    },
+    "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha1-MIHa28NGBmG3UedZHX+upd853Sk="
+      "integrity": "sha1-MIHa28NGBmG3UedZHX+upd853Sk=",
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
-    "@isaacs/brace-expansion": {
+    "node_modules/@isaacs/brace-expansion": {
       "version": "5.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
       "integrity": "sha1-Sz2rq32OdaQpQUqWvWe/TB0T4PM=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
-    "@isaacs/cliui": {
+    "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha1-s3Znt7wYHBaHgiWbq0JHT79StVA=",
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
         "strip-ansi": "^7.0.1",
         "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
         "wrap-ansi": "^8.1.0",
         "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
-    "@nodelib/fs.scandir": {
+    "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "@nodelib/fs.stat": {
+    "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos="
+      "integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
-    "@nodelib/fs.walk": {
+    "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "@types/node": {
+    "node_modules/@types/node": {
       "version": "25.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-25.0.2.tgz",
       "integrity": "sha1-QR+d1ssr9e5GrtcZmp+FymsGi04=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "undici-types": "~7.16.0"
       }
     },
-    "@types/shelljs": {
+    "node_modules/@types/shelljs": {
       "version": "0.8.17",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/shelljs/-/shelljs-0.8.17.tgz",
       "integrity": "sha1-iyG493AVryY6fj5Qk/8rdzIORdI=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "@types/node": "*",
         "glob": "^11.0.3"
       }
     },
-    "adm-zip": {
+    "node_modules/adm-zip": {
       "version": "0.5.16",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk="
+      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
     },
-    "agent-base": {
+    "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
-    "ansi-regex": {
+    "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha1-YCFu6kZNhkWXzigyAAc4oFiWUME="
+      "integrity": "sha1-YCFu6kZNhkWXzigyAAc4oFiWUME=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
     },
-    "ansi-styles": {
+    "node_modules/ansi-styles": {
       "version": "6.2.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha1-wETV3MUhoHZBNHJZehrLHxA8QEE="
+      "integrity": "sha1-wETV3MUhoHZBNHJZehrLHxA8QEE=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
     },
-    "azure-devops-node-api": {
+    "node_modules/azure-devops-node-api": {
       "version": "11.2.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-11.2.0.tgz",
       "integrity": "sha1-vwTtvvYDExF6BQdBXu1HkKQgrWs=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "tunnel": "0.0.6",
         "typed-rest-client": "^1.8.4"
       }
     },
-    "azure-pipelines-task-lib": {
+    "node_modules/azure-pipelines-task-lib": {
       "version": "5.2.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.3.tgz",
       "integrity": "sha1-vcoulfL9GkbPLlXy/AmdOAOxT/s=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "adm-zip": "^0.5.10",
         "minimatch": "3.0.5",
         "nodejs-file-downloader": "^4.11.1",
@@ -113,137 +172,194 @@
         "semver": "^5.7.2",
         "shelljs": "^0.10.0",
         "uuid": "^3.0.1"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "3.0.5",
-          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.0.5.tgz",
-          "integrity": "sha1-TajxKQ7g8PjoPWDKafjxNAaGBKM=",
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        }
       }
     },
-    "balanced-match": {
+    "node_modules/azure-pipelines-task-lib/node_modules/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha1-TajxKQ7g8PjoPWDKafjxNAaGBKM=",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
+      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
+      "license": "MIT"
     },
-    "brace-expansion": {
+    "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "braces": {
+    "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/braces/-/braces-3.0.3.tgz",
       "integrity": "sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "call-bind-apply-helpers": {
+    "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha1-S1QowiK+mF15w9gmV0edvgtZstY=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "call-bound": {
+    "node_modules/call-bound": {
       "version": "1.0.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha1-I43pNdKippKSjFOMfM+pEGf9Bio=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "color-convert": {
+    "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
       }
     },
-    "color-name": {
+    "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+      "license": "MIT"
     },
-    "concat-map": {
+    "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "license": "MIT"
     },
-    "cross-spawn": {
+    "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "debug": {
+    "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.4.3.tgz",
       "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
-    "dunder-proto": {
+    "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha1-165mfh3INIL4tw/Q9u78UNow9Yo=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
         "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "eastasianwidth": {
+    "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s="
+      "integrity": "sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s=",
+      "license": "MIT"
     },
-    "emoji-regex": {
+    "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha1-hAyIA7DYBH9P8M+WMXazLU7z7XI="
+      "integrity": "sha1-hAyIA7DYBH9P8M+WMXazLU7z7XI=",
+      "license": "MIT"
     },
-    "es-define-property": {
+    "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha1-mD6y+aZyTpMD9hrd8BHHLgngsPo="
+      "integrity": "sha1-mD6y+aZyTpMD9hrd8BHHLgngsPo=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
-    "es-errors": {
+    "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8="
+      "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
-    "es-object-atoms": {
+    "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha1-HE8sSDcydZfOadLKGQp/3RcjOME=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "execa": {
+    "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/execa/-/execa-5.1.1.tgz",
       "integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.0",
         "human-signals": "^2.1.0",
@@ -254,66 +370,107 @@
         "signal-exit": "^3.0.3",
         "strip-final-newline": "^2.0.0"
       },
-      "dependencies": {
-        "signal-exit": {
-          "version": "3.0.7",
-          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
-          "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk="
-        }
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "fast-glob": {
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
+      "license": "ISC"
+    },
+    "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha1-0G1YXOjbqQoWsFBcVDw8z7OuuBg=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
         "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
       }
     },
-    "fastq": {
+    "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha1-1Q6rqAPIhGqIPBZJKCHrzSzaVfU=",
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "reusify": "^1.0.4"
       }
     },
-    "fill-range": {
+    "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "follow-redirects": {
+    "node_modules/follow-redirects": {
       "version": "1.15.11",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha1-d31z1yqS+OxNLkEOtHNSpWuOg0A="
+      "integrity": "sha1-d31z1yqS+OxNLkEOtHNSpWuOg0A=",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
-    "foreground-child": {
+    "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha1-Mujp7Rtoo0l777msK2rfkqY4V28=",
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "function-bind": {
+    "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw="
+      "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "get-intrinsic": {
+    "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha1-dD8OO2lkqTpUke0b/6rgVNf5jQE=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -324,535 +481,882 @@
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
         "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "get-proto": {
+    "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha1-FQs/J0OGnvPoUewMSdFbHRTQDuE=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "get-stream": {
+    "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c="
+      "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
-    "glob": {
+    "node_modules/glob": {
       "version": "11.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-11.1.0.tgz",
       "integrity": "sha1-T4JlduTrmcfa04N5PS+fCPZ+UKY=",
-      "requires": {
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
         "foreground-child": "^3.3.1",
         "jackspeak": "^4.1.1",
         "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
         "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "glob-parent": {
+    "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "gopd": {
+    "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha1-ifVrghe9vIgCvSmd9tfxCB1+UaE="
+      "integrity": "sha1-ifVrghe9vIgCvSmd9tfxCB1+UaE=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "has-symbols": {
+    "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha1-/JxqeDoISVHQuXH+EBjegTcHozg="
+      "integrity": "sha1-/JxqeDoISVHQuXH+EBjegTcHozg=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "hasown": {
+    "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "https-proxy-agent": {
+    "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "agent-base": "6",
         "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "human-signals": {
+    "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA="
+      "integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
     },
-    "is-extglob": {
+    "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "is-fullwidth-code-point": {
+    "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
+      "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "is-glob": {
+    "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "is-number": {
+    "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
+      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
     },
-    "is-stream": {
+    "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc="
+      "integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
-    "isexe": {
+    "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "license": "ISC"
     },
-    "jackspeak": {
+    "node_modules/jackspeak": {
       "version": "4.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jackspeak/-/jackspeak-4.1.1.tgz",
       "integrity": "sha1-lodgMPRQUCBH/H6Mf8+M6BJOQ64=",
-      "requires": {
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
         "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "lru-cache": {
+    "node_modules/lru-cache": {
       "version": "11.2.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lru-cache/-/lru-cache-11.2.4.tgz",
-      "integrity": "sha1-7LUj67Dm9Ng3yAetGrrqjgYZdw0="
+      "integrity": "sha1-7LUj67Dm9Ng3yAetGrrqjgYZdw0=",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
-    "math-intrinsics": {
+    "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha1-oN10voHiqlwvJ+Zc4oNgXuTit/k="
+      "integrity": "sha1-oN10voHiqlwvJ+Zc4oNgXuTit/k=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
-    "merge-stream": {
+    "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A="
+      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
+      "license": "MIT"
     },
-    "merge2": {
+    "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4="
+      "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
-    "micromatch": {
+    "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha1-1m+hjzpHB2eJMgubGvMr2G2fogI=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
-    "mime-db": {
+    "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A="
+      "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "mime-types": {
+    "node_modules/mime-types": {
       "version": "2.1.35",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "mimic-fn": {
+    "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs="
+      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
-    "minimatch": {
+    "node_modules/minimatch": {
       "version": "10.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-10.1.1.tgz",
       "integrity": "sha1-5uYbmwwdyrEWtafRRY6LaunnOlU=",
-      "requires": {
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
         "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "minipass": {
+    "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha1-k6libOXl5mvU24aEnnUV6SNApwc="
+      "integrity": "sha1-k6libOXl5mvU24aEnnUV6SNApwc=",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
     },
-    "ms": {
+    "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
     },
-    "nodejs-file-downloader": {
+    "node_modules/nodejs-file-downloader": {
       "version": "4.13.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
       "integrity": "sha1-2ofDAIHeX/TouGQGLJjN7APmatA=",
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "follow-redirects": "^1.15.6",
         "https-proxy-agent": "^5.0.0",
         "mime-types": "^2.1.27",
         "sanitize-filename": "^1.6.3"
       }
     },
-    "npm-run-path": {
+    "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "object-inspect": {
+    "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha1-g3UmXiG8IND6WCwi4bE0hdbgAhM="
+      "integrity": "sha1-g3UmXiG8IND6WCwi4bE0hdbgAhM=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "onetime": {
+    "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "package-json-from-dist": {
+    "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha1-TxRxoBCCeob5TP2bByfjbSZ95QU="
+      "integrity": "sha1-TxRxoBCCeob5TP2bByfjbSZ95QU=",
+      "license": "BlueOak-1.0.0"
     },
-    "path-key": {
+    "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U="
+      "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "path-scurry": {
+    "node_modules/path-scurry": {
       "version": "2.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-scurry/-/path-scurry-2.0.1.tgz",
       "integrity": "sha1-S2VyN2z9i4EfypzR9cJLPLrA/hA=",
-      "requires": {
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
         "lru-cache": "^11.0.0",
         "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "picomatch": {
+    "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI="
-    },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-    },
-    "qs": {
-      "version": "6.14.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha1-xj+kBoDSxclBQSoOiZyJr2DAqTA=",
-      "requires": {
-        "side-channel": "^1.1.0"
+      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "queue-microtask": {
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha1-pB2FudOQLzHSeGF5BQYpSIGHEVk=",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM="
+      "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
-    "reusify": {
+    "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha1-D+E7lSLhRz9RtVjueW4I8R+bSJ8="
+      "integrity": "sha1-D+E7lSLhRz9RtVjueW4I8R+bSJ8=",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
     },
-    "run-parallel": {
+    "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
-      "requires": {
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
         "queue-microtask": "^1.2.2"
       }
     },
-    "sanitize-filename": {
+    "node_modules/sanitize-filename": {
       "version": "1.6.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
       "integrity": "sha1-dV69dSBFkxl34wsgJdNA18kJA3g=",
-      "requires": {
+      "license": "WTFPL OR ISC",
+      "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"
       }
     },
-    "semver": {
+    "node_modules/semver": {
       "version": "5.7.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg="
+      "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
     },
-    "shebang-command": {
+    "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "shebang-regex": {
+    "node_modules/shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI="
+      "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "shelljs": {
+    "node_modules/shelljs": {
       "version": "0.10.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.10.0.tgz",
       "integrity": "sha1-47uumbDz8MxdzgW0ajRvriCQ6IM=",
-      "requires": {
+      "license": "BSD-3-Clause",
+      "dependencies": {
         "execa": "^5.1.1",
         "fast-glob": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
-    "side-channel": {
+    "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha1-w/z/nE2pMnhIczNeyXZfqU/2a8k=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
         "side-channel-list": "^1.0.0",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "side-channel-list": {
+    "node_modules/side-channel-list": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha1-EMtZhCYxFdO3oOM2WR4pCoMK+K0=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "side-channel-map": {
+    "node_modules/side-channel-map": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha1-1rtrN5Asb+9RdOX1M/q0xzKib0I=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.5",
         "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "side-channel-weakmap": {
+    "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha1-Ed2hnVNo5Azp7CvcH7DsvAeQ7Oo=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.5",
         "object-inspect": "^1.13.3",
         "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "signal-exit": {
+    "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ="
+      "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
-    "string-width": {
+    "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha1-FPja7G2B5yIdKjV+Zoyrc728p5Q=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
         "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "string-width-cjs": {
-      "version": "npm:string-width@4.2.3",
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
-      "requires": {
+      "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
       }
     },
-    "strip-ansi": {
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
       "version": "7.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha1-Eyh1q95njH6o1pFTPy5+Irt0Tbo=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "strip-ansi-cjs": {
-      "version": "npm:strip-ansi@6.0.1",
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
-      "requires": {
-        "ansi-regex": "^5.0.1"
-      },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
-        }
+        "ansi-regex": "^5.0.1"
       }
     },
-    "strip-final-newline": {
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0="
+      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
-    "to-regex-range": {
+    "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
-    "truncate-utf8-bytes": {
+    "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
       "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
-      "requires": {
+      "license": "WTFPL",
+      "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
     },
-    "tunnel": {
+    "node_modules/tunnel": {
       "version": "0.0.6",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw="
+      "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
     },
-    "typed-rest-client": {
+    "node_modules/typed-rest-client": {
       "version": "1.8.11",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
       "integrity": "sha1-aQbwLjyR6NhRV58lWr8P1ggAoE0=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "qs": "^6.9.1",
         "tunnel": "0.0.6",
         "underscore": "^1.12.1"
       }
     },
-    "underscore": {
+    "node_modules/underscore": {
       "version": "1.13.7",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha1-lw4zljr5p92iKPF+voOZ5fvmOhA="
+      "integrity": "sha1-lw4zljr5p92iKPF+voOZ5fvmOhA=",
+      "license": "MIT"
     },
-    "undici-types": {
+    "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha1-/8zf82rqSITL/OmnUKBYAiT1ikY="
+      "integrity": "sha1-/8zf82rqSITL/OmnUKBYAiT1ikY=",
+      "license": "MIT"
     },
-    "utf8-byte-length": {
+    "node_modules/utf8-byte-length": {
       "version": "1.0.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
-      "integrity": "sha1-+fY5ENFVNu4rLV3UZlOJcV6sXB4="
+      "integrity": "sha1-+fY5ENFVNu4rLV3UZlOJcV6sXB4=",
+      "license": "(WTFPL OR MIT)"
     },
-    "uuid": {
+    "node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
+      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
     },
-    "which": {
+    "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/which/-/which-2.0.2.tgz",
       "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "wrap-ansi": {
+    "node_modules/wrap-ansi": {
       "version": "8.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha1-VtwiNo7lcPrOG0mBmXXZuaXq0hQ=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
         "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "wrap-ansi-cjs": {
-      "version": "npm:wrap-ansi@7.0.0",
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
-      "requires": {
+      "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
-      },
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+      "license": "MIT",
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/task.json
@@ -12,8 +12,8 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 15,
-    "Minor": 267,
-    "Patch": 1
+    "Minor": 269,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "1.99.0",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
@@ -1600,9 +1600,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha1-xj+kBoDSxclBQSoOiZyJr2DAqTA=",
+      "version": "6.14.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha1-pB2FudOQLzHSeGF5BQYpSIGHEVk=",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
@@ -8,8 +8,8 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 16,
-    "Minor": 267,
-    "Patch": 1
+    "Minor": 269,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 ﻿﻿{
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.266.0",
+  "version": "16.269.0",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5757,6 +5757,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha1-g3UmXiG8IND6WCwi4bE0hdbgAhM=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object-keys/-/object-keys-1.1.1.tgz",
@@ -6295,13 +6308,19 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha1-Ou7/yRln7241wOSI70b7KWq3aq0=",
+      "version": "6.14.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha1-pB2FudOQLzHSeGF5BQYpSIGHEVk=",
       "dev": true,
       "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
       "engines": {
         "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -7026,6 +7045,82 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha1-w/z/nE2pMnhIczNeyXZfqU/2a8k=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha1-EMtZhCYxFdO3oOM2WR4pCoMK+K0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha1-1rtrN5Asb+9RdOX1M/q0xzKib0I=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha1-Ed2hnVNo5Azp7CvcH7DsvAeQ7Oo=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {

--- a/package.js
+++ b/package.js
@@ -96,8 +96,8 @@ function copyCommonModules(currentExtnRoot, commonDeps, commonSrc) {
                 // Copy the task to the layout folder.
                 const targetPath = path.join(currentExtnRoot, "Src", "Tasks", task.name);
                 shell.mkdir('-p', targetPath);
-                shell.rm(path.join(targetPath, '*.csproj'));
-                shell.rm(path.join(targetPath, '*.md'));
+                shell.rm('-f', path.join(targetPath, '*.csproj'));
+                shell.rm('-f', path.join(targetPath, '*.md'));
                 // Path to UI contribution files
                 const uiPath = path.join(currentExtnRoot, "Src", "UIContribution");
                 // Statically link the required internal common modules.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "shell-quote": "^1.8.2"
   },
   "overrides": {
+    "qs": "6.14.1",
     "gulp-typescript": {
       "braces": "3.0.3"
     },


### PR DESCRIPTION
**Description**:
*   Updated the `qs` package from `6.5.3`/`6.14.0` to `6.14.1` to address security vulnerabilities in multiple locations:
    *   Root workspace (via `overrides` in `package.json`).
    *   `ExternalTfs` extension tasks (`DownloadArtifactsTfsVersionControl`, `DownloadArtifactsTfsGit`, `DownloadExternalBuildArtifacts`).
    *   `ArtifactEngine` extension.
*   Fixed a build error in `package.js` where `shell.rm` would fail if `*.csproj` or `*.md` files did not exist in the task directory (occurring in TypeScript-only tasks like Ansible). Added the force flag (`-f`) to these commands to ignore "file not found" errors.
*   Updated corresponding `package-lock.json` files. Note that `DownloadArtifactsTfsVersionControl/package-lock.json` has a large diff because it was upgraded to the modern lockfile v3 format.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.