### PR TITLE
Fix minimist version

### DIFF
--- a/Extensions/Common/lib/vsts-task-lib/package-lock.json
+++ b/Extensions/Common/lib/vsts-task-lib/package-lock.json
@@ -23,8 +23,6 @@
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha1-s3Znt7wYHBaHgiWbq0JHT79StVA=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -41,8 +39,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha1-YCFu6kZNhkWXzigyAAc4oFiWUME=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -54,8 +50,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha1-Eyh1q95njH6o1pFTPy5+Irt0Tbo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -70,8 +64,6 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -83,8 +75,6 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -92,8 +82,6 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -105,8 +93,6 @@
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha1-p36nQvqyV3UUVDTrHSMoz1ATrDM=",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -116,8 +102,6 @@
     },
     "node_modules/ansi-gray": {
       "version": "0.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-gray/-/ansi-gray-0.1.1.tgz",
-      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -129,8 +113,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -139,8 +121,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "2.2.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -149,32 +129,24 @@
     },
     "node_modules/ansi-wrap": {
       "version": "0.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
       "dev": true,
-      "license": "MIT (https://github.com/jonschlinkert/ansi-wrap/blob/master/LICENSE)",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/archy": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
       "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/arr-diff": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -183,8 +155,6 @@
     },
     "node_modules/arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -193,8 +163,6 @@
     },
     "node_modules/arr-union": {
       "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -203,8 +171,6 @@
     },
     "node_modules/array-differ": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -213,8 +179,6 @@
     },
     "node_modules/array-each": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/array-each/-/array-each-1.0.1.tgz",
-      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -223,8 +187,6 @@
     },
     "node_modules/array-slice": {
       "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/array-slice/-/array-slice-1.1.0.tgz",
-      "integrity": "sha1-42jqFfibxwaff/uJrsOmx9SsItQ=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -233,8 +195,6 @@
     },
     "node_modules/array-union": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -246,8 +206,6 @@
     },
     "node_modules/array-uniq": {
       "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -256,8 +214,6 @@
     },
     "node_modules/array-unique": {
       "version": "0.3.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -266,8 +222,6 @@
     },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -276,15 +230,11 @@
     },
     "node_modules/async": {
       "version": "1.5.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/atob": {
       "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
       "dev": true,
       "license": "(MIT OR Apache-2.0)",
       "bin": {
@@ -296,15 +246,11 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/base": {
       "version": "0.11.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/base/-/base-0.11.2.tgz",
-      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -322,8 +268,6 @@
     },
     "node_modules/base/node_modules/define-property": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -335,8 +279,6 @@
     },
     "node_modules/base/node_modules/is-descriptor": {
       "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-descriptor/-/is-descriptor-1.0.3.tgz",
-      "integrity": "sha1-ktJ8s80xHEl3pNtH30VyNKE8swY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -349,8 +291,6 @@
     },
     "node_modules/beeper": {
       "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/beeper/-/beeper-1.1.1.tgz",
-      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -359,8 +299,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -370,8 +308,6 @@
     },
     "node_modules/braces": {
       "version": "2.3.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -392,8 +328,6 @@
     },
     "node_modules/braces/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -405,15 +339,11 @@
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/byline": {
       "version": "4.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/byline/-/byline-4.2.2.tgz",
-      "integrity": "sha1-wgOpilsCkIIqk4anjtosvVvNsy8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -422,8 +352,6 @@
     },
     "node_modules/cache-base": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -443,8 +371,6 @@
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha1-VoW5XrIJrJwMF3Rnd4ychN9Yupo=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -456,8 +382,6 @@
     },
     "node_modules/chalk": {
       "version": "1.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -473,8 +397,6 @@
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha1-e+N6TAPJruHs/oYqSiOyxwwgXTA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -489,8 +411,6 @@
     },
     "node_modules/class-utils": {
       "version": "0.3.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/class-utils/-/class-utils-0.3.6.tgz",
-      "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -505,8 +425,6 @@
     },
     "node_modules/class-utils/node_modules/define-property": {
       "version": "0.2.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -518,8 +436,6 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha1-DASwddsCy/5g3I5s8vVIaxo2CKo=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -533,8 +449,6 @@
     },
     "node_modules/cliui/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -543,8 +457,6 @@
     },
     "node_modules/cliui/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -559,15 +471,11 @@
     },
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -581,8 +489,6 @@
     },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -594,8 +500,6 @@
     },
     "node_modules/cliui/node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -612,8 +516,6 @@
     },
     "node_modules/clone": {
       "version": "1.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -622,15 +524,11 @@
     },
     "node_modules/clone-stats": {
       "version": "0.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/clone-stats/-/clone-stats-0.0.1.tgz",
-      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/collection-visit": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -643,8 +541,6 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -656,15 +552,11 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/color-support": {
       "version": "1.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI=",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -673,8 +565,6 @@
     },
     "node_modules/commander": {
       "version": "2.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/commander/-/commander-2.3.0.tgz",
-      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
       "dev": true,
       "engines": {
         "node": ">= 0.6.x"
@@ -682,8 +572,6 @@
     },
     "node_modules/component-emitter": {
       "version": "1.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/component-emitter/-/component-emitter-1.3.1.tgz",
-      "integrity": "sha1-7x1XlvfZPxNe5vtoQ0CyZAPJfRc=",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -692,15 +580,11 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -709,15 +593,11 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -730,8 +610,6 @@
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/which/-/which-2.0.2.tgz",
-      "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -745,8 +623,6 @@
     },
     "node_modules/dateformat": {
       "version": "2.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/dateformat/-/dateformat-2.2.0.tgz",
-      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -755,8 +631,6 @@
     },
     "node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -765,8 +639,6 @@
     },
     "node_modules/decamelize": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha1-qkcte/Zg6xXzSU79UxyrfypwmDc=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -778,8 +650,6 @@
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha1-5p2+JdN5QRcd1UDgJMREzVGI4ek=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -788,8 +658,6 @@
     },
     "node_modules/defaults": {
       "version": "1.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha1-sLAgYsHiqmL/XZUo8PmLqpCXjXo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -801,8 +669,6 @@
     },
     "node_modules/define-property": {
       "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/define-property/-/define-property-2.0.2.tgz",
-      "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -815,8 +681,6 @@
     },
     "node_modules/define-property/node_modules/is-descriptor": {
       "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-descriptor/-/is-descriptor-1.0.3.tgz",
-      "integrity": "sha1-ktJ8s80xHEl3pNtH30VyNKE8swY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -829,8 +693,6 @@
     },
     "node_modules/del": {
       "version": "1.2.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/del/-/del-1.2.1.tgz",
-      "integrity": "sha1-rtblvNfLcyXfNPVjEl+iZbLBoBQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -847,8 +709,6 @@
     },
     "node_modules/deprecated": {
       "version": "0.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/deprecated/-/deprecated-0.0.1.tgz",
-      "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
       "dev": true,
       "engines": {
         "node": ">= 0.9"
@@ -856,8 +716,6 @@
     },
     "node_modules/detect-file": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/detect-file/-/detect-file-1.0.0.tgz",
-      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -866,8 +724,6 @@
     },
     "node_modules/diff": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/diff/-/diff-1.4.0.tgz",
