### PR TITLE
Pin picomatch to 2.3.2 via npm overrides to address CVE-2026-33671.

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
@@ -571,9 +571,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+      "version": "2.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/Extensions/Ansible/Src/Tasks/Ansible/package.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package.json
@@ -16,7 +16,8 @@
     "vso-node-api": "6.0.1-preview"
   },
   "overrides": {
-    "underscore": "1.13.8"
+    "underscore": "1.13.8",
+    "picomatch": "2.3.2"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 272,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "instanceNameFormat": "Run playbook",

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 272,
-        "Patch": 1
+        "Minor": 273,
+        "Patch": 0
     },
     "demands": [],
     "instanceNameFormat": "Run playbook",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.272.0",
+  "version": "0.272.1",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.272.1",
+  "version": "0.273.0",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/ArtifactEngine/package-lock.json
+++ b/Extensions/ArtifactEngine/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-engine",
-  "version": "1.271.1",
+  "version": "1.272.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-engine",
-      "version": "1.271.1",
+      "version": "1.272.0",
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.2.8",
@@ -3264,9 +3264,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+      "version": "2.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/Extensions/ArtifactEngine/package.json
+++ b/Extensions/ArtifactEngine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "1.272.0",
+  "version": "1.272.1",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",
@@ -22,7 +22,8 @@
     "tunnel": "0.0.4"
   },
   "overrides": {
-    "minimatch": "3.1.5"
+    "minimatch": "3.1.5",
+    "picomatch": "2.3.2"
   },
   "devDependencies": {
     "@types/minimatch": "^2.0.29",

--- a/Extensions/ArtifactEngine/package.json
+++ b/Extensions/ArtifactEngine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "1.272.1",
+  "version": "1.273.0",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",

--- a/Extensions/ArtifactEngineV2/package-lock.json
+++ b/Extensions/ArtifactEngineV2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-engine",
-  "version": "2.272.0",
+  "version": "2.272.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-engine",
-      "version": "2.272.0",
+      "version": "2.272.1",
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.2.8",

--- a/Extensions/ArtifactEngineV2/package.json
+++ b/Extensions/ArtifactEngineV2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "2.272.1",
+  "version": "2.272.2",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",
@@ -21,6 +21,9 @@
     "hash-wasm": "^4.12.0",
     "minimatch": "^10.0.1",
     "tunnel": "0.0.4"
+  },
+  "overrides": {
+    "picomatch": "2.3.2"
   },
   "devDependencies": {
     "@types/minimatch": "^5.1.2",

--- a/Extensions/ArtifactEngineV2/package.json
+++ b/Extensions/ArtifactEngineV2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "2.272.2",
+  "version": "2.273.0",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package-lock.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package-lock.json
@@ -445,9 +445,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+      "version": "2.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -882,7 +882,7 @@
       "integrity": "sha1-1m+hjzpHB2eJMgubGvMr2G2fogI=",
       "requires": {
         "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
+        "picomatch": "2.3.2"
       }
     },
     "mime-db": {
@@ -949,9 +949,9 @@
       "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U="
     },
     "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI="
+      "version": "2.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE="
     },
     "q": {
       "version": "1.5.1",

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package.json
@@ -6,6 +6,7 @@
     "vso-node-api": "6.0.1-preview"
   },
   "overrides": {
-    "underscore": "1.13.8"
+    "underscore": "1.13.8",
+    "picomatch": "2.3.2"
   }
 }

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
@@ -13,8 +13,8 @@
   "demands": [],
   "version": {
     "Major": 15,
-    "Minor": 272,
-    "Patch": 1
+    "Minor": 273,
+    "Patch": 0
   },
   "minimumAgentVersion": "1.99.0",
   "instanceNameFormat": "Download Artifacts - Bitbucket",

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 15,
     "Minor": 272,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "1.99.0",
   "instanceNameFormat": "Download Artifacts - Bitbucket",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.272.0",
+  "version": "15.272.1",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.272.1",
+  "version": "15.273.0",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package-lock.json
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package-lock.json
@@ -484,9 +484,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+      "version": "2.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package.json
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package.json
@@ -11,6 +11,7 @@
   "overrides": {
     "artifact-engine": {
       "handlebars": "4.7.9"
-    }
+    },
+    "picomatch": "2.3.2"
   }
 }

