### PR TITLE
remove minimatch overrides and align task-lib dependencies

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@types/ssh2-sftp-client": "5.2.0",
-        "azure-pipelines-task-lib": "^5.2.3",
+        "azure-pipelines-task-lib": "^5.2.8",
         "shell-quote": "^1.8.2",
         "shelljs": "^0.10.0",
         "ssh2": "1.4.0",
@@ -122,13 +122,13 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.3.tgz",
-      "integrity": "sha1-vcoulfL9GkbPLlXy/AmdOAOxT/s=",
+      "version": "5.2.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+      "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
-        "minimatch": "3.0.5",
+        "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",

--- a/Extensions/Ansible/Src/Tasks/Ansible/package.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package.json
@@ -7,7 +7,7 @@
   "license": "ISC",
   "dependencies": {
     "@types/ssh2-sftp-client": "5.2.0",
-    "azure-pipelines-task-lib": "^5.2.3",
+    "azure-pipelines-task-lib": "^5.2.8",
     "shell-quote": "^1.8.2",
     "shelljs": "^0.10.0",
     "ssh2": "1.4.0",
@@ -16,7 +16,6 @@
     "vso-node-api": "6.0.1-preview"
   },
   "overrides": {
-    "minimatch": "3.1.5",
     "underscore": "1.13.8"
   },
   "scripts": {

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 271,
-        "Patch": 1
+        "Minor": 272,
+        "Patch": 0
     },
     "demands": [],
     "instanceNameFormat": "Run playbook",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.271.1",
+  "version": "0.272.0",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package-lock.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "DownloadArtifactsBitbucket",
       "dependencies": {
-        "azure-pipelines-task-lib": "^5.2.3",
+        "azure-pipelines-task-lib": "^5.2.8",
         "vso-node-api": "6.0.1-preview"
       }
     },
@@ -67,13 +67,13 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.3.tgz",
-      "integrity": "sha1-vcoulfL9GkbPLlXy/AmdOAOxT/s=",
+      "version": "5.2.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+      "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
-        "minimatch": "3.0.5",
+        "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
@@ -704,12 +704,12 @@
       }
     },
     "azure-pipelines-task-lib": {
-      "version": "5.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.3.tgz",
-      "integrity": "sha1-vcoulfL9GkbPLlXy/AmdOAOxT/s=",
+      "version": "5.2.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+      "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
       "requires": {
         "adm-zip": "^0.5.10",
-        "minimatch": "3.1.5",
+        "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package.json
@@ -2,11 +2,10 @@
   "name": "DownloadArtifactsBitbucket",
   "main": "download.js",
   "dependencies": {
-    "azure-pipelines-task-lib": "^5.2.3",
+    "azure-pipelines-task-lib": "^5.2.8",
     "vso-node-api": "6.0.1-preview"
   },
   "overrides": {
-    "minimatch": "3.1.5",
     "underscore": "1.13.8"
   }
 }

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
@@ -13,8 +13,8 @@
   "demands": [],
   "version": {
     "Major": 15,
-    "Minor": 271,
-    "Patch": 1
+    "Minor": 272,
+    "Patch": 0
   },
   "minimumAgentVersion": "1.99.0",
   "instanceNameFormat": "Download Artifacts - Bitbucket",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.271.1",
+  "version": "15.272.0",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package-lock.json
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package-lock.json
@@ -8,7 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "^6.14.13",
-        "artifact-engine": "^1.263.0",
+        "artifact-engine": "^1.271.1",
         "azure-pipelines-task-lib": "^5.2.8",
         "underscore": "1.13.8"
       }