-      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
@@ -875,8 +731,6 @@
     },
     "node_modules/duplexer2": {
       "version": "0.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/duplexer2/-/duplexer2-0.0.2.tgz",
-      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
       "license": "BSD",
       "dependencies": {
@@ -885,8 +739,6 @@
     },
     "node_modules/duplexify": {
       "version": "3.7.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/duplexify/-/duplexify-3.7.1.tgz",
-      "integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -898,8 +750,6 @@
     },
     "node_modules/duplexify/node_modules/end-of-stream": {
       "version": "1.4.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha1-c0TXEd6kDgt0q8LtSXeHQ8ztsIw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -908,15 +758,11 @@
     },
     "node_modules/duplexify/node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/duplexify/node_modules/readable-stream": {
       "version": "2.3.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha1-kRJegEK7obmIf0k0X2J3Anzovps=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -931,8 +777,6 @@
     },
     "node_modules/duplexify/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -941,8 +785,6 @@
     },
     "node_modules/each-async": {
       "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/each-async/-/each-async-1.1.1.tgz",
-      "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -955,22 +797,16 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha1-hAyIA7DYBH9P8M+WMXazLU7z7XI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
       "version": "0.1.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/end-of-stream/-/end-of-stream-0.1.5.tgz",
-      "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -979,8 +815,6 @@
     },
     "node_modules/end-of-stream/node_modules/once": {
       "version": "1.3.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/once/-/once-1.3.3.tgz",
-      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -989,8 +823,6 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -999,8 +831,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1009,8 +839,6 @@
     },
     "node_modules/execa": {
       "version": "5.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -1032,14 +860,10 @@
     },
     "node_modules/execa/node_modules/merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
       "license": "MIT"
     },
     "node_modules/execa/node_modules/onetime": {
       "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -1053,8 +877,6 @@
     },
     "node_modules/expand-brackets": {
       "version": "2.1.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/expand-brackets/-/expand-brackets-2.1.4.tgz",
-      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1072,8 +894,6 @@
     },
     "node_modules/expand-brackets/node_modules/define-property": {
       "version": "0.2.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1085,8 +905,6 @@
     },
     "node_modules/expand-brackets/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1098,8 +916,6 @@
     },
     "node_modules/expand-tilde": {
       "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/expand-tilde/-/expand-tilde-2.0.2.tgz",
-      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1111,15 +927,11 @@
     },
     "node_modules/extend": {
       "version": "3.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/extend-shallow": {
       "version": "3.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1132,8 +944,6 @@
     },
     "node_modules/extend-shallow/node_modules/is-extendable": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-extendable/-/is-extendable-1.0.1.tgz",
-      "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1145,8 +955,6 @@
     },
     "node_modules/extglob": {
       "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/extglob/-/extglob-2.0.4.tgz",
-      "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1165,8 +973,6 @@
     },
     "node_modules/extglob/node_modules/define-property": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1178,8 +984,6 @@
     },
     "node_modules/extglob/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1191,8 +995,6 @@
     },
     "node_modules/extglob/node_modules/is-descriptor": {
       "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-descriptor/-/is-descriptor-1.0.3.tgz",
-      "integrity": "sha1-ktJ8s80xHEl3pNtH30VyNKE8swY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1205,8 +1007,6 @@
     },
     "node_modules/fancy-log": {
       "version": "1.3.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fancy-log/-/fancy-log-1.3.3.tgz",
-      "integrity": "sha1-28GRVPVYaQFQojlToK29A1vkX8c=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1221,8 +1021,6 @@
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha1-0G1YXOjbqQoWsFBcVDw8z7OuuBg=",
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -1237,8 +1035,6 @@
     },
     "node_modules/fast-glob/node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k=",
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -1249,8 +1045,6 @@
     },
     "node_modules/fast-glob/node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI=",
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -1261,8 +1055,6 @@
     },
     "node_modules/fast-glob/node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -1270,8 +1062,6 @@
     },
     "node_modules/fast-glob/node_modules/micromatch": {
       "version": "4.0.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha1-1m+hjzpHB2eJMgubGvMr2G2fogI=",
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -1283,8 +1073,6 @@
     },
     "node_modules/fast-glob/node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -1295,8 +1083,6 @@
     },
     "node_modules/fastq": {
       "version": "1.19.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha1-1Q6rqAPIhGqIPBZJKCHrzSzaVfU=",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -1304,8 +1090,6 @@
     },
     "node_modules/fill-range": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1320,8 +1104,6 @@
     },
     "node_modules/fill-range/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1333,15 +1115,11 @@
     },
     "node_modules/find-index": {
       "version": "0.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/find-index/-/find-index-0.1.1.tgz",
-      "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1357,8 +1135,6 @@
     },
     "node_modules/findup-sync": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/findup-sync/-/findup-sync-2.0.0.tgz",
-      "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1373,8 +1149,6 @@
     },
     "node_modules/fined": {
       "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fined/-/fined-1.2.0.tgz",
-      "integrity": "sha1-0AvszxqitHXRbUI7Aji3E6LEo3s=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1390,8 +1164,6 @@
     },
     "node_modules/first-chunk-stream": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-      "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1400,8 +1172,6 @@
     },
     "node_modules/flagged-respawn": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
-      "integrity": "sha1-595vEnnd2cqarIpZcdYYYGs6q0E=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1410,8 +1180,6 @@
     },
     "node_modules/flat": {
       "version": "5.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha1-jKb+MyBp/6nTJMMnGYxZglnOskE=",
       "dev": true,
       "license": "BSD-3-Clause",
       "bin": {
@@ -1420,8 +1188,6 @@
     },
     "node_modules/for-in": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1430,8 +1196,6 @@
     },
     "node_modules/for-own": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/for-own/-/for-own-1.0.0.tgz",
