### PR TITLE
fix(security): upgrade handlebars to 4.7.9 

### DIFF
--- a/Extensions/ArtifactEngine/package-lock.json
+++ b/Extensions/ArtifactEngine/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.2.8",
-        "handlebars": "4.7.7",
+        "handlebars": "4.7.9",
         "minimatch": "3.1.5",
         "tunnel": "0.0.4"
       },
@@ -75,7 +75,6 @@
       "integrity": "sha1-VdrYCNW/NEWhCO78iOo/3wNHSaQ=",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -890,7 +889,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -1724,13 +1722,13 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha1-nOM0FqrQLb1sj6+oJA1dmABJRaE=",
+      "version": "4.7.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha1-bxOQgqtY3E5aDlHv59ta6JDVag8=",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
+        "neo-async": "^2.6.2",
         "source-map": "^0.6.1",
         "wordwrap": "^1.0.0"
       },

--- a/Extensions/ArtifactEngine/package.json
+++ b/Extensions/ArtifactEngine/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "azure-pipelines-task-lib": "^5.2.8",
-    "handlebars": "4.7.7",
+    "handlebars": "4.7.9",
     "minimatch": "3.1.5",
     "tunnel": "0.0.4"
   },

--- a/Extensions/ArtifactEngine/package.json
+++ b/Extensions/ArtifactEngine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "1.271.1",
+  "version": "1.272.0",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",

--- a/Extensions/ArtifactEngineV2/package-lock.json
+++ b/Extensions/ArtifactEngineV2/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.2.8",
-        "handlebars": "4.7.7",
+        "handlebars": "4.7.9",
         "hash-wasm": "^4.12.0",
         "minimatch": "^10.0.1",
         "tunnel": "0.0.4"
@@ -1478,13 +1478,13 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "version": "4.7.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha1-bxOQgqtY3E5aDlHv59ta6JDVag8=",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
+        "neo-async": "^2.6.2",
         "source-map": "^0.6.1",
         "wordwrap": "^1.0.0"
       },

--- a/Extensions/ArtifactEngineV2/package.json
+++ b/Extensions/ArtifactEngineV2/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "azure-pipelines-task-lib": "^5.2.8",
-    "handlebars": "4.7.7",
+    "handlebars": "4.7.9",
     "hash-wasm": "^4.12.0",
     "minimatch": "^10.0.1",
     "tunnel": "0.0.4"

--- a/Extensions/ArtifactEngineV2/package.json
+++ b/Extensions/ArtifactEngineV2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "2.272.0",
+  "version": "2.272.1",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",

--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package-lock.json
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package-lock.json
@@ -8,14 +8,14 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "^6.14.13",
-        "artifact-engine": "file:../../../../ArtifactEngine",
+        "artifact-engine": "^1.271.1",
         "azure-pipelines-task-lib": "^5.2.8",
         "underscore": "1.13.8"
       }
     },
     "../../../../ArtifactEngine": {
       "name": "artifact-engine",
-      "version": "1.271.1",
+      "version": "1.272.0",
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.2.8",

--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package-lock.json
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package-lock.json
@@ -8,9 +8,35 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "^6.14.13",
-        "artifact-engine": "^1.271.1",
+        "artifact-engine": "file:../../../../ArtifactEngine",
         "azure-pipelines-task-lib": "^5.2.8",
         "underscore": "1.13.8"
+      }
+    },
+    "../../../../ArtifactEngine": {
+      "name": "artifact-engine",
+      "version": "1.271.1",
+      "license": "MIT",
+      "dependencies": {
+        "azure-pipelines-task-lib": "^5.2.8",
+        "handlebars": "4.7.9",
+        "minimatch": "3.1.5",
+        "tunnel": "0.0.4"
+      },
+      "devDependencies": {
+        "@types/minimatch": "^2.0.29",
+        "@types/mocha": "^10.0.10",
+        "@types/node": "^10.17.0",
+        "@types/xml2js": "^0.4.8",
+        "assert": "1.4.1",
+        "mocha": "^11.7.5",
+        "mocha-tap-reporter": "0.1.3",
+        "nconf": "^0.12.0",
+        "nock": "9.1.0",
+        "nyc": "^15.0.0",
+        "sinon": "4.0.1",
+        "typescript": "4.0.2",
+        "xml2js": "^0.6.2"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -76,16 +102,8 @@
       }
     },
     "node_modules/artifact-engine": {
-      "version": "1.271.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/artifact-engine/-/artifact-engine-1.271.1.tgz",
-      "integrity": "sha1-YYyVEf2JccgJRiBjcXmeZgDozQc=",
-      "license": "MIT",
-      "dependencies": {
-        "azure-pipelines-task-lib": "^5.2.8",
-        "handlebars": "4.7.7",
-        "minimatch": "3.1.5",
-        "tunnel": "0.0.4"
-      }
+      "resolved": "../../../../ArtifactEngine",
+      "link": true
     },
     "node_modules/azure-pipelines-task-lib": {
       "version": "5.2.8",
@@ -271,27 +289,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha1-nOM0FqrQLb1sj6+oJA1dmABJRaE=",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -432,25 +429,10 @@
         "node": "*"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
-      "license": "MIT"
-    },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
       "license": "MIT"
     },
     "node_modules/nodejs-file-downloader": {
@@ -635,15 +617,6 @@
       "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
       "license": "ISC"
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -672,28 +645,6 @@
       "license": "WTFPL",
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
-      }
-    },
-    "node_modules/tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
-    "node_modules/uglify-js": {
-      "version": "3.19.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uglify-js/-/uglify-js-3.19.3.tgz",
-      "integrity": "sha1-gjFem7xvKyWIiFis0f/4RBA1t38=",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/underscore": {
@@ -732,12 +683,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "license": "MIT"
     }
   }
 }