@@ -76,47 +76,15 @@
       }
     },
     "node_modules/artifact-engine": {
-      "version": "1.263.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/artifact-engine/-/artifact-engine-1.263.0.tgz",
-      "integrity": "sha1-5WHgCddfqOSQ8dt0Bprh8UyupfQ=",
+      "version": "1.271.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/artifact-engine/-/artifact-engine-1.271.1.tgz",
+      "integrity": "sha1-YYyVEf2JccgJRiBjcXmeZgDozQc=",
       "license": "MIT",
       "dependencies": {
-        "azure-pipelines-task-lib": "^4.12.1",
+        "azure-pipelines-task-lib": "^5.2.8",
         "handlebars": "4.7.7",
-        "minimatch": "^3.0.5",
+        "minimatch": "3.1.5",
         "tunnel": "0.0.4"
-      }
-    },
-    "node_modules/artifact-engine/node_modules/azure-pipelines-task-lib": {
-      "version": "4.17.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
-      "integrity": "sha1-/VMnGollIKefO6iDOcwLNiv51bk=",
-      "license": "MIT",
-      "dependencies": {
-        "adm-zip": "^0.5.10",
-        "minimatch": "3.0.5",
-        "nodejs-file-downloader": "^4.11.1",
-        "q": "^1.5.1",
-        "semver": "^5.7.2",
-        "shelljs": "^0.8.5",
-        "uuid": "^3.0.1"
-      }
-    },
-    "node_modules/artifact-engine/node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha1-3gVUCNg2G+1mxmnS8ABTjO2O4gw=",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/azure-pipelines-task-lib": {
@@ -279,21 +247,6 @@
         }
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "license": "ISC"
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
@@ -304,27 +257,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -360,18 +292,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -392,47 +312,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
-      "license": "ISC"
-    },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha1-KpiAGoSfQ+Kt1kT7trxiKbGaTvQ=",
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -598,15 +477,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onetime/-/onetime-5.1.2.tgz",
@@ -622,15 +492,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-key/-/path-key-3.1.1.tgz",
@@ -639,12 +500,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
-      "license": "MIT"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -688,37 +543,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha1-qthXzh/7i/qbCxrCnxFWOD9owmI=",
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -829,18 +653,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -926,12 +738,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "license": "MIT"
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "license": "ISC"
     }
   }
 }

--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package.json
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package.json
@@ -4,11 +4,8 @@
   "license": "MIT",
   "dependencies": {
     "@types/node": "^6.14.13",
-    "artifact-engine": "^1.263.0",
+    "artifact-engine": "^1.271.1",
     "azure-pipelines-task-lib": "^5.2.8",
     "underscore": "1.13.8"
-  },
-  "overrides": {
-    "minimatch": "3.1.5"
   }
 }

--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/task.json
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/task.json
@@ -9,8 +9,8 @@
     "preview": true,
     "version": {
       "Major": 0,
-      "Minor": 271,
-      "Patch": 1
+      "Minor": 272,
+      "Patch": 0
     },
     "demands": [],
     "inputs": [

--- a/Extensions/CircleCI/Src/vss-extension.json
+++ b/Extensions/CircleCI/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-circleci-extension",
   "name": "CircleCI artifacts for Release Pipeline",
   "publisher": "ms-vscs-rm",
-  "version": "0.271.1",
+  "version": "0.272.0",
   "public": true,
   "description": "Tool for connecting with CircleCI",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@azure/msal-node": "^2.7.0",
         "azure-devops-node-api": "14.1.0",
-        "azure-pipelines-task-lib": "^5.2.3",
+        "azure-pipelines-task-lib": "^5.2.8",
         "azure-pipelines-tasks-azure-arm-rest": "^3.267.0"
       }
     },
@@ -344,13 +344,13 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.3.tgz",
-      "integrity": "sha1-vcoulfL9GkbPLlXy/AmdOAOxT/s=",
+      "version": "5.2.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+      "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
-        "minimatch": "3.0.5",
+        "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
@@ -369,9 +369,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.267.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.267.0.tgz",
-      "integrity": "sha1-h1JWhsD6hj1tAeONnSlH/GjoTm8=",
+      "version": "3.271.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.271.2.tgz",
+      "integrity": "sha1-lK3Yaxn+x7CSUHpaTdub8HQqPlU=",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.2.1",
@@ -380,8 +380,8 @@
         "@types/node": "^10.17.0",
         "@types/q": "1.5.4",
         "async-mutex": "^0.4.0",
