### PR TITLE
 Fix CG alert 396982: Update arm-rest dependency to resolve `@azure/msal-browser` vulnerability

### DIFF
--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
@@ -9,7 +9,7 @@
         "@azure/msal-node": "^2.7.0",
         "azure-devops-node-api": "14.1.0",
         "azure-pipelines-task-lib": "^5.2.8",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.267.0"
+        "azure-pipelines-tasks-azure-arm-rest": "^3.272.1"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.22.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.2.tgz",
-      "integrity": "sha1-fhTyHSWrYnzQdnattdmqzY4ulcw=",
+      "version": "1.23.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+      "integrity": "sha1-NfFuHBgMqVRcJgrBJLdRvh2pwIw=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
@@ -67,7 +67,7 @@
         "@azure/core-tracing": "^1.3.0",
         "@azure/core-util": "^1.13.0",
         "@azure/logger": "^1.3.0",
-        "@typespec/ts-http-runtime": "^0.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@azure/identity": {
-      "version": "4.13.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/identity/-/identity-4.13.0.tgz",
-      "integrity": "sha1-sr5jZGlkq1ng3A6tyo5PVi/DH5Y=",
+      "version": "4.13.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha1-vcCRZYuqWaR+6furSHpLsBhym8M=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
@@ -113,8 +113,8 @@
         "@azure/core-tracing": "^1.0.0",
         "@azure/core-util": "^1.11.0",
         "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^4.2.0",
-        "@azure/msal-node": "^3.5.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
         "open": "^10.1.0",
         "tslib": "^2.2.0"
       },
@@ -123,26 +123,26 @@
       }
     },
     "node_modules/@azure/identity/node_modules/@azure/msal-common": {
-      "version": "15.13.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-15.13.3.tgz",
-      "integrity": "sha1-4TKach9HPxylRm/Q1nVuTCrGj1I=",
+      "version": "16.4.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-16.4.1.tgz",
+      "integrity": "sha1-HVDFiCd6yXqCMZEwIyP8YMmoNXQ=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/identity/node_modules/@azure/msal-node": {
-      "version": "3.8.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-3.8.4.tgz",
-      "integrity": "sha1-98CCsuISIUjMNiT65YPyZDuBeI4=",
+      "version": "5.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-5.1.2.tgz",
+      "integrity": "sha1-FeqtaVmWayqII0+1aJLXuNavnWI=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.13.3",
+        "@azure/msal-common": "16.4.1",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       }
     },
     "node_modules/@azure/logger": {
@@ -159,21 +159,21 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "4.27.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-browser/-/msal-browser-4.27.0.tgz",
-      "integrity": "sha1-ZAVOYCs/sKuiVjIH+rUnhmlAOXs=",
+      "version": "5.6.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-browser/-/msal-browser-5.6.3.tgz",
+      "integrity": "sha1-3JC+l9ChwY28kyDp5n7cMpaXfqk=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.13.3"
+        "@azure/msal-common": "16.4.1"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
-      "version": "15.13.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-15.13.3.tgz",
-      "integrity": "sha1-4TKach9HPxylRm/Q1nVuTCrGj1I=",
+      "version": "16.4.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-16.4.1.tgz",
+      "integrity": "sha1-HVDFiCd6yXqCMZEwIyP8YMmoNXQ=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -253,9 +253,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "16.18.126",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.18.126.tgz",
-      "integrity": "sha1-J4dfqikmwPR1s5qLseVGwBdvjUs=",
+      "version": "10.17.60",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha1-NfPWIT2u2V2n8Pc+dbzGmA6QWXs=",
       "license": "MIT"
     },
     "node_modules/@types/q": {
@@ -265,9 +265,9 @@
       "license": "MIT"
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.2.tgz",
-      "integrity": "sha1-EEjfYYKwK+yJYqnP/Rxe4aEpVB8=",
+      "version": "0.3.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.4.tgz",
+      "integrity": "sha1-xfI26lkkyFrY/5bWDs3woiWFQRw=",
       "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^7.0.0",
@@ -276,15 +276,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@typespec/ts-http-runtime/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/@typespec/ts-http-runtime/node_modules/https-proxy-agent": {
@@ -301,24 +292,21 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk=",
+      "version": "0.5.17",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha1-XAtl83ruxcKpSZXAJPkx9i5LvFo=",
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+      "version": "7.1.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
       "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/async-mutex": {
@@ -369,12 +357,12 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.271.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.271.2.tgz",
-      "integrity": "sha1-lK3Yaxn+x7CSUHpaTdub8HQqPlU=",
+      "version": "3.272.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.272.1.tgz",
+      "integrity": "sha1-+3XFJlvgCjHjcKKNSOqBvJBiciE=",
       "license": "MIT",
       "dependencies": {
-        "@azure/identity": "^4.2.1",
+        "@azure/identity": "^4.13.1",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -391,21 +379,6 @@
         "q": "1.5.1",
         "typed-rest-client": "^2.2.0",
         "xml2js": "0.6.2"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha1-NfPWIT2u2V2n8Pc+dbzGmA6QWXs=",
-      "license": "MIT"
-    },
-    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/agent-base": {
-      "version": "5.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-5.1.1.tgz",
-      "integrity": "sha1-6Ps/JClZ20TWO+Zl23qOc5U3oyw=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0"
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-devops-node-api": {
@@ -437,30 +410,17 @@
         "node": ">= 16.0.0"
       }
     },