--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package.json
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "dependencies": {
     "@types/node": "^6.14.13",
-    "artifact-engine": "^1.271.1",
+    "artifact-engine": "file:../../../../ArtifactEngine",
     "azure-pipelines-task-lib": "^5.2.8",
     "underscore": "1.13.8"
   }

--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package.json
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package.json
@@ -4,8 +4,13 @@
   "license": "MIT",
   "dependencies": {
     "@types/node": "^6.14.13",
-    "artifact-engine": "file:../../../../ArtifactEngine",
+    "artifact-engine": "^1.271.1",
     "azure-pipelines-task-lib": "^5.2.8",
     "underscore": "1.13.8"
+  },
+  "overrides": {
+    "artifact-engine": {
+      "handlebars": "4.7.9"
+    }
   }
 }

--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/task.json
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/task.json
@@ -10,7 +10,7 @@
     "version": {
       "Major": 0,
       "Minor": 272,
-      "Patch": 0
+      "Patch": 1
     },
     "demands": [],
     "inputs": [

--- a/Extensions/CircleCI/Src/vss-extension.json
+++ b/Extensions/CircleCI/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-circleci-extension",
   "name": "CircleCI artifacts for Release Pipeline",
   "publisher": "ms-vscs-rm",
-  "version": "0.272.0",
+  "version": "0.272.1",
   "public": true,
   "description": "Tool for connecting with CircleCI",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
@@ -7,7 +7,7 @@
       "name": "DownloadExternalBuildArtifacts",
       "dependencies": {
         "@azure/msal-node": "^3.7.3",
-        "artifact-engine": "file:../../../../ArtifactEngine",
+        "artifact-engine": "^1.271.1",
         "azure-devops-node-api": "14.1.0",
         "azure-pipelines-task-lib": "^5.2.8",
         "azure-pipelines-tasks-azure-arm-rest": "^3.267.0"
@@ -18,7 +18,7 @@
     },
     "../../../../ArtifactEngine": {
       "name": "artifact-engine",
-      "version": "1.271.1",
+      "version": "1.272.0",
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.2.8",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
@@ -7,13 +7,39 @@
       "name": "DownloadExternalBuildArtifacts",
       "dependencies": {
         "@azure/msal-node": "^3.7.3",
-        "artifact-engine": "^1.271.1",
+        "artifact-engine": "file:../../../../ArtifactEngine",
         "azure-devops-node-api": "14.1.0",
         "azure-pipelines-task-lib": "^5.2.8",
         "azure-pipelines-tasks-azure-arm-rest": "^3.267.0"
       },
       "devDependencies": {
         "typescript": "5.1.6"
+      }
+    },
+    "../../../../ArtifactEngine": {
+      "name": "artifact-engine",
+      "version": "1.271.1",
+      "license": "MIT",
+      "dependencies": {
+        "azure-pipelines-task-lib": "^5.2.8",
+        "handlebars": "4.7.9",
+        "minimatch": "3.1.5",
+        "tunnel": "0.0.4"
+      },
+      "devDependencies": {
+        "@types/minimatch": "^2.0.29",
+        "@types/mocha": "^10.0.10",
+        "@types/node": "^10.17.0",
+        "@types/xml2js": "^0.4.8",
+        "assert": "1.4.1",
+        "mocha": "^11.7.5",
+        "mocha-tap-reporter": "0.1.3",
+        "nconf": "^0.12.0",
+        "nock": "9.1.0",
+        "nyc": "^15.0.0",
+        "sinon": "4.0.1",
+        "typescript": "4.0.2",
+        "xml2js": "^0.6.2"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -294,16 +320,8 @@
       }
     },
     "node_modules/artifact-engine": {
-      "version": "1.271.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/artifact-engine/-/artifact-engine-1.271.1.tgz",
-      "integrity": "sha1-YYyVEf2JccgJRiBjcXmeZgDozQc=",
-      "license": "MIT",
-      "dependencies": {
-        "azure-pipelines-task-lib": "^5.2.8",
-        "handlebars": "4.7.7",
-        "minimatch": "3.1.5",
-        "tunnel": "0.0.4"
-      }
+      "resolved": "../../../../ArtifactEngine",
+      "link": true
     },
     "node_modules/async-mutex": {
       "version": "0.4.1",
@@ -911,27 +929,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha1-nOM0FqrQLb1sj6+oJA1dmABJRaE=",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -1278,25 +1275,10 @@
         "node": "*"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
-      "license": "MIT"
-    },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
       "license": "MIT"
     },
     "node_modules/node-fetch": {
@@ -1662,15 +1644,6 @@
       "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
       "license": "ISC"
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -1713,15 +1686,6 @@
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "license": "0BSD"
     },