-        "azure-devops-node-api": "^14.0.1",
-        "azure-pipelines-task-lib": "^4.11.0",
+        "azure-devops-node-api": "^15.1.3",
+        "azure-pipelines-task-lib": "^5.2.4",
         "https-proxy-agent": "^4.0.0",
         "jsonwebtoken": "^9.0.3",
         "msalv1": "npm:@azure/msal-node@^1.18.4",
@@ -389,7 +389,7 @@
         "msalv3": "npm:@azure/msal-node@^3.5.3",
         "node-fetch": "^2.6.7",
         "q": "1.5.1",
-        "typed-rest-client": "^2.0.1",
+        "typed-rest-client": "^2.2.0",
         "xml2js": "0.6.2"
       }
     },
@@ -408,19 +408,33 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-pipelines-task-lib": {
-      "version": "4.17.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
-      "integrity": "sha1-/VMnGollIKefO6iDOcwLNiv51bk=",
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-devops-node-api": {
+      "version": "15.1.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-15.1.3.tgz",
+      "integrity": "sha1-X6phYKWoJOiNKVj3nCDsPWbH0VM=",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
-        "minimatch": "3.0.5",
-        "nodejs-file-downloader": "^4.11.1",
-        "q": "^1.5.1",
-        "semver": "^5.7.2",
-        "shelljs": "^0.8.5",
-        "uuid": "^3.0.1"
+        "tunnel": "0.0.6",
+        "typed-rest-client": "2.1.0"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-devops-node-api/node_modules/typed-rest-client": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/https-proxy-agent": {
@@ -436,31 +450,20 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha1-3gVUCNg2G+1mxmnS8ABTjO2O4gw=",
-      "license": "BSD-3-Clause",
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/typed-rest-client": {
+      "version": "2.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.2.0.tgz",
+      "integrity": "sha1-2gcn5AiEm9tpgg2G7mZK/KNHd6M=",
+      "license": "MIT",
       "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.14.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -761,12 +764,6 @@
         }
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "license": "ISC"
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
@@ -823,27 +820,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -938,46 +914,11 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "license": "ISC"
-    },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha1-KpiAGoSfQ+Kt1kT7trxiKbGaTvQ=",
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
@@ -1389,15 +1330,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onetime/-/onetime-5.1.2.tgz",
@@ -1431,15 +1363,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-key/-/path-key-3.1.1.tgz",
@@ -1448,12 +1371,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
-      "license": "MIT"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -1512,37 +1429,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha1-qthXzh/7i/qbCxrCnxFWOD9owmI=",
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -1754,18 +1640,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1875,12 +1749,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "license": "ISC"
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
@@ -4,11 +4,10 @@
   "dependencies": {
     "@azure/msal-node": "^2.7.0",
     "azure-devops-node-api": "14.1.0",
-    "azure-pipelines-task-lib": "^5.2.3",
+    "azure-pipelines-task-lib": "^5.2.8",
     "azure-pipelines-tasks-azure-arm-rest": "^3.267.0"
   },
   "overrides": {
-    "minimatch": "3.1.5",
     "underscore": "1.13.8"
   }
 }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
@@ -13,8 +13,8 @@
   "demands": [],
   "version": {
     "Major": 16,
-    "Minor": 271,
-    "Patch": 1
+    "Minor": 272,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "Download Artifacts - External TFS Git",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@types/shelljs": "^0.8.17",
         "azure-devops-node-api": "11.2.0",
-        "azure-pipelines-task-lib": "^5.2.3",
+        "azure-pipelines-task-lib": "^5.2.8",
         "shelljs": "^0.10.0"
       }
     },
@@ -139,13 +139,13 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.3.tgz",
-      "integrity": "sha1-vcoulfL9GkbPLlXy/AmdOAOxT/s=",
+      "version": "5.2.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+      "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
-        "minimatch": "3.0.5",
+        "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
@@ -514,6 +514,42 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha1-YU2q7NCmiPZgu7yQmodIw9gNQzY=",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha1-Rls6zL0CGLgoH1MB4nztxpf5b94=",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gopd": {

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/package.json
@@ -4,11 +4,10 @@
   "dependencies": {
     "@types/shelljs": "^0.8.17",
     "azure-devops-node-api": "11.2.0",
-    "azure-pipelines-task-lib": "^5.2.3",
+    "azure-pipelines-task-lib": "^5.2.8",
     "shelljs": "^0.10.0"
   },
   "overrides": {
-    "minimatch": "3.1.5",
     "underscore": "1.13.8"
   }
 }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/task.json