-    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/https-proxy-agent": {
-      "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-      "integrity": "sha1-cCtx+1UgoTKmbeH2dUHZ5iFU2Cs=",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "5",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/typed-rest-client": {
-      "version": "2.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.2.0.tgz",
-      "integrity": "sha1-2gcn5AiEm9tpgg2G7mZK/KNHd6M=",
+      "version": "2.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.3.0.tgz",
+      "integrity": "sha1-YBK4gubNvRsOC2BAf31OP6VJih0=",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",
         "js-md4": "^0.3.2",
         "qs": "^6.14.1",
         "tunnel": "0.0.6",
-        "underscore": "^1.12.1"
+        "underscore": "^1.13.8"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -473,9 +433,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
+      "version": "1.1.13",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha1-03h1wB3J7/mI3UnREqV8tntU7+Y=",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -565,9 +525,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha1-5ai8bLxMbNPmQwiwaTo9T6VQGJs=",
+      "version": "4.4.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -582,9 +542,9 @@
       }
     },
     "node_modules/default-browser": {
-      "version": "5.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/default-browser/-/default-browser-5.4.0.tgz",
-      "integrity": "sha1-tVzzNbsLRl3XyWGgLNJCRqpDQoc=",
+      "version": "5.5.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha1-J5LohvJCKJRUWUfMgOGkRElsWXY=",
       "license": "MIT",
       "dependencies": {
         "bundle-name": "^4.1.0",
@@ -724,9 +684,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha1-1Q6rqAPIhGqIPBZJKCHrzSzaVfU=",
+      "version": "1.20.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha1-ynUKENySW8ixiDn9ID4+9LPO1nU=",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -883,26 +843,26 @@
         "node": ">= 14"
       }
     },