-    "node_modules/tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
     "node_modules/typed-rest-client": {
       "version": "2.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
@@ -1759,19 +1723,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/uglify-js": {
-      "version": "3.19.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uglify-js/-/uglify-js-3.19.3.tgz",
-      "integrity": "sha1-gjFem7xvKyWIiFis0f/4RBA1t38=",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/underscore": {
@@ -1825,12 +1776,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "license": "MIT"
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
@@ -3,7 +3,7 @@
   "main": "download.js",
   "dependencies": {
     "@azure/msal-node": "^3.7.3",
-    "artifact-engine": "file:../../../../ArtifactEngine",
+    "artifact-engine": "^1.271.1",
     "azure-devops-node-api": "14.1.0",
     "azure-pipelines-task-lib": "^5.2.8",
     "azure-pipelines-tasks-azure-arm-rest": "^3.267.0"
@@ -12,6 +12,9 @@
     "typescript": "5.1.6"
   },
   "overrides": {
-    "underscore": "1.13.8"
+    "underscore": "1.13.8",
+    "artifact-engine": {
+      "handlebars": "4.7.9"
+    }
   }
 }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
@@ -3,7 +3,7 @@
   "main": "download.js",
   "dependencies": {
     "@azure/msal-node": "^3.7.3",
-    "artifact-engine": "^1.271.1",
+    "artifact-engine": "file:../../../../ArtifactEngine",
     "azure-devops-node-api": "14.1.0",
     "azure-pipelines-task-lib": "^5.2.8",
     "azure-pipelines-tasks-azure-arm-rest": "^3.267.0"

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 16,
     "Minor": 272,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 ﻿﻿{
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.272.0",
+  "version": "16.272.1",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package-lock.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package-lock.json
@@ -6,14 +6,14 @@
     "": {
       "name": "DownloadTeamCityArtifacts",
       "dependencies": {
-        "artifact-engine": "file:../../../../ArtifactEngine",
+        "artifact-engine": "^1.271.1",
         "azure-pipelines-task-lib": "^5.2.8",
         "underscore": "^1.13.8"
       }
     },
     "../../../../ArtifactEngine": {
       "name": "artifact-engine",
-      "version": "1.271.1",
+      "version": "1.272.0",
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.2.8",

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package-lock.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package-lock.json
@@ -6,9 +6,35 @@
     "": {
       "name": "DownloadTeamCityArtifacts",
       "dependencies": {
-        "artifact-engine": "^1.271.1",
+        "artifact-engine": "file:../../../../ArtifactEngine",
         "azure-pipelines-task-lib": "^5.2.8",
         "underscore": "^1.13.8"
+      }
+    },
+    "../../../../ArtifactEngine": {
+      "name": "artifact-engine",
+      "version": "1.271.1",
+      "license": "MIT",
+      "dependencies": {
+        "azure-pipelines-task-lib": "^5.2.8",
+        "handlebars": "4.7.9",
+        "minimatch": "3.1.5",
+        "tunnel": "0.0.4"
+      },
+      "devDependencies": {
+        "@types/minimatch": "^2.0.29",
+        "@types/mocha": "^10.0.10",
+        "@types/node": "^10.17.0",
+        "@types/xml2js": "^0.4.8",
+        "assert": "1.4.1",
+        "mocha": "^11.7.5",
+        "mocha-tap-reporter": "0.1.3",
+        "nconf": "^0.12.0",
+        "nock": "9.1.0",
+        "nyc": "^15.0.0",
+        "sinon": "4.0.1",
+        "typescript": "4.0.2",
+        "xml2js": "^0.6.2"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -68,16 +94,8 @@
       }
     },
     "node_modules/artifact-engine": {
-      "version": "1.271.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/artifact-engine/-/artifact-engine-1.271.1.tgz",
-      "integrity": "sha1-YYyVEf2JccgJRiBjcXmeZgDozQc=",
-      "license": "MIT",
-      "dependencies": {
-        "azure-pipelines-task-lib": "^5.2.8",
-        "handlebars": "4.7.7",
-        "minimatch": "3.1.5",
-        "tunnel": "0.0.4"
-      }
+      "resolved": "../../../../ArtifactEngine",
+      "link": true
     },
     "node_modules/azure-pipelines-task-lib": {
       "version": "5.2.8",
@@ -263,27 +281,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha1-nOM0FqrQLb1sj6+oJA1dmABJRaE=",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -424,25 +421,10 @@
         "node": "*"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
-      "license": "MIT"
-    },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
       "license": "MIT"
     },
     "node_modules/nodejs-file-downloader": {
@@ -627,15 +609,6 @@
       "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
       "license": "ISC"
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -664,28 +637,6 @@
       "license": "WTFPL",
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
-      }
-    },
-    "node_modules/tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
-    "node_modules/uglify-js": {
-      "version": "3.19.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uglify-js/-/uglify-js-3.19.3.tgz",
-      "integrity": "sha1-gjFem7xvKyWIiFis0f/4RBA1t38=",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/underscore": {
@@ -724,12 +675,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "license": "MIT"
     }
   }
 }

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package.json
@@ -2,8 +2,13 @@
   "name": "DownloadTeamCityArtifacts",
   "main": "download.js",
   "dependencies": {
-    "artifact-engine": "file:../../../../ArtifactEngine",
+    "artifact-engine": "^1.271.1",
     "azure-pipelines-task-lib": "^5.2.8",
     "underscore": "^1.13.8"
+  },
+  "overrides": {
+    "artifact-engine": {
+      "handlebars": "4.7.9"
+    }
   }
 }

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package.json
@@ -2,7 +2,7 @@
   "name": "DownloadTeamCityArtifacts",
   "main": "download.js",
   "dependencies": {
-    "artifact-engine": "^1.271.1",
+    "artifact-engine": "file:../../../../ArtifactEngine",
     "azure-pipelines-task-lib": "^5.2.8",
     "underscore": "^1.13.8"
   }

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 15,
     "Minor": 272,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.272.0",
+  "version": "15.272.1",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",


### PR DESCRIPTION
**Description**: Upgraded handlebars to 4.7.9 to address the Handlebars CLI precompiler code-injection vulnerabilities flagged by CVE-2026-33937/33938/33939/33940/33941. Updated the affected dependency manifests/lockfiles and regenerated build outputs so packaged task dependencies no longer include handlebars@4.7.7.

**Documentation changes required:** (N) No user-facing behavior changes; dependency/security update only.

**Added unit tests:** (N) No functional code paths changed; dependency-only update.

**Attached related issue:** (N)

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