--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/task.json
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/task.json
@@ -9,8 +9,8 @@
     "preview": true,
     "version": {
       "Major": 0,
-      "Minor": 272,
-      "Patch": 2
+      "Minor": 273,
+      "Patch": 0
     },
     "demands": [],
     "inputs": [

--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/task.json
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/task.json
@@ -10,7 +10,7 @@
     "version": {
       "Major": 0,
       "Minor": 272,
-      "Patch": 1
+      "Patch": 2
     },
     "demands": [],
     "inputs": [

--- a/Extensions/CircleCI/Src/vss-extension.json
+++ b/Extensions/CircleCI/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-circleci-extension",
   "name": "CircleCI artifacts for Release Pipeline",
   "publisher": "ms-vscs-rm",
-  "version": "0.272.2",
+  "version": "0.273.0",
   "public": true,
   "description": "Tool for connecting with CircleCI",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/CircleCI/Src/vss-extension.json
+++ b/Extensions/CircleCI/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-circleci-extension",
   "name": "CircleCI artifacts for Release Pipeline",
   "publisher": "ms-vscs-rm",
-  "version": "0.272.1",
+  "version": "0.272.2",
   "public": true,
   "description": "Tool for connecting with CircleCI",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/Common/lib/vsts-task-lib/package-lock.json
+++ b/Extensions/Common/lib/vsts-task-lib/package-lock.json
@@ -3152,7 +3152,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/Extensions/Common/lib/vsts-task-lib/package.json
+++ b/Extensions/Common/lib/vsts-task-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-lib",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Team Services Agent Task Library",
   "main": "./task.js",
   "scripts": {
@@ -38,6 +38,7 @@
   },
   "overrides": {
     "minimist": "0.2.4",
+    "picomatch": "2.3.2",
     "mkdirp@0.5.1": {
       "minimist": "0.2.4"
     }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
@@ -1373,9 +1373,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+      "version": "2.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
@@ -8,6 +8,7 @@
     "azure-pipelines-tasks-azure-arm-rest": "^3.267.0"
   },
   "overrides": {
-    "underscore": "1.13.8"
+    "underscore": "1.13.8",
+    "picomatch": "2.3.2"
   }
 }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 16,
     "Minor": 272,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "Download Artifacts - External TFS Git",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
@@ -13,8 +13,8 @@
   "demands": [],
   "version": {
     "Major": 16,
-    "Minor": 272,
-    "Patch": 1
+    "Minor": 273,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "Download Artifacts - External TFS Git",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/package-lock.json
@@ -868,9 +868,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+      "version": "2.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/package.json
@@ -8,6 +8,7 @@
     "shelljs": "^0.10.0"
   },
   "overrides": {
-    "underscore": "1.13.8"
+    "underscore": "1.13.8",
+    "picomatch": "2.3.2"
   }
 }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 15,
     "Minor": 272,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "1.99.0",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/task.json
@@ -12,8 +12,8 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 15,
-    "Minor": 272,
-    "Patch": 1
+    "Minor": 273,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "1.99.0",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
@@ -1380,9 +1380,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+      "version": "2.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
@@ -15,6 +15,7 @@
     "underscore": "1.13.8",
     "artifact-engine": {
       "handlebars": "4.7.9"
-    }
+    },
+    "picomatch": "2.3.2"
   }
 }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 16,
     "Minor": 272,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
@@ -8,8 +8,8 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 16,
-    "Minor": 272,
-    "Patch": 2
+    "Minor": 273,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 ﻿﻿{
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.272.1",
+  "version": "16.272.2",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 ﻿﻿{
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.272.2",
+  "version": "16.273.0",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package-lock.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package-lock.json
@@ -476,9 +476,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+      "version": "2.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package.json
@@ -9,6 +9,7 @@
   "overrides": {
     "artifact-engine": {
       "handlebars": "4.7.9"
-    }
+    },
+    "picomatch": "2.3.2"
   }
 }

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 15,
     "Minor": 272,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
@@ -8,8 +8,8 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 15,
-    "Minor": 272,
-    "Patch": 2
+    "Minor": 273,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.272.1",
+  "version": "15.272.2",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.272.2",
+  "version": "15.273.0",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -257,8 +257,11 @@ gulp.task("compileNode", gulp.series("compilePS", function(cb){
     }
 
     // Compile UIExtensions
-    fs.readdirSync( path.join(__dirname, 'Extensions/')).filter(function (file) {
-        return fs.statSync(path.join(_extnBuildRoot, file)).isDirectory() && file != "Common";
+    // Note: when running with --testAreaPath, only a subset of extensions are copied into _build.
+    // Guard against missing directories so scoped builds don't fail.
+    fs.readdirSync(path.join(__dirname, 'Extensions/')).filter(function (file) {
+        var buildExtensionPath = path.join(_extnBuildRoot, file);
+        return fs.existsSync(buildExtensionPath) && fs.statSync(buildExtensionPath).isDirectory() && file != "Common";
     }).forEach(compileUIExtensions);
 
     //Foreach task under extensions copy common modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -4483,7 +4483,9 @@
       "license": "MIT"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "shell-quote": "^1.8.2"
   },
   "overrides": {
+    "picomatch": "2.3.2",
     "qs": "6.14.1",
     "mocha@5.2.0": {
       "minimatch": "3.1.5"


### PR DESCRIPTION
**Description**:
Pinned picomatch to 2.3.2 to address CVE-2026-33671 (ReDoS in crafted extglob patterns). 
This is enforced via npm overrides in the affected extensions, tasks, and libs, and the corresponding files were regenerated. 
Build outputs were refreshed so pipeline-scanned artifacts no longer include picomatch 2.3.1. 

This change also prevents the build from failing when running a scoped build by skipping extension folders that aren’t copied into
_build. 
**Example :** npx gulp build --testAreaPath=ArtifactEngine,ArtifactEngineV2,

**Documentation changes required:** (Y/N) **(N)** No user-facing documentation needed; dependency/security update only.

**Added unit tests:** (Y/N) **(N)** No functional code paths changed; dependency pin + build-script robustness.

**Attached related issue:** (Y/N) **(N)**

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [ ] Checked that applied changes work as expected.