-    "node_modules/http-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+      "integrity": "sha1-cCtx+1UgoTKmbeH2dUHZ5iFU2Cs=",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "5",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/agent-base": {
+      "version": "5.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-5.1.1.tgz",
+      "integrity": "sha1-6Ps/JClZ20TWO+Zl23qOc5U3oyw=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/human-signals": {
@@ -996,9 +956,9 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha1-4cZX45wQCQr8vt7GFyD2uSTDy9I=",
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha1-MniXsmgyo+sRfabCdJLQTKEyWU8=",
       "license": "MIT",
       "dependencies": {
         "is-inside-container": "^1.0.0"
@@ -1045,9 +1005,9 @@
       }
     },
     "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha1-Z9mf3NNc7CHm+Lh6f9UVoz+YK1g=",
+      "version": "7.7.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha1-KEZONgYOmR+noR0CedLT87V6foo=",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1252,12 +1212,12 @@
     },
     "node_modules/msalv3": {
       "name": "@azure/msal-node",
-      "version": "3.8.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-3.8.0.tgz",
-      "integrity": "sha1-F2NOurG01vaj+sGjeMSSn97q550=",
+      "version": "3.8.10",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-3.8.10.tgz",
+      "integrity": "sha1-RMkAkFsCPmMUbOrSmZcg8JBsdMo=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.13.0",
+        "@azure/msal-common": "15.17.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -1266,9 +1226,9 @@
       }
     },
     "node_modules/msalv3/node_modules/@azure/msal-common": {
-      "version": "15.13.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-15.13.0.tgz",
-      "integrity": "sha1-IpAI+Lrb9a9qRGoL4cQ2vi9MjNk=",
+      "version": "15.17.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-15.17.0.tgz",
+      "integrity": "sha1-rjwDN4yFJkKxyaMDOA6UXCuJfwI=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -1304,6 +1264,31 @@
         "https-proxy-agent": "^5.0.0",
         "mime-types": "^2.1.27",
         "sanitize-filename": "^1.6.3"
+      }
+    },
+    "node_modules/nodejs-file-downloader/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/nodejs-file-downloader/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/npm-run-path": {
@@ -1396,9 +1381,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha1-pB2FudOQLzHSeGF5BQYpSIGHEVk=",
+      "version": "6.15.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha1-24/V0bHS1rWzOtr4dCmAXxkJ57M=",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -1496,19 +1481,22 @@
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha1-dV69dSBFkxl34wsgJdNA18kJA3g=",
+      "version": "1.6.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha1-trOevtm9GhiYuFxcAwidp0WQ1vg=",
       "license": "WTFPL OR ISC",
       "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"
       }
     },
     "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha1-RMyJiDd/EmME07P8EBDHM7kp7w8=",
-      "license": "ISC"
+      "version": "1.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha1-2lljdikwe5fnxMso4ICnvDhWDVs=",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/semver": {
       "version": "5.7.2",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
@@ -5,7 +5,7 @@
     "@azure/msal-node": "^2.7.0",
     "azure-devops-node-api": "14.1.0",
     "azure-pipelines-task-lib": "^5.2.8",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.267.0"
+    "azure-pipelines-tasks-azure-arm-rest": "^3.272.1"
   },
   "overrides": {
     "underscore": "1.13.8",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 16,
     "Minor": 273,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "Download Artifacts - External TFS Git",


### PR DESCRIPTION
**Description:**

## Summary
Resolves Component Governance alert [396982](https://dev.azure.com/mseng/AzureDevOps/_componentGovernance/alert/396982) (High severity) by updating the `azure-pipelines-tasks-azure-arm-rest` dependency, which transitively pulls a patched version of `@azure/msal-browser`.

## Vulnerability
- **Alert:** MVS-2026-vmmw-f85q (High)
- **Affected package:** `@azure/msal-browser@4.27.0` (transitive via `arm-rest` → `@azure/identity`)
- **Issue:** Authorization code theft due to improper COOP handling

## Fix
Updated `azure-pipelines-tasks-azure-arm-rest` from `^3.267.0` to `^3.272.1`, which pulls `@azure/identity@^4.13.1` → `@azure/msal-browser@^5.5.0` (resolves to `5.6.3`), replacing the vulnerable `4.27.0`.

## Changes

| File | Change |
|------|--------|
| package.json | `azure-pipelines-tasks-azure-arm-rest`: `^3.267.0` → `^3.272.1` |
| task.json | Version bump `16.273.0` → `16.273.1` |
| package-lock.json | Regenerated — `@azure/msal-browser` now resolves to `5.6.3` |

## Risk Assessment
**Low** — The task only imports `getFederatedToken` from arm-rest (in `auth.js`). The API surface is unchanged between arm-rest `3.267.0` and `3.272.1`. Task execution handlers remain `Node16` and `Node20`.

## Testing
- Verified `npm ls @azure/msal-browser` resolves to `5.6.3` (no longer `4.27.0`)
- No logic changes — dependency-only update with patch version bump