@@ -12,8 +12,8 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 15,
-    "Minor": 271,
-    "Patch": 1
+    "Minor": 272,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "1.99.0",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
@@ -7,7 +7,7 @@
       "name": "DownloadExternalBuildArtifacts",
       "dependencies": {
         "@azure/msal-node": "^3.7.3",
-        "artifact-engine": "^1.263.0",
+        "artifact-engine": "^1.271.1",
         "azure-devops-node-api": "14.1.0",
         "azure-pipelines-task-lib": "^5.2.8",
         "azure-pipelines-tasks-azure-arm-rest": "^3.267.0"
@@ -250,6 +250,15 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@typespec/ts-http-runtime/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/@typespec/ts-http-runtime/node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -273,66 +282,27 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
+      "version": "6.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
       "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/artifact-engine": {
-      "version": "1.263.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/artifact-engine/-/artifact-engine-1.263.0.tgz",
-      "integrity": "sha1-5WHgCddfqOSQ8dt0Bprh8UyupfQ=",
+      "version": "1.271.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/artifact-engine/-/artifact-engine-1.271.1.tgz",
+      "integrity": "sha1-YYyVEf2JccgJRiBjcXmeZgDozQc=",
       "license": "MIT",
       "dependencies": {
-        "azure-pipelines-task-lib": "^4.12.1",
+        "azure-pipelines-task-lib": "^5.2.8",
         "handlebars": "4.7.7",
-        "minimatch": "^3.0.5",
+        "minimatch": "3.1.5",
         "tunnel": "0.0.4"
-      }
-    },
-    "node_modules/artifact-engine/node_modules/azure-pipelines-task-lib": {
-      "version": "4.17.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
-      "integrity": "sha1-/VMnGollIKefO6iDOcwLNiv51bk=",
-      "license": "MIT",
-      "dependencies": {
-        "adm-zip": "^0.5.10",
-        "minimatch": "3.0.5",
-        "nodejs-file-downloader": "^4.11.1",
-        "q": "^1.5.1",
-        "semver": "^5.7.2",
-        "shelljs": "^0.8.5",
-        "uuid": "^3.0.1"
-      }
-    },
-    "node_modules/artifact-engine/node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha1-3gVUCNg2G+1mxmnS8ABTjO2O4gw=",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/artifact-engine/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/async-mutex": {
@@ -381,6 +351,15 @@
         "uuid": "^3.0.1"
       }
     },
+    "node_modules/azure-pipelines-task-lib/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/azure-pipelines-task-lib/node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
@@ -417,12 +396,21 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/@azure/msal-common": {
-      "version": "14.16.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-14.16.1.tgz",
-      "integrity": "sha1-0j7M5AgjpNA610Fg3IGdYuDAp4c=",
+      "version": "13.3.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-13.3.1.tgz",
+      "integrity": "sha1-ASRlv5QNEjddxHOHt1TM+da5IYA=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/agent-base": {
+      "version": "5.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-5.1.1.tgz",
+      "integrity": "sha1-6Ps/JClZ20TWO+Zl23qOc5U3oyw=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-devops-node-api": {
@@ -454,19 +442,68 @@
         "node": ">= 16.0.0"
       }
     },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/https-proxy-agent": {
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+      "integrity": "sha1-cCtx+1UgoTKmbeH2dUHZ5iFU2Cs=",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "5",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/msalv1": {
+      "name": "@azure/msal-node",
+      "version": "1.18.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-1.18.4.tgz",
+      "integrity": "sha1-ySGwRHyS+zsMsev1qadvytLsfCE=",
+      "dependencies": {
+        "@azure/msal-common": "13.3.1",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      }
+    },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/msalv2": {
       "name": "@azure/msal-node",
       "version": "2.16.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-2.16.3.tgz",
       "integrity": "sha1-i4BRUq14CwSNbCszsdTibXtGM2g=",