-      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1443,8 +1207,6 @@
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha1-Mujp7Rtoo0l777msK2rfkqY4V28=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1460,8 +1222,6 @@
     },
     "node_modules/foreground-child/node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -1473,8 +1233,6 @@
     },
     "node_modules/fragment-cache": {
       "version": "0.2.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fragment-cache/-/fragment-cache-0.2.1.tgz",
-      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1486,15 +1244,11 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1503,8 +1257,6 @@
     },
     "node_modules/gaze": {
       "version": "0.5.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/gaze/-/gaze-0.5.2.tgz",
-      "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
       "dev": true,
       "dependencies": {
         "globule": "~0.1.0"
@@ -1515,8 +1267,6 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -1525,8 +1275,6 @@
     },
     "node_modules/get-stream": {
       "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1537,8 +1285,6 @@
     },
     "node_modules/get-value": {
       "version": "2.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1547,9 +1293,6 @@
     },
     "node_modules/glob": {
       "version": "5.0.15",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1565,8 +1308,6 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -1577,8 +1318,6 @@
     },
     "node_modules/glob-parent/node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -1589,8 +1328,6 @@
     },
     "node_modules/glob-stream": {
       "version": "3.1.18",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob-stream/-/glob-stream-3.1.18.tgz",
-      "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
       "dev": true,
       "dependencies": {
         "glob": "^4.3.1",
@@ -1606,9 +1343,6 @@
     },
     "node_modules/glob-stream/node_modules/glob": {
       "version": "4.5.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-4.5.3.tgz",
-      "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1623,9 +1357,6 @@
     },
     "node_modules/glob-stream/node_modules/minimatch": {
       "version": "2.0.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-2.0.10.tgz",
-      "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1637,8 +1368,6 @@
     },
     "node_modules/glob-stream/node_modules/readable-stream": {
       "version": "1.0.34",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1650,8 +1379,6 @@
     },
     "node_modules/glob-stream/node_modules/through2": {
       "version": "0.6.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1661,8 +1388,6 @@
     },
     "node_modules/glob-watcher": {
       "version": "0.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob-watcher/-/glob-watcher-0.0.6.tgz",
-      "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
       "dev": true,
       "dependencies": {
         "gaze": "^0.5.1"
@@ -1673,8 +1398,6 @@
     },
     "node_modules/glob2base": {
       "version": "0.0.12",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob2base/-/glob2base-0.0.12.tgz",
-      "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
       "dev": true,
       "dependencies": {
         "find-index": "^0.1.1"
@@ -1685,8 +1408,6 @@
     },
     "node_modules/global-modules": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/global-modules/-/global-modules-1.0.0.tgz",
-      "integrity": "sha1-bXcPDrUjrHgWTXK15xqIdyZcw+o=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1700,8 +1421,6 @@
     },
     "node_modules/global-prefix": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/global-prefix/-/global-prefix-1.0.2.tgz",
-      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1717,8 +1436,6 @@
     },
     "node_modules/globby": {
       "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/globby/-/globby-2.1.0.tgz",
-      "integrity": "sha1-npGSvNM/Srak+JTl5+qLcTITxII=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1733,8 +1450,6 @@
     },
     "node_modules/globule": {
       "version": "0.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/globule/-/globule-0.1.0.tgz",
-      "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
       "dev": true,
       "dependencies": {
         "glob": "~3.1.21",
@@ -1747,9 +1462,6 @@
     },
     "node_modules/globule/node_modules/glob": {
       "version": "3.1.21",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-3.1.21.tgz",
-      "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "license": "BSD",
       "dependencies": {
@@ -1763,9 +1475,6 @@
     },
     "node_modules/globule/node_modules/graceful-fs": {
       "version": "1.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/graceful-fs/-/graceful-fs-1.2.3.tgz",
-      "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
       "dev": true,
       "license": "BSD",
       "engines": {
@@ -1774,17 +1483,12 @@
     },
     "node_modules/globule/node_modules/inherits": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inherits/-/inherits-1.0.2.tgz",
-      "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
       "dev": true
     },
     "node_modules/globule/node_modules/minimatch": {
       "version": "0.2.14",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-0.2.14.tgz",
-      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
       "dev": true,
-      "license": "MIT (http://github.com/isaacs/minimatch/raw/master/LICENSE)",
+      "license": "MIT",
       "dependencies": {
         "lru-cache": "2",
         "sigmund": "~1.0.0"
@@ -1795,8 +1499,6 @@
     },
     "node_modules/glogg": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glogg/-/glogg-1.0.2.tgz",
-      "integrity": "sha1-LX3XAr7aIus7/634gGltpthGMT8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1808,8 +1510,6 @@
     },
     "node_modules/graceful-fs": {
       "version": "3.0.12",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/graceful-fs/-/graceful-fs-3.0.12.tgz",
-      "integrity": "sha1-ADSUfOntaV7IqwuFS8kZ6Csf+u8=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1821,15 +1521,11 @@
     },
     "node_modules/growl": {
       "version": "1.9.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/gulp": {
       "version": "3.9.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/gulp/-/gulp-3.9.1.tgz",
-      "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1856,8 +1552,6 @@
     },
     "node_modules/gulp-mocha": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/gulp-mocha/-/gulp-mocha-2.0.0.tgz",
-      "integrity": "sha1-LNsyBGSdUB0+9s1ZI9RdzmP/MpQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1871,8 +1565,6 @@
     },
     "node_modules/gulp-mocha/node_modules/debug": {
       "version": "2.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-2.2.0.tgz",
-      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1881,8 +1573,6 @@
     },
     "node_modules/gulp-mocha/node_modules/escape-string-regexp": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1891,9 +1581,6 @@
     },
     "node_modules/gulp-mocha/node_modules/glob": {
       "version": "3.2.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-3.2.11.tgz",
-      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "license": "BSD",
       "dependencies": {
@@ -1906,11 +1593,8 @@
     },
     "node_modules/gulp-mocha/node_modules/minimatch": {
       "version": "0.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-0.3.0.tgz",
-      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
       "dev": true,
-      "license": "MIT (http://github.com/isaacs/minimatch/raw/master/LICENSE)",
+      "license": "MIT",
       "dependencies": {
         "lru-cache": "2",
         "sigmund": "~1.0.0"
@@ -1920,17 +1604,12 @@
       }
     },
     "node_modules/gulp-mocha/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "0.2.4",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/gulp-mocha/node_modules/mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1942,8 +1621,6 @@
     },
     "node_modules/gulp-mocha/node_modules/mocha": {
       "version": "2.5.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mocha/-/mocha-2.5.3.tgz",
-      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1968,14 +1645,10 @@
     },
     "node_modules/gulp-mocha/node_modules/ms": {
       "version": "0.7.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-0.7.1.tgz",
-      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
       "dev": true
     },
     "node_modules/gulp-mocha/node_modules/supports-color": {
       "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-color/-/supports-color-1.2.0.tgz",
-      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1987,8 +1660,6 @@
     },
     "node_modules/gulp-tsc": {
       "version": "0.10.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/gulp-tsc/-/gulp-tsc-0.10.1.tgz",
-      "integrity": "sha1-H1IutxaLsfvBE9l3fLv1FIQTqD8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2009,15 +1680,11 @@
     },
     "node_modules/gulp-tsc/node_modules/async": {
       "version": "0.9.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/async/-/async-0.9.2.tgz",
-      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/gulp-tsc/node_modules/clone": {
       "version": "0.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/clone/-/clone-0.2.0.tgz",
-      "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2026,9 +1693,6 @@
     },
     "node_modules/gulp-tsc/node_modules/glob": {
       "version": "4.5.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-4.5.3.tgz",
-      "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2043,8 +1707,6 @@
     },
     "node_modules/gulp-tsc/node_modules/glob-stream": {
       "version": "4.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob-stream/-/glob-stream-4.1.1.tgz",
-      "integrity": "sha1-uELfENaIx+trz869hG84UilrMgA=",
       "dev": true,
       "dependencies": {
         "glob": "^4.3.1",
@@ -2060,8 +1722,6 @@
     },
     "node_modules/gulp-tsc/node_modules/glob-watcher": {
       "version": "0.0.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob-watcher/-/glob-watcher-0.0.8.tgz",
-      "integrity": "sha1-aK62Yefizo02NDgbLsQV8AxrwqQ=",
       "dev": true,
       "dependencies": {
         "gaze": "^0.5.1"
@@ -2072,16 +1732,11 @@
     },
     "node_modules/gulp-tsc/node_modules/lodash": {
       "version": "3.10.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/gulp-tsc/node_modules/minimatch": {
       "version": "2.0.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-2.0.10.tgz",
-      "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2091,10 +1746,32 @@
         "node": "*"
       }
     },
+    "node_modules/gulp-tsc/node_modules/minimist": {
+      "version": "0.2.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha1-AIXVUB4pAzdIovKk2gGAFCaXpHU=",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gulp-tsc/node_modules/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/gulp-tsc/node_modules/object-assign": {
       "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object-assign/-/object-assign-2.1.1.tgz",
-      "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2103,8 +1780,6 @@
     },
     "node_modules/gulp-tsc/node_modules/readable-stream": {
       "version": "1.0.34",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2116,8 +1791,6 @@
     },
     "node_modules/gulp-tsc/node_modules/through2": {
       "version": "0.6.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2127,8 +1800,6 @@
     },
     "node_modules/gulp-tsc/node_modules/unique-stream": {
       "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/unique-stream/-/unique-stream-2.3.1.tgz",
-      "integrity": "sha1-xl0RDppK35psWUiygFPZqNBMvqw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2138,8 +1809,6 @@
     },
     "node_modules/gulp-tsc/node_modules/vinyl": {
       "version": "0.4.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/vinyl/-/vinyl-0.4.6.tgz",
-      "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
       "dev": true,
       "dependencies": {
         "clone": "^0.2.0",
@@ -2151,8 +1820,6 @@
     },
     "node_modules/gulp-tsc/node_modules/vinyl-fs": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/vinyl-fs/-/vinyl-fs-1.0.0.tgz",
-      "integrity": "sha1-0VdS5owtrXQ2Tn6FNHNzU1RpLt8=",
       "dev": true,
       "dependencies": {
         "duplexify": "^3.2.0",
@@ -2172,9 +1839,6 @@
     },
     "node_modules/gulp-util": {
       "version": "3.0.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/gulp-util/-/gulp-util-3.0.8.tgz",
-      "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-      "deprecated": "gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2201,10 +1865,28 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/gulp-util/node_modules/minimist": {
+      "version": "0.2.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha1-AIXVUB4pAzdIovKk2gGAFCaXpHU=",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gulp/node_modules/minimist": {
+      "version": "0.2.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha1-AIXVUB4pAzdIovKk2gGAFCaXpHU=",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gulplog": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/gulplog/-/gulplog-1.0.0.tgz",
-      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2216,8 +1898,6 @@
     },
     "node_modules/has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2229,8 +1909,6 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2239,8 +1917,6 @@
     },
     "node_modules/has-gulplog": {
       "version": "0.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-gulplog/-/has-gulplog-0.1.0.tgz",
-      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2252,8 +1928,6 @@
     },
     "node_modules/has-value": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-value/-/has-value-1.0.0.tgz",
-      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2267,8 +1941,6 @@
     },
     "node_modules/has-values": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-values/-/has-values-1.0.0.tgz",
-      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2281,8 +1953,6 @@
     },
     "node_modules/has-values/node_modules/kind-of": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/kind-of/-/kind-of-4.0.0.tgz",
-      "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2294,8 +1964,6 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2307,8 +1975,6 @@
     },
     "node_modules/he": {
       "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/he/-/he-1.2.0.tgz",
-      "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2317,8 +1983,6 @@
     },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
-      "integrity": "sha1-dDKYzvTlrz4ZQWH7rcwhUdOgWOg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2330,8 +1994,6 @@
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
@@ -2339,9 +2001,6 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2351,22 +2010,16 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha1-op2kJbSIBvNHZ6Tvzjlyaa8oQyw=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/interpret": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2375,8 +2028,6 @@
     },
     "node_modules/is-absolute": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-absolute/-/is-absolute-1.0.0.tgz",
