### PR TITLE
Upgrade minimatch to 3.1.5 across extension packages

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha1-aly6mzH1A4hwGPV5yJ+B9hFi5iQ=",
+      "version": "3.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"

--- a/Extensions/Ansible/Src/Tasks/Ansible/package.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package.json
@@ -16,7 +16,7 @@
     "vso-node-api": "6.0.1-preview"
   },
   "overrides": {
-    "minimatch": "3.1.3"
+    "minimatch": "3.1.5"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/Extensions/ArtifactEngine/package-lock.json
+++ b/Extensions/ArtifactEngine/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "artifact-engine",
-  "version": "1.267.0",
+  "version": "1.271.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-engine",
-      "version": "1.267.0",
+      "version": "1.271.0",
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.2.3",
         "handlebars": "4.7.7",
-        "minimatch": "^3.0.5",
+        "minimatch": "3.1.5",
         "tunnel": "0.0.4"
       },
       "devDependencies": {
@@ -832,18 +832,6 @@
         "semver": "^5.7.2",
         "shelljs": "^0.10.0",
         "uuid": "^3.0.1"
-      }
-    },
-    "node_modules/azure-pipelines-task-lib/node_modules/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha1-TajxKQ7g8PjoPWDKafjxNAaGBKM=",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/balanced-match": {
@@ -2497,9 +2485,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
+      "version": "3.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -2648,6 +2636,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/mocha/node_modules/minimatch": {

--- a/Extensions/ArtifactEngine/package.json
+++ b/Extensions/ArtifactEngine/package.json
@@ -18,8 +18,11 @@
   "dependencies": {
     "azure-pipelines-task-lib": "^5.2.3",
     "handlebars": "4.7.7",
-    "minimatch": "3.1.3",
+    "minimatch": "3.1.5",
     "tunnel": "0.0.4"
+  },
+  "overrides": {
+    "minimatch": "3.1.5"
   },
   "devDependencies": {
     "@types/minimatch": "^2.0.29",

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package-lock.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package-lock.json
@@ -379,9 +379,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha1-aly6mzH1A4hwGPV5yJ+B9hFi5iQ=",
+      "version": "3.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -709,7 +709,7 @@
       "integrity": "sha1-vcoulfL9GkbPLlXy/AmdOAOxT/s=",
       "requires": {
         "adm-zip": "^0.5.10",
-        "minimatch": "3.1.3",
+        "minimatch": "3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
@@ -904,9 +904,9 @@
       "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs="
     },
     "minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha1-aly6mzH1A4hwGPV5yJ+B9hFi5iQ=",
+      "version": "3.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "requires": {
         "brace-expansion": "^1.1.7"
       }

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package.json
@@ -6,6 +6,6 @@
     "vso-node-api": "6.0.1-preview"
   },
   "overrides": {
-    "minimatch": "3.1.3"
+    "minimatch": "3.1.5"
   }
 }

--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package-lock.json
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package-lock.json
@@ -538,9 +538,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha1-aly6mzH1A4hwGPV5yJ+B9hFi5iQ=",
+      "version": "3.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"

--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package.json
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package.json
@@ -9,6 +9,6 @@
     "underscore": "1.13.4"
   },
   "overrides": {
-    "minimatch": "3.1.3"
+    "minimatch": "3.1.5"
   }
 }

--- a/Extensions/Common/lib/vsts-task-lib/package-lock.json
+++ b/Extensions/Common/lib/vsts-task-lib/package-lock.json
@@ -17,7 +17,7 @@
         "gulp": "^3.9.0",
         "gulp-mocha": "2.0.0",
         "gulp-tsc": "^0.10.1",
-        "minimatch": "3.1.3",
+        "minimatch": "3.1.5",
         "mocha": "^11.7.5"
       }
     },
@@ -3114,9 +3114,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha1-aly6mzH1A4hwGPV5yJ+B9hFi5iQ=",
+      "version": "3.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/Extensions/Common/lib/vsts-task-lib/package.json
+++ b/Extensions/Common/lib/vsts-task-lib/package.json
@@ -33,7 +33,7 @@
     "gulp": "^3.9.0",
     "gulp-mocha": "2.0.0",
     "gulp-tsc": "^0.10.1",
-    "minimatch": "3.1.3",
+    "minimatch": "3.1.5",
     "mocha": "^11.7.5"
   },
   "readme": "# Team Services DevOps Task SDK\n\nLibraries for writing Team Services and TFS build and deployment tasks\n\n## Node Task Lib\nLibrary for writing tasks with the node handler\n\n## Contributing\n\n### Node\n\nOnce:\n```bash\n$ cd node\n$ npm install\n$ sudo npm install gulp -g\n```\n\nBuild and test:\n```bash\n$ cd node\n$ gulp\n```\n\n### Powershell\n\nComing soon\n",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
@@ -1252,9 +1252,9 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha1-aly6mzH1A4hwGPV5yJ+B9hFi5iQ=",
+      "version": "3.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
@@ -8,6 +8,6 @@
     "azure-pipelines-tasks-azure-arm-rest": "^3.267.0"
   },
   "overrides": {
-    "minimatch": "3.1.3"
+    "minimatch": "3.1.5"
   }
 }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/package-lock.json
@@ -153,18 +153,6 @@
         "uuid": "^3.0.1"
       }
     },
-    "node_modules/azure-pipelines-task-lib/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha1-aly6mzH1A4hwGPV5yJ+B9hFi5iQ=",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -528,18 +516,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha1-aly6mzH1A4hwGPV5yJ+B9hFi5iQ=",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/gopd/-/gopd-1.2.0.tgz",
@@ -744,6 +720,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/minipass": {

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/package.json
@@ -8,6 +8,6 @@
     "shelljs": "^0.10.0"
   },
   "overrides": {
-    "minimatch": "3.1.3"
+    "minimatch": "3.1.5"
   }
 }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
@@ -1386,9 +1386,9 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha1-aly6mzH1A4hwGPV5yJ+B9hFi5iQ=",
+      "version": "3.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
@@ -12,6 +12,6 @@
     "typescript": "5.1.6"
   },
   "overrides": {
-    "minimatch": "3.1.3"
+    "minimatch": "3.1.5"
   }
 }

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package-lock.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package-lock.json
@@ -530,9 +530,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha1-aly6mzH1A4hwGPV5yJ+B9hFi5iQ=",
+      "version": "3.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package.json
@@ -7,6 +7,6 @@
     "underscore": "^1.13.4"
   },
   "overrides": {
-    "minimatch": "3.1.3"
+    "minimatch": "3.1.5"
   }
 }


### PR DESCRIPTION
**Description**: Updated minimatch from 3.1.3 to 3.1.5 across relevant extension [package.json](vscode-file://vscode-app/c:/Users/razvanmanole/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) files (including overrides where applicable), regenerated all source [package-lock.json](vscode-file://vscode-app/c:/Users/razvanmanole/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) files, and validated compatibility by running a full gulp build successfully. This change is focused on reducing vulnerability exposure from older minimatch versions while keeping dependency resolution consistent across the repo.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Version was bumped in prev PR when changing to 3.1.3 - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