-      "license": "MIT",
       "dependencies": {
         "@azure/msal-common": "14.16.1",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
-      },
+      }
+    },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/msalv2/node_modules/@azure/msal-common": {
+      "version": "14.16.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-14.16.1.tgz",
+      "integrity": "sha1-0j7M5AgjpNA610Fg3IGdYuDAp4c=",
+      "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/msalv3": {
+      "name": "@azure/msal-node",
+      "version": "3.8.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-3.8.9.tgz",
+      "integrity": "sha1-3lRiiscI4wqk1RubmbM60Tn3Jaw=",
+      "dependencies": {
+        "@azure/msal-common": "15.16.1",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/msalv3/node_modules/@azure/msal-common": {
+      "version": "15.16.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-15.16.1.tgz",
+      "integrity": "sha1-XfNpfsDVPQgnjyU21TvVIhTlLDk=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/tunnel": {
@@ -792,12 +829,6 @@
         }
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "license": "ISC"
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
@@ -854,27 +885,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -959,26 +969,26 @@
         "node": ">= 14"
       }
     },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/https-proxy-agent": {
-      "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-      "integrity": "sha1-cCtx+1UgoTKmbeH2dUHZ5iFU2Cs=",
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "5",
+        "agent-base": "6",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/https-proxy-agent/node_modules/agent-base": {
-      "version": "5.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-5.1.1.tgz",
-      "integrity": "sha1-6Ps/JClZ20TWO+Zl23qOc5U3oyw=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {
@@ -990,46 +1000,11 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "license": "ISC"
-    },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha1-KpiAGoSfQ+Kt1kT7trxiKbGaTvQ=",
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
@@ -1153,18 +1128,6 @@
       "engines": {
         "node": ">=12",
         "npm": ">=6"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha1-KEZONgYOmR+noR0CedLT87V6foo=",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/jwa": {
@@ -1330,46 +1293,6 @@
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
-    "node_modules/msalv1": {
-      "name": "@azure/msal-node",
-      "version": "1.18.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-1.18.4.tgz",
-      "integrity": "sha1-ySGwRHyS+zsMsev1qadvytLsfCE=",
-      "deprecated": "A newer major version of this library is available. Please upgrade to the latest available version.",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/msal-common": "13.3.1",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": "10 || 12 || 14 || 16 || 18"
-      }
-    },
-    "node_modules/msalv1/node_modules/@azure/msal-common": {
-      "version": "13.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-13.3.1.tgz",
-      "integrity": "sha1-ASRlv5QNEjddxHOHt1TM+da5IYA=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/msalv3": {
-      "name": "@azure/msal-node",
-      "version": "3.8.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-3.8.9.tgz",
-      "integrity": "sha1-3lRiiscI4wqk1RubmbM60Tn3Jaw=",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/msal-common": "15.16.1",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/neo-async/-/neo-async-2.6.2.tgz",
@@ -1408,31 +1331,6 @@
         "sanitize-filename": "^1.6.3"
       }
     },
-    "node_modules/nodejs-file-downloader/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/nodejs-file-downloader/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -1455,15 +1353,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -1499,15 +1388,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-key/-/path-key-3.1.1.tgz",
@@ -1516,12 +1396,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
-      "license": "MIT"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -1580,37 +1454,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha1-qthXzh/7i/qbCxrCnxFWOD9owmI=",
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -1696,12 +1539,15 @@
       }
     },
     "node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
+      "version": "7.7.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha1-KEZONgYOmR+noR0CedLT87V6foo=",
       "license": "ISC",
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {
@@ -1832,18 +1678,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/to-regex-range": {
@@ -1997,12 +1831,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "license": "MIT"
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "license": "ISC"
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
@@ -3,7 +3,7 @@
   "main": "download.js",
   "dependencies": {
     "@azure/msal-node": "^3.7.3",
-    "artifact-engine": "^1.263.0",
+    "artifact-engine": "^1.271.1",
     "azure-devops-node-api": "14.1.0",
     "azure-pipelines-task-lib": "^5.2.8",
     "azure-pipelines-tasks-azure-arm-rest": "^3.267.0"
@@ -12,7 +12,6 @@
     "typescript": "5.1.6"
   },
   "overrides": {
-    "minimatch": "3.1.5",
     "underscore": "1.13.8"
   }
 }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
