### PR TITLE
Update Node version to 24.* in CI pipeline

### DIFF
--- a/ci/azure-pipelines-extensions.yml
+++ b/ci/azure-pipelines-extensions.yml
@@ -78,10 +78,10 @@ extends:
           errorActionPreference: continue
           failOnStderr: true
           displayName: 'Code Checks'
-        - task: NodeTool@0
-          displayName: 'Use Node 10.24.1'
+        - task: UseNode@1
+          displayName: Use Node 24.*
           inputs:
-            versionSpec: 10.24.1
+            version: 24.*
         - powershell: 'node getUpdatedPaths.js'
           displayName: 'PowerShell Script'
         - task: Npm@1


### PR DESCRIPTION
**Description**: Update Node version v24 to support all updated vulnerable dependencies that requires >=Node v12/v18/v20

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.
- [ ] Checked that applied changes work as expected.