-      "integrity": "sha1-OV4a6EsR8mrReV5zwXN45IowFXY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2389,8 +2040,6 @@
     },
     "node_modules/is-accessor-descriptor": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-accessor-descriptor/-/is-accessor-descriptor-1.0.1.tgz",
-      "integrity": "sha1-MiOxBig1RkS4YmDbKbPmk/XO7dQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2402,15 +2051,11 @@
     },
     "node_modules/is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha1-KpiAGoSfQ+Kt1kT7trxiKbGaTvQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2425,8 +2070,6 @@
     },
     "node_modules/is-data-descriptor": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-data-descriptor/-/is-data-descriptor-1.0.1.tgz",
-      "integrity": "sha1-IQkWRCYWbTLqOMQFweCUXZ5qTus=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2438,8 +2081,6 @@
     },
     "node_modules/is-descriptor": {
       "version": "0.1.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-descriptor/-/is-descriptor-0.1.7.tgz",
-      "integrity": "sha1-JyfrYf14nc1b3w7UVp9VHS/jvjM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2452,8 +2093,6 @@
     },
     "node_modules/is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2462,8 +2101,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2471,8 +2108,6 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2481,8 +2116,6 @@
     },
     "node_modules/is-glob": {
       "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-glob/-/is-glob-3.1.0.tgz",
-      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2494,8 +2127,6 @@
     },
     "node_modules/is-number": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2507,8 +2138,6 @@
     },
     "node_modules/is-number/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2520,8 +2149,6 @@
     },
     "node_modules/is-path-cwd": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2530,8 +2157,6 @@
     },
     "node_modules/is-path-in-cwd": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-      "integrity": "sha1-WsSLNF72dTOb1sekipEhELJBz1I=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2543,8 +2168,6 @@
     },
     "node_modules/is-path-inside": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2556,8 +2179,6 @@
     },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha1-ReQuN/zPH0Dajl927iFRWEDAkoc=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2566,8 +2187,6 @@
     },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2579,8 +2198,6 @@
     },
     "node_modules/is-relative": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-relative/-/is-relative-1.0.0.tgz",