@@ -8,8 +8,8 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 16,
-    "Minor": 271,
-    "Patch": 1
+    "Minor": 272,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 ﻿﻿{
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.271.1",
+  "version": "16.272.0",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package-lock.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "DownloadTeamCityArtifacts",
       "dependencies": {
-        "artifact-engine": "^1.263.0",
+        "artifact-engine": "^1.271.1",
         "azure-pipelines-task-lib": "^5.2.8",
         "underscore": "^1.13.8"
       }
@@ -68,47 +68,15 @@
       }
     },
     "node_modules/artifact-engine": {
-      "version": "1.263.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/artifact-engine/-/artifact-engine-1.263.0.tgz",
-      "integrity": "sha1-5WHgCddfqOSQ8dt0Bprh8UyupfQ=",
+      "version": "1.271.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/artifact-engine/-/artifact-engine-1.271.1.tgz",
+      "integrity": "sha1-YYyVEf2JccgJRiBjcXmeZgDozQc=",
       "license": "MIT",
       "dependencies": {
-        "azure-pipelines-task-lib": "^4.12.1",
+        "azure-pipelines-task-lib": "^5.2.8",
         "handlebars": "4.7.7",
-        "minimatch": "^3.0.5",
+        "minimatch": "3.1.5",
         "tunnel": "0.0.4"
-      }
-    },
-    "node_modules/artifact-engine/node_modules/azure-pipelines-task-lib": {
-      "version": "4.17.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
-      "integrity": "sha1-/VMnGollIKefO6iDOcwLNiv51bk=",
-      "license": "MIT",
-      "dependencies": {
-        "adm-zip": "^0.5.10",
-        "minimatch": "3.0.5",
-        "nodejs-file-downloader": "^4.11.1",
-        "q": "^1.5.1",
-        "semver": "^5.7.2",
-        "shelljs": "^0.8.5",
-        "uuid": "^3.0.1"
-      }
-    },
-    "node_modules/artifact-engine/node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha1-3gVUCNg2G+1mxmnS8ABTjO2O4gw=",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/azure-pipelines-task-lib": {
@@ -271,21 +239,6 @@
         }
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "license": "ISC"
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
@@ -296,27 +249,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -352,18 +284,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -384,47 +304,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
-      "license": "ISC"
-    },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha1-KpiAGoSfQ+Kt1kT7trxiKbGaTvQ=",
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -590,15 +469,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onetime/-/onetime-5.1.2.tgz",
@@ -614,15 +484,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-key/-/path-key-3.1.1.tgz",
@@ -631,12 +492,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
-      "license": "MIT"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -680,37 +535,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha1-qthXzh/7i/qbCxrCnxFWOD9owmI=",
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -821,18 +645,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -918,12 +730,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "license": "MIT"
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "license": "ISC"
     }
   }
 }

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package.json
@@ -2,11 +2,8 @@
   "name": "DownloadTeamCityArtifacts",
   "main": "download.js",
   "dependencies": {
-    "artifact-engine": "^1.263.0",
+    "artifact-engine": "^1.271.1",
     "azure-pipelines-task-lib": "^5.2.8",
     "underscore": "^1.13.8"
-  },
-  "overrides": {
-    "minimatch": "3.1.5"
   }
 }

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
@@ -8,8 +8,8 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 15,
-    "Minor": 271,
-    "Patch": 1
+    "Minor": 272,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.271.1",
+  "version": "15.272.0",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",


### PR DESCRIPTION
This PR remediates minimatch-related dependency findings across extension task packages and aligns dependency trees to remove the old minimatch 3.0.5 path.

Changes included:

Upgraded impacted task packages to azure-pipelines-task-lib ^5.2.8.
Upgraded artifact-engine consumers to ^1.271.1 where applicable.
Removed now-redundant minimatch overrides from task package.json files.
Regenerated package-lock.json files for affected tasks.
Bumped task and extension versions for updated artifacts.
Validated by running gulp build and local Microsoft component-detection NPM scan.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
