### PR TITLE
Remediate CVE-2026-27601 by upgrading/overriding underscore to 1.13.8

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
@@ -901,9 +901,9 @@
       "license": "MIT"
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha1-lw4zljr5p92iKPF+voOZ5fvmOhA=",
+      "version": "1.13.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha1-qTohGGwEnb8OhHSW26cre9jB6Ss=",
       "license": "MIT"
     },
     "node_modules/undici-types": {

--- a/Extensions/Ansible/Src/Tasks/Ansible/package.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package.json
@@ -16,7 +16,8 @@
     "vso-node-api": "6.0.1-preview"
   },
   "overrides": {
-    "minimatch": "3.1.5"
+    "minimatch": "3.1.5",
+    "underscore": "1.13.8"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 271,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "instanceNameFormat": "Run playbook",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.271.0",
+  "version": "0.271.1",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package-lock.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package-lock.json
@@ -618,9 +618,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha1-lw4zljr5p92iKPF+voOZ5fvmOhA=",
+      "version": "1.13.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha1-qTohGGwEnb8OhHSW26cre9jB6Ss=",
       "license": "MIT"
     },
     "node_modules/utf8-byte-length": {
@@ -1043,9 +1043,9 @@
       "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
     "underscore": {
-      "version": "1.13.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha1-lw4zljr5p92iKPF+voOZ5fvmOhA="
+      "version": "1.13.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha1-qTohGGwEnb8OhHSW26cre9jB6Ss="
     },
     "utf8-byte-length": {
       "version": "1.0.5",
@@ -1064,7 +1064,7 @@
       "requires": {
         "q": "^1.0.1",
         "tunnel": "0.0.4",
-        "underscore": "^1.8.3"
+        "underscore": "1.13.8"
       }
     },
     "which": {

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package.json
@@ -6,6 +6,7 @@
     "vso-node-api": "6.0.1-preview"
   },
   "overrides": {
-    "minimatch": "3.1.5"
+    "minimatch": "3.1.5",
+    "underscore": "1.13.8"
   }
 }

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 15,
     "Minor": 271,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "1.99.0",
   "instanceNameFormat": "Download Artifacts - Bitbucket",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.271.0",
+  "version": "15.271.1",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package-lock.json
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package-lock.json
@@ -10,7 +10,7 @@
         "@types/node": "^6.14.13",
         "artifact-engine": "^1.263.0",
         "azure-pipelines-task-lib": "^5.2.3",
-        "underscore": "1.13.4"
+        "underscore": "1.13.8"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -885,9 +885,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.4.tgz",
-      "integrity": "sha1-eIa0a73wf3aOAFLxgo4dyrQMDe4=",
+      "version": "1.13.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha1-qTohGGwEnb8OhHSW26cre9jB6Ss=",
       "license": "MIT"
     },
     "node_modules/utf8-byte-length": {

--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package.json
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package.json
@@ -6,7 +6,7 @@
     "@types/node": "^6.14.13",
     "artifact-engine": "^1.263.0",
     "azure-pipelines-task-lib": "^5.2.3",
-    "underscore": "1.13.4"
+    "underscore": "1.13.8"
   },
   "overrides": {
     "minimatch": "3.1.5"

--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/task.json
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/task.json
@@ -10,7 +10,7 @@
     "version": {
       "Major": 0,
       "Minor": 271,
-      "Patch": 0
+      "Patch": 1
     },
     "demands": [],
     "inputs": [

--- a/Extensions/CircleCI/Src/vss-extension.json
+++ b/Extensions/CircleCI/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-circleci-extension",
   "name": "CircleCI artifacts for Release Pipeline",
   "publisher": "ms-vscs-rm",
-  "version": "0.271.0",
+  "version": "0.271.1",
   "public": true,
   "description": "Tool for connecting with CircleCI",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
@@ -1825,9 +1825,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha1-lw4zljr5p92iKPF+voOZ5fvmOhA=",
+      "version": "1.13.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha1-qTohGGwEnb8OhHSW26cre9jB6Ss=",
       "license": "MIT"
     },
     "node_modules/utf8-byte-length": {

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
@@ -8,6 +8,7 @@
     "azure-pipelines-tasks-azure-arm-rest": "^3.267.0"
   },
   "overrides": {
-    "minimatch": "3.1.5"
+    "minimatch": "3.1.5",
+    "underscore": "1.13.8"
   }
 }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 16,
     "Minor": 271,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "Download Artifacts - External TFS Git",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/package-lock.json
@@ -1197,9 +1197,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha1-lw4zljr5p92iKPF+voOZ5fvmOhA=",
+      "version": "1.13.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha1-qTohGGwEnb8OhHSW26cre9jB6Ss=",
       "license": "MIT"
     },
     "node_modules/undici-types": {

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/package.json
@@ -8,6 +8,7 @@
     "shelljs": "^0.10.0"
   },
   "overrides": {
-    "minimatch": "3.1.5"
+    "minimatch": "3.1.5",
+    "underscore": "1.13.8"
   }
 }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 15,
     "Minor": 271,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "1.99.0",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
@@ -1958,9 +1958,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha1-lw4zljr5p92iKPF+voOZ5fvmOhA=",
+      "version": "1.13.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha1-qTohGGwEnb8OhHSW26cre9jB6Ss=",
       "license": "MIT"
     },
     "node_modules/utf8-byte-length": {

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
@@ -12,6 +12,7 @@
     "typescript": "5.1.6"
   },
   "overrides": {
-    "minimatch": "3.1.5"
+    "minimatch": "3.1.5",
+    "underscore": "1.13.8"
   }
 }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 16,
     "Minor": 271,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 ﻿﻿{
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.271.0",
+  "version": "16.271.1",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package-lock.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "artifact-engine": "^1.263.0",
         "azure-pipelines-task-lib": "^5.2.3",
-        "underscore": "^1.13.4"
+        "underscore": "^1.13.8"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -877,9 +877,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha1-lw4zljr5p92iKPF+voOZ5fvmOhA=",
+      "version": "1.13.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha1-qTohGGwEnb8OhHSW26cre9jB6Ss=",
       "license": "MIT"
     },
     "node_modules/utf8-byte-length": {

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "artifact-engine": "^1.263.0",
     "azure-pipelines-task-lib": "^5.2.3",
-    "underscore": "^1.13.4"
+    "underscore": "^1.13.8"
   },
   "overrides": {
     "minimatch": "3.1.5"

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 15,
     "Minor": 271,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.271.0",
+  "version": "15.271.1",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",


### PR DESCRIPTION

**Description**: 

Remediates CVE-2026-27601 (GHSA-qpx9-hpmf-5gmw) in underscore by ensuring all task-level dependency graphs resolve underscore to >= 1.13.8 (patched). 

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped. (Patch versions bumped for impacted extensions/tasks)
- [x] Checked that applied changes work as expected. (Validated with lockfile trees + successful gulp build --verbose)
