### PR TITLE
Fix CG alert: Update azure-pipelines-tasks-azure-arm-rest to 3.272.1 in DownloadArtifactsTfsGit

### DIFF
--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
@@ -9,7 +9,7 @@
         "@azure/msal-node": "^2.7.0",
         "azure-devops-node-api": "14.1.0",
         "azure-pipelines-task-lib": "^5.2.8",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.267.0"
+        "azure-pipelines-tasks-azure-arm-rest": "^3.272.1"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.22.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.2.tgz",
-      "integrity": "sha1-fhTyHSWrYnzQdnattdmqzY4ulcw=",
+      "version": "1.23.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+      "integrity": "sha1-NfFuHBgMqVRcJgrBJLdRvh2pwIw=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
@@ -67,7 +67,7 @@
         "@azure/core-tracing": "^1.3.0",
         "@azure/core-util": "^1.13.0",
         "@azure/logger": "^1.3.0",
-        "@typespec/ts-http-runtime": "^0.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@azure/identity": {
-      "version": "4.13.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/identity/-/identity-4.13.0.tgz",
-      "integrity": "sha1-sr5jZGlkq1ng3A6tyo5PVi/DH5Y=",
+      "version": "4.13.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha1-vcCRZYuqWaR+6furSHpLsBhym8M=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
@@ -113,8 +113,8 @@
         "@azure/core-tracing": "^1.0.0",
         "@azure/core-util": "^1.11.0",
         "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^4.2.0",
-        "@azure/msal-node": "^3.5.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
         "open": "^10.1.0",
         "tslib": "^2.2.0"
       },
@@ -123,26 +123,26 @@
       }
     },
     "node_modules/@azure/identity/node_modules/@azure/msal-common": {
-      "version": "15.13.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-15.13.3.tgz",
-      "integrity": "sha1-4TKach9HPxylRm/Q1nVuTCrGj1I=",
+      "version": "16.4.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-16.4.1.tgz",
+      "integrity": "sha1-HVDFiCd6yXqCMZEwIyP8YMmoNXQ=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/identity/node_modules/@azure/msal-node": {
-      "version": "3.8.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-3.8.4.tgz",
-      "integrity": "sha1-98CCsuISIUjMNiT65YPyZDuBeI4=",
+      "version": "5.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-5.1.2.tgz",
+      "integrity": "sha1-FeqtaVmWayqII0+1aJLXuNavnWI=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.13.3",
+        "@azure/msal-common": "16.4.1",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       }
     },
     "node_modules/@azure/logger": {
@@ -159,21 +159,21 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "4.27.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-browser/-/msal-browser-4.27.0.tgz",
-      "integrity": "sha1-ZAVOYCs/sKuiVjIH+rUnhmlAOXs=",
+      "version": "5.6.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-browser/-/msal-browser-5.6.3.tgz",
+      "integrity": "sha1-3JC+l9ChwY28kyDp5n7cMpaXfqk=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.13.3"
+        "@azure/msal-common": "16.4.1"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
-      "version": "15.13.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-15.13.3.tgz",
-      "integrity": "sha1-4TKach9HPxylRm/Q1nVuTCrGj1I=",
+      "version": "16.4.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-16.4.1.tgz",
+      "integrity": "sha1-HVDFiCd6yXqCMZEwIyP8YMmoNXQ=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -265,9 +265,9 @@
       "license": "MIT"
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.2.tgz",
-      "integrity": "sha1-EEjfYYKwK+yJYqnP/Rxe4aEpVB8=",
+      "version": "0.3.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.4.tgz",
+      "integrity": "sha1-xfI26lkkyFrY/5bWDs3woiWFQRw=",
       "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^7.0.0",
@@ -369,12 +369,12 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.271.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.271.2.tgz",
-      "integrity": "sha1-lK3Yaxn+x7CSUHpaTdub8HQqPlU=",
+      "version": "3.272.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.272.1.tgz",
+      "integrity": "sha1-+3XFJlvgCjHjcKKNSOqBvJBiciE=",
       "license": "MIT",
       "dependencies": {
-        "@azure/identity": "^4.2.1",
+        "@azure/identity": "^4.13.1",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -582,9 +582,9 @@
       }
     },
     "node_modules/default-browser": {
-      "version": "5.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/default-browser/-/default-browser-5.4.0.tgz",
-      "integrity": "sha1-tVzzNbsLRl3XyWGgLNJCRqpDQoc=",
+      "version": "5.5.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha1-J5LohvJCKJRUWUfMgOGkRElsWXY=",
       "license": "MIT",
       "dependencies": {
         "bundle-name": "^4.1.0",
@@ -996,9 +996,9 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha1-4cZX45wQCQr8vt7GFyD2uSTDy9I=",
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha1-MniXsmgyo+sRfabCdJLQTKEyWU8=",
       "license": "MIT",
       "dependencies": {
         "is-inside-container": "^1.0.0"

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
@@ -5,7 +5,7 @@
     "@azure/msal-node": "^2.7.0",
     "azure-devops-node-api": "14.1.0",
     "azure-pipelines-task-lib": "^5.2.8",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.267.0"
+    "azure-pipelines-tasks-azure-arm-rest": "^3.272.1"
   },
   "overrides": {
     "underscore": "1.13.8",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 16,
     "Minor": 273,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "Download Artifacts - External TFS Git",


### PR DESCRIPTION
**Description:**

This PR fixes a Component Governance (CG) security alert ([Alert 396982](https://dev.azure.com/mseng/AzureDevOps/_componentGovernance/192/alert/396982?typeId=560841)).

**Vulnerability Details:**
- **Alert ID:** MVS-2026-vmmw-f85q
- **Severity:** High
- **Affected Package:** `@azure/msal-browser` 4.27.0
- **Type:** Auth code theft / Cross Origin Opener Policy (COOP) handling vulnerability
- **Advisory:** https://aka.ms/msaljs/vul-march2026

**Root Cause:**
`@azure/msal-browser@4.27.0` was pulled in as a transitive dependency through `azure-pipelines-tasks-azure-arm-rest@3.267.0` → `@azure/identity` → `@azure/msal-browser`.

**Fix:**
Updated `azure-pipelines-tasks-azure-arm-rest` from `^3.267.0` to `^3.272.1` in the `DownloadArtifactsTfsGit` task. The newer arm-rest version depends on `@azure/identity@^4.13.1`, which pulls `@azure/msal-browser@^5.5.0` (resolves to `5.6.3`), eliminating the vulnerable version.

**Changes:**
| File | Change |
|---|---|
| package.json | `azure-pipelines-tasks-azure-arm-rest`: `^3.267.0` → `^3.272.1` |
| package-lock.json | Regenerated lock file (`@azure/msal-browser`: `4.27.0` → `5.6.3`) |
| task.json | Version bump: `16.273.0` → `16.273.1` |

**Risk Assessment:** Low
- `@azure/msal-browser` is a browser-only library, never executed in the Node.js pipeline agent context
- The task only imports `getFederatedToken` from the arm-rest package, which is unchanged in this minor version update
- The sibling task `DownloadExternalBuildArtifacts` already uses the same arm-rest version successfully

**Testing:**
- `npm install` and `npm ls @azure/msal-browser` confirm the vulnerable version is replaced
- No task logic or source code changes — dependency update only

---

Want me to commit and push these changes?