### PR TITLE
Added verbs to ServiceNow extension binding

### DIFF
--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.262.1",
+  "version": "4.272.1",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [
@@ -302,11 +302,13 @@
               {
                 "target": "AccessToken",
                 "dataSourceName": "AccessToken",
+                "requestVerb": "Post",
                 "resultTemplate": "{\"AccessToken\" : \"{{{access_token}}}\", \"RefreshToken\" : \"{{{refresh_token}}}\", \"ExpiresIn\" : \"{{{expires_in}}}\", \"TokenType\" : \"{{{token_type}}}\", \"Scope\" : \"{{{scope}}}\", \"Error\" : \"{{{error}}}\", \"ErrorDescription\" : \"{{{error_description}}}\"}"
               },
               {
                 "target": "RefreshToken",
                 "dataSourceName": "RefreshToken",
+                "requestVerb": "Post",
                 "resultTemplate": "{\"AccessToken\" : \"{{{access_token}}}\", \"RefreshToken\" : \"{{{refresh_token}}}\", \"ExpiresIn\" : \"{{{expires_in}}}\", \"TokenType\" : \"{{{token_type}}}\", \"Scope\" : \"{{{scope}}}\", \"Error\" : \"{{{error}}}\", \"ErrorDescription\" : \"{{{error_description}}}\"}"
               }
             ]


### PR DESCRIPTION
**Description**:  Add missing requestVerb: "Post" to AccessToken and RefreshToken dataSourceBindings in the ServiceNow OAuth2
  authentication scheme.

  When the OAuth2 auth scheme's dataSourceBindings omit requestVerb, the Azure DevOps server-side code (
  ServiceEndpointContributionExtensions.ToDataSourceBinding()) defaults it to "GET". During the OAuth callback flow, the proxy
  service detects a mismatch between the request verb (GET) and the DataSource template verb (Post), and logs a warning:

   OverrideDataSourceDetailsWithDataSourceProperties. Request verb: 'GET' doesn't match
   template/default verb: 'Post', endpoint type: 'ServiceNow', Data Source name: 'AccessToken'

  The DataSource templates in dataSources[] already correctly define "requestVerb": "Post", so the server overrides the verb and
  OAuth works. However, the mismatch generates unnecessary telemetry noise and creates risk if the override logic changes in the
  future.

  This PR adds "requestVerb": "Post" to both the AccessToken and RefreshToken DataSourceBindings to match their corresponding
  DataSource template definitions.

**Documentation changes required:** N

**Added unit tests:** N — This is a declarative JSON configuration change. The verb was already being corrected server-side; this
  change aligns the binding with the existing template definition.

**Attached related issue:** N

**Checklist**:
- [X] Version was bumped - please check that version of the extension, task or library has been bumped.
- [X] Checked that applied changes work as expected.