-      "integrity": "sha1-obtpNc6MXboei5dUubLcwCDiJg0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2592,8 +2209,6 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2604,8 +2219,6 @@
     },
     "node_modules/is-unc-path": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-unc-path/-/is-unc-path-1.0.0.tgz",
-      "integrity": "sha1-1zHoiY7QkKEsNSrS6u1Qla0yLJ0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2617,8 +2230,6 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha1-PybHaoCVk7Ur+i7LVxDtJ3m1Iqc=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2630,15 +2241,11 @@
     },
     "node_modules/is-utf8": {
       "version": "0.2.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2647,21 +2254,15 @@
     },
     "node_modules/isarray": {
       "version": "0.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "license": "ISC"
     },
     "node_modules/isobject": {
       "version": "3.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2670,8 +2271,6 @@
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha1-iDOp2Jq0rN5hiJQr0cU7Y5DtWoo=",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -2686,9 +2285,6 @@
     },
     "node_modules/jade": {
       "version": "0.26.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jade/-/jade-0.26.3.tgz",
-      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
-      "deprecated": "Jade has been renamed to pug, please install the latest version of pug instead of jade",
       "dev": true,
       "dependencies": {
         "commander": "0.6.1",
@@ -2700,8 +2296,6 @@
     },
     "node_modules/jade/node_modules/commander": {
       "version": "0.6.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/commander/-/commander-0.6.1.tgz",
-      "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
       "dev": true,
       "engines": {
         "node": ">= 0.4.x"
@@ -2709,9 +2303,6 @@
     },
     "node_modules/jade/node_modules/mkdirp": {
       "version": "0.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mkdirp/-/mkdirp-0.3.0.tgz",
-      "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
       "dev": true,
       "license": "MIT/X11",
       "engines": {
@@ -2720,8 +2311,6 @@
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha1-hUwpJGdwW2mUduGi3swMijRYgGs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2733,15 +2322,11 @@
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2750,8 +2335,6 @@
     },
     "node_modules/liftoff": {
       "version": "2.5.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/liftoff/-/liftoff-2.5.0.tgz",
-      "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2770,8 +2353,6 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2786,8 +2367,6 @@
     },
     "node_modules/lodash": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash/-/lodash-1.0.2.tgz",
-      "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
       "dev": true,
       "engines": [
         "node",
@@ -2797,71 +2376,51 @@
     },
     "node_modules/lodash._basecopy": {
       "version": "3.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash._basetostring": {
       "version": "3.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash._basevalues": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash._isiterateecall": {
       "version": "3.0.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash._reescape": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash._reevaluate": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash._root": {
       "version": "3.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash._root/-/lodash._root-3.0.1.tgz",
-      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.escape": {
       "version": "3.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash.escape/-/lodash.escape-3.2.0.tgz",
-      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2870,22 +2429,16 @@
     },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isarray": {
       "version": "3.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.keys": {
       "version": "3.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2896,15 +2449,11 @@
     },
     "node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.template": {
       "version": "3.6.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash.template/-/lodash.template-3.6.2.tgz",
-      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2921,8 +2470,6 @@
     },
     "node_modules/lodash.templatesettings": {
       "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-      "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2932,8 +2479,6 @@
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha1-P727lbRoOsn8eFER55LlWNSr1QM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2949,8 +2494,6 @@
     },
     "node_modules/log-symbols/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2965,8 +2508,6 @@
     },
     "node_modules/log-symbols/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2982,8 +2523,6 @@
     },
     "node_modules/log-symbols/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2995,15 +2534,11 @@
     },
     "node_modules/lru-cache": {
       "version": "2.7.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/make-iterator": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/make-iterator/-/make-iterator-1.0.1.tgz",
-      "integrity": "sha1-KbM/MSqo9UfEpeSQ9Wr87JkTOtY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3015,8 +2550,6 @@
     },
     "node_modules/map-cache": {
       "version": "0.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3025,8 +2558,6 @@
     },
     "node_modules/map-visit": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/map-visit/-/map-visit-1.0.0.tgz",
-      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3038,8 +2569,6 @@
     },
     "node_modules/merge-stream": {
       "version": "0.1.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge-stream/-/merge-stream-0.1.8.tgz",
-      "integrity": "sha1-SKB7O0oSHXSj7b/c20sIrb8CQLE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3048,8 +2577,6 @@
     },
     "node_modules/merge-stream/node_modules/readable-stream": {
       "version": "1.0.34",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3061,8 +2588,6 @@
     },
     "node_modules/merge-stream/node_modules/through2": {
       "version": "0.6.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3072,8 +2597,6 @@
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -3081,8 +2604,6 @@
     },
     "node_modules/micromatch": {
       "version": "3.1.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3106,8 +2627,6 @@
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3126,20 +2645,8 @@
         "node": "*"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/minipass": {
       "version": "7.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha1-k6libOXl5mvU24aEnnUV6SNApwc=",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -3148,8 +2655,6 @@
     },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mixin-deep/-/mixin-deep-1.3.2.tgz",
-      "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3162,8 +2667,6 @@
     },
     "node_modules/mixin-deep/node_modules/is-extendable": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-extendable/-/is-extendable-1.0.1.tgz",
-      "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3173,23 +2676,8 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/mocha": {
       "version": "11.7.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mocha/-/mocha-11.7.5.tgz",
-      "integrity": "sha1-WPW7+l4CEc5+XuYSgQfO/CUVpic=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3225,8 +2713,6 @@
     },
     "node_modules/mocha/node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3235,8 +2721,6 @@
     },
     "node_modules/mocha/node_modules/brace-expansion": {
       "version": "5.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha1-apxsJo+FtTlZ7FJ66v4PcwAlju8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3248,8 +2732,6 @@
     },
     "node_modules/mocha/node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3266,8 +2748,6 @@
     },
     "node_modules/mocha/node_modules/diff": {
       "version": "7.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha1-P7NNOHzXbYA/buvqZ7kh2rAYKpo=",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -3276,8 +2756,6 @@
     },
     "node_modules/mocha/node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3289,8 +2767,6 @@
     },
     "node_modules/mocha/node_modules/glob": {
       "version": "10.5.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha1-jsA1WRnNMzjChCiiPU8k7MX+c4w=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3310,8 +2786,6 @@
     },
     "node_modules/mocha/node_modules/is-path-inside": {
       "version": "3.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha1-0jE2LlOgf/Kw4Op/7QSRYf/RYoM=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3320,8 +2794,6 @@
     },
     "node_modules/mocha/node_modules/minimatch": {
       "version": "9.0.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-9.0.8.tgz",
-      "integrity": "sha1-uzqjbXtC6nepPETVwQgrGIESSXw=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3336,15 +2808,11 @@
     },
     "node_modules/mocha/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/mocha/node_modules/supports-color": {
       "version": "8.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3359,15 +2827,11 @@
     },
     "node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/multipipe": {
       "version": "0.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/multipipe/-/multipipe-0.1.2.tgz",
-      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3376,8 +2840,6 @@
     },
     "node_modules/nanomatch": {
       "version": "1.2.13",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/nanomatch/-/nanomatch-1.2.13.tgz",
-      "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3399,16 +2861,11 @@
     },
     "node_modules/natives": {
       "version": "1.1.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/natives/-/natives-1.1.6.tgz",
-      "integrity": "sha1-pgO0pJirdxc2ErnqGs3sTZgPALs=",
-      "deprecated": "This module relies on Node.js's internals and will break at some point. Do not use it, and update to graceful-fs@4.x.",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
@@ -3419,8 +2876,6 @@
     },
     "node_modules/object-assign": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object-assign/-/object-assign-3.0.0.tgz",
-      "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3429,8 +2884,6 @@
     },
     "node_modules/object-copy": {
       "version": "0.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object-copy/-/object-copy-0.1.0.tgz",
-      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3444,8 +2897,6 @@
     },
     "node_modules/object-copy/node_modules/define-property": {
       "version": "0.2.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3457,8 +2908,6 @@
     },
     "node_modules/object-copy/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3470,8 +2919,6 @@
     },
     "node_modules/object-visit": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object-visit/-/object-visit-1.0.1.tgz",
-      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3483,8 +2930,6 @@
     },
     "node_modules/object.defaults": {
       "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object.defaults/-/object.defaults-1.1.0.tgz",
-      "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3499,8 +2944,6 @@
     },
     "node_modules/object.map": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object.map/-/object.map-1.0.1.tgz",
-      "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3513,8 +2956,6 @@
     },
     "node_modules/object.pick": {
       "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object.pick/-/object.pick-1.3.0.tgz",
-      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3526,8 +2967,6 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3536,8 +2975,6 @@
     },
     "node_modules/onetime": {
       "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3546,8 +2983,6 @@
     },
     "node_modules/orchestrator": {
       "version": "0.3.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/orchestrator/-/orchestrator-0.3.8.tgz",
-      "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3558,15 +2993,11 @@
     },
     "node_modules/ordered-read-streams": {
       "version": "0.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-      "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3575,8 +3006,6 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3591,8 +3020,6 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3607,15 +3034,11 @@
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha1-TxRxoBCCeob5TP2bByfjbSZ95QU=",
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parse-filepath": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/parse-filepath/-/parse-filepath-1.0.2.tgz",
-      "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3629,8 +3052,6 @@
     },
     "node_modules/parse-node-version": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/parse-node-version/-/parse-node-version-1.0.1.tgz",
-      "integrity": "sha1-4rXb7eAOf6m8NjYH9TMn6LBzGJs=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3639,8 +3060,6 @@
     },
     "node_modules/parse-passwd": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3649,8 +3068,6 @@
     },
     "node_modules/pascalcase": {
       "version": "0.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3659,8 +3076,6 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3669,8 +3084,6 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3679,15 +3092,11 @@
     },
     "node_modules/path-is-inside": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true,
       "license": "(WTFPL OR MIT)"
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3695,15 +3104,11 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/path-root": {
       "version": "0.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-root/-/path-root-0.1.1.tgz",
-      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3715,8 +3120,6 @@
     },
     "node_modules/path-root-regex": {
       "version": "0.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-root-regex/-/path-root-regex-0.1.2.tgz",
-      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3725,8 +3128,6 @@
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha1-eWCmaIiFlKByCxKpEdGnQqufEdI=",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -3742,22 +3143,16 @@
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "10.4.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha1-QQ/IoXtw5ZgBPfJXwkRrfzOD8Rk=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -3768,8 +3163,6 @@
     },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3778,8 +3171,6 @@
     },
     "node_modules/pretty-hrtime": {
       "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3788,16 +3179,11 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/q": {
       "version": "1.5.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
       "license": "MIT",
       "engines": {
         "node": ">=0.6.0",
@@ -3806,8 +3192,6 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
       "funding": [
         {
           "type": "github",
@@ -3826,8 +3210,6 @@
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3836,8 +3218,6 @@
     },
     "node_modules/readable-stream": {
       "version": "1.1.14",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3849,8 +3229,6 @@
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha1-64WAFDX78qfuWPGeCSGwaPxplI0=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3863,8 +3241,6 @@
     },
     "node_modules/rechoir": {
       "version": "0.6.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "dependencies": {
         "resolve": "^1.1.6"
@@ -3875,8 +3251,6 @@
     },
     "node_modules/regex-not": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/regex-not/-/regex-not-1.0.2.tgz",
-      "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3889,8 +3263,6 @@
     },
     "node_modules/repeat-element": {
       "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/repeat-element/-/repeat-element-1.1.4.tgz",
-      "integrity": "sha1-vmgVIIR6tYx1aKx1+/rSjtQtOek=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3899,8 +3271,6 @@
     },
     "node_modules/repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3909,8 +3279,6 @@
     },
     "node_modules/replace-ext": {
       "version": "0.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/replace-ext/-/replace-ext-0.0.1.tgz",
-      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -3918,8 +3286,6 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3928,8 +3294,6 @@
     },
     "node_modules/resolve": {
       "version": "1.22.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha1-tmPoP/sJu/I4aURza6roAwKbizk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3949,8 +3313,6 @@
     },
     "node_modules/resolve-dir": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/resolve-dir/-/resolve-dir-1.0.1.tgz",
-      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3963,16 +3325,11 @@
     },
     "node_modules/resolve-url": {
       "version": "0.2.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-      "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ret": {
       "version": "0.1.15",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3981,8 +3338,6 @@
     },
     "node_modules/reusify": {
       "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha1-D+E7lSLhRz9RtVjueW4I8R+bSJ8=",
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -3991,9 +3346,6 @@
     },
     "node_modules/rimraf": {
       "version": "2.7.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4005,9 +3357,6 @@
     },
     "node_modules/rimraf/node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4027,8 +3376,6 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
       "funding": [
         {
           "type": "github",
@@ -4050,15 +3397,11 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/safe-regex/-/safe-regex-1.1.0.tgz",
-      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4067,8 +3410,6 @@
     },
     "node_modules/semver": {
       "version": "4.3.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-4.3.6.tgz",
-      "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4077,8 +3418,6 @@
     },
     "node_modules/sequencify": {
       "version": "0.0.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sequencify/-/sequencify-0.0.7.tgz",
-      "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -4086,8 +3425,6 @@
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha1-3voeBVyDv21Z6oBdjahiJU62psI=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4096,8 +3433,6 @@
     },
     "node_modules/set-immediate-shim": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4106,8 +3441,6 @@
     },
     "node_modules/set-value": {
       "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/set-value/-/set-value-2.0.1.tgz",
-      "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4122,8 +3455,6 @@
     },
     "node_modules/set-value/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4135,8 +3466,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -4147,8 +3476,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4156,8 +3483,6 @@
     },
     "node_modules/shelljs": {
       "version": "0.10.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.10.0.tgz",
-      "integrity": "sha1-47uumbDz8MxdzgW0ajRvriCQ6IM=",
       "license": "BSD-3-Clause",
       "dependencies": {
         "execa": "^5.1.1",
@@ -4169,21 +3494,15 @@
     },
     "node_modules/sigmund": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
       "license": "ISC"
     },
     "node_modules/snapdragon": {
       "version": "0.8.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/snapdragon/-/snapdragon-0.8.2.tgz",
-      "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4202,8 +3521,6 @@
     },
     "node_modules/snapdragon-node": {
       "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4217,8 +3534,6 @@
     },
     "node_modules/snapdragon-node/node_modules/define-property": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4230,8 +3545,6 @@
     },
     "node_modules/snapdragon-node/node_modules/is-descriptor": {
       "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-descriptor/-/is-descriptor-1.0.3.tgz",
-      "integrity": "sha1-ktJ8s80xHEl3pNtH30VyNKE8swY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4244,8 +3557,6 @@
     },
     "node_modules/snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4257,8 +3568,6 @@
     },
     "node_modules/snapdragon-util/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4270,8 +3579,6 @@
     },
     "node_modules/snapdragon/node_modules/define-property": {
       "version": "0.2.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4283,8 +3590,6 @@
     },
     "node_modules/snapdragon/node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4296,8 +3601,6 @@
     },
     "node_modules/source-map": {
       "version": "0.5.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -4306,9 +3609,6 @@
     },
     "node_modules/source-map-resolve": {
       "version": "0.5.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
-      "integrity": "sha1-GQhmvs51U+H48mei7oLGBrVQmho=",
-      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4321,16 +3621,11 @@
     },
     "node_modules/source-map-url": {
       "version": "0.4.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/source-map-url/-/source-map-url-0.4.1.tgz",
-      "integrity": "sha1-CvZmBadFpaL5HPG7+KevvCg97FY=",
-      "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/sparkles": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sparkles/-/sparkles-1.0.1.tgz",
-      "integrity": "sha1-AI22XtzmxQ7sDF4ijhlFBh3QQ3w=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4339,8 +3634,6 @@
     },
     "node_modules/split-string": {
       "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4352,8 +3645,6 @@
     },
     "node_modules/static-extend": {
       "version": "0.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/static-extend/-/static-extend-0.1.2.tgz",
-      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4366,8 +3657,6 @@
     },
     "node_modules/static-extend/node_modules/define-property": {
       "version": "0.2.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/define-property/-/define-property-0.2.5.tgz",
-      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4379,29 +3668,21 @@
     },
     "node_modules/stream-consume": {
       "version": "0.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/stream-consume/-/stream-consume-0.1.1.tgz",
-      "integrity": "sha1-0721mMK9CugrjKx6xQsRB6eZbEg=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/stream-shift": {
       "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/stream-shift/-/stream-shift-1.0.3.tgz",
-      "integrity": "sha1-hbj6tNcQEPw7qHcugEbMSbijhks=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "0.10.31",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha1-FPja7G2B5yIdKjV+Zoyrc728p5Q=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4419,19 +3700,19 @@
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/string-width-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4440,15 +3721,11 @@
     },
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4460,8 +3737,6 @@
     },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "6.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha1-YCFu6kZNhkWXzigyAAc4oFiWUME=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4473,8 +3748,6 @@
     },
     "node_modules/string-width/node_modules/strip-ansi": {
       "version": "7.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha1-Eyh1q95njH6o1pFTPy5+Irt0Tbo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4489,8 +3762,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4503,17 +3774,17 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4522,8 +3793,6 @@
     },
     "node_modules/strip-bom": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-bom/-/strip-bom-1.0.0.tgz",
-      "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4539,8 +3808,6 @@
     },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4548,8 +3815,6 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4561,8 +3826,6 @@
     },
     "node_modules/supports-color": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4571,8 +3834,6 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4584,8 +3845,6 @@
     },
     "node_modules/temp": {
       "version": "0.8.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/temp/-/temp-0.8.4.tgz",
-      "integrity": "sha1-jJejOkdwBy4KBfkZOWx2ZafdWfI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4597,9 +3856,6 @@
     },
     "node_modules/temp/node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4619,9 +3875,6 @@
     },
     "node_modules/temp/node_modules/rimraf": {
       "version": "2.6.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4633,15 +3886,11 @@
     },
     "node_modules/through": {
       "version": "2.3.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/through2": {
       "version": "2.0.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4651,8 +3900,6 @@
     },
     "node_modules/through2-filter": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/through2-filter/-/through2-filter-3.0.0.tgz",
-      "integrity": "sha1-cA54bfI2fCyIzYqlvkz5weeDElQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4662,15 +3909,11 @@
     },
     "node_modules/through2/node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/through2/node_modules/readable-stream": {
       "version": "2.3.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha1-kRJegEK7obmIf0k0X2J3Anzovps=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4685,8 +3928,6 @@
     },
     "node_modules/through2/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4695,8 +3936,6 @@
     },
     "node_modules/tildify": {
       "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tildify/-/tildify-1.2.0.tgz",
-      "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4708,8 +3947,6 @@
     },
     "node_modules/time-stamp": {
       "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/time-stamp/-/time-stamp-1.1.0.tgz",
-      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4718,16 +3955,11 @@
     },
     "node_modules/to-iso-string": {
       "version": "0.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-iso-string/-/to-iso-string-0.0.2.tgz",
-      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
-      "deprecated": "to-iso-string has been deprecated, use @segment/to-iso-string instead.",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/to-object-path": {
       "version": "0.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-object-path/-/to-object-path-0.3.0.tgz",
-      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4739,8 +3971,6 @@
     },
     "node_modules/to-object-path/node_modules/kind-of": {
       "version": "3.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4752,8 +3982,6 @@
     },
     "node_modules/to-regex": {
       "version": "3.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-regex/-/to-regex-3.0.2.tgz",
-      "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4768,8 +3996,6 @@
     },
     "node_modules/to-regex-range": {
       "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4782,8 +4008,6 @@
     },
     "node_modules/typescript": {
       "version": "1.8.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-1.8.10.tgz",
-      "integrity": "sha1-tHXW4N/wv1DyluXKbvn7tccyDx4=",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -4797,8 +4021,6 @@
     },
     "node_modules/unc-path-regex": {
       "version": "0.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4807,8 +4029,6 @@
     },
     "node_modules/union-value": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/union-value/-/union-value-1.0.1.tgz",
-      "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4823,15 +4043,11 @@
     },
     "node_modules/unique-stream": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/unique-stream/-/unique-stream-1.0.0.tgz",
-      "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
       "dev": true,
       "license": "BSD"
     },
     "node_modules/unset-value": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/unset-value/-/unset-value-1.0.0.tgz",
-      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4844,8 +4060,6 @@
     },
     "node_modules/unset-value/node_modules/has-value": {
       "version": "0.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-value/-/has-value-0.3.1.tgz",
-      "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4859,8 +4073,6 @@
     },
     "node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
       "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4872,8 +4084,6 @@
     },
     "node_modules/unset-value/node_modules/has-values": {
       "version": "0.1.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-values/-/has-values-0.1.4.tgz",
-      "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4882,23 +4092,16 @@
     },
     "node_modules/unset-value/node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/urix": {
       "version": "0.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-      "deprecated": "Please see https://github.com/lydell/urix#deprecated",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/use": {
       "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/use/-/use-3.1.1.tgz",
-      "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4907,8 +4110,6 @@
     },
     "node_modules/user-home": {
       "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/user-home/-/user-home-1.1.1.tgz",
-      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4920,15 +4121,11 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/v8flags": {
       "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/v8flags/-/v8flags-2.1.1.tgz",
-      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "dev": true,
       "dependencies": {
         "user-home": "^1.1.1"
@@ -4939,8 +4136,6 @@
     },
     "node_modules/vinyl": {
       "version": "0.5.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/vinyl/-/vinyl-0.5.3.tgz",
-      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4954,8 +4149,6 @@
     },
     "node_modules/vinyl-fs": {
       "version": "0.3.14",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-      "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
       "dev": true,
       "dependencies": {
         "defaults": "^1.0.0",
@@ -4973,18 +4166,38 @@
     },
     "node_modules/vinyl-fs/node_modules/clone": {
       "version": "0.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/clone/-/clone-0.2.0.tgz",
-      "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
+    "node_modules/vinyl-fs/node_modules/minimist": {
+      "version": "0.2.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha1-AIXVUB4pAzdIovKk2gGAFCaXpHU=",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/vinyl-fs/node_modules/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/vinyl-fs/node_modules/readable-stream": {
       "version": "1.0.34",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4996,8 +4209,6 @@
     },
     "node_modules/vinyl-fs/node_modules/through2": {
       "version": "0.6.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5007,8 +4218,6 @@
     },
     "node_modules/vinyl-fs/node_modules/vinyl": {
       "version": "0.4.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/vinyl/-/vinyl-0.4.6.tgz",
-      "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
       "dev": true,
       "dependencies": {
         "clone": "^0.2.0",
@@ -5020,8 +4229,6 @@
     },
     "node_modules/which": {
       "version": "1.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/which/-/which-1.3.1.tgz",
-      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5033,15 +4240,11 @@
     },
     "node_modules/workerpool": {
       "version": "9.3.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/workerpool/-/workerpool-9.3.4.tgz",
-      "integrity": "sha1-9skjlbIUGv144qiJ6AyzOP6fykE=",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha1-VtwiNo7lcPrOG0mBmXXZuaXq0hQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5059,19 +4262,22 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5080,8 +4286,6 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5096,15 +4300,11 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5118,8 +4318,6 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5131,8 +4329,6 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha1-YCFu6kZNhkWXzigyAAc4oFiWUME=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5144,8 +4340,6 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "6.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha1-wETV3MUhoHZBNHJZehrLHxA8QEE=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5157,8 +4351,6 @@
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "7.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha1-Eyh1q95njH6o1pFTPy5+Irt0Tbo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5173,15 +4365,11 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/xtend": {
       "version": "4.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5190,8 +4378,6 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -5200,8 +4386,6 @@
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha1-mR3zmspnWhkrgW4eA2P5110qomk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5219,8 +4403,6 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha1-kJa87r+ZDSG7MfqVFuDt4pSnfTU=",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -5229,8 +4411,6 @@
     },
     "node_modules/yargs-unparser": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-      "integrity": "sha1-8TH5ImkRrl2a04xDL+gJNmwjJes=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5245,8 +4425,6 @@
     },
     "node_modules/yargs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5255,15 +4433,11 @@
     },
     "node_modules/yargs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5277,8 +4451,6 @@
     },
     "node_modules/yargs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5290,8 +4462,6 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/Extensions/Common/lib/vsts-task-lib/package.json
+++ b/Extensions/Common/lib/vsts-task-lib/package.json
@@ -36,6 +36,12 @@
     "minimatch": "3.1.5",
     "mocha": "^11.7.5"
   },
+  "overrides": {
+    "minimist": "0.2.4",
+    "mkdirp@0.5.1": {
+      "minimist": "0.2.4"
+    }
+  },
   "readme": "# Team Services DevOps Task SDK\n\nLibraries for writing Team Services and TFS build and deployment tasks\n\n## Node Task Lib\nLibrary for writing tasks with the node handler\n\n## Contributing\n\n### Node\n\nOnce:\n```bash\n$ cd node\n$ npm install\n$ sudo npm install gulp -g\n```\n\nBuild and test:\n```bash\n$ cd node\n$ gulp\n```\n\n### Powershell\n\nComing soon\n",
   "readmeFilename": "README.md",
   "_id": "vsts-task-lib@0.4.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2452,6 +2452,30 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/fstream/node_modules/minimist": {
+      "version": "0.2.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha1-AIXVUB4pAzdIovKk2gGAFCaXpHU=",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fstream/node_modules/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "0.2.4"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
@@ -3197,9 +3221,9 @@
       }
     },
     "node_modules/gulp-mocha/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "0.2.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3211,7 +3235,7 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.4"
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -4770,19 +4794,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/mockery": {
@@ -9076,7 +9087,6 @@
       "integrity": "sha1-CVl5+bzA0J2jJNWNA86Pg3TL5lo=",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     "mocha@5.2.0": {
       "minimatch": "3.1.5"
     },
+    "mkdirp@0.5.1": {
+      "minimist": "0.2.4"
+    },
     "vsts-task-lib": {
       "minimatch": "3.1.5"
     },


### PR DESCRIPTION
**Description**: Fixes governed repo finding for CVE-2021-44906 (prototype pollution in minimist) by forcing transitive minimist resolution away from 0.0.8 to 0.2.4. Implemented npm overrides and regenerated lockfiles so future npm install/lockfile regeneration keeps the fix. Verified npm install and gulp build succeed.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N Governed repositories alert: CVE-2021-44906 (minimist via gulp-mocha)

**Checklist**:
- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
