### PR TITLE
Fix ArtifactEngine unit tests failing locally

### DIFF
--- a/Extensions/ArtifactEngine/ProvidersTests/webProviderTests.ts
+++ b/Extensions/ArtifactEngine/ProvidersTests/webProviderTests.ts
@@ -6,6 +6,11 @@ import * as assert from 'assert';
 import * as httpm from '../Providers/typed-rest-client/HttpClient';
 import * as models from '../Models';
 libMocker.registerMock('fs', {
+    statSync: () => {
+        return {
+            isDirectory: () => true
+        }
+    },
     createWriteStream: (a) => {
         var mockedStream = stream.Writable();
         mockedStream._write = () => { };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -159,7 +159,7 @@ gulp.task("TaskModuleTest", gulp.series('copy:TaskModuleTest', function() {
     var tfBuild = ('' + process.env['TF_BUILD']).toLowerCase() == 'true'
 
     gulp.src([testSuitePath])
-        .pipe(mocha({ reporter: 'spec', ui: 'bdd', useColors: !tfBuild }));
+        .pipe(mocha({ reporter: 'spec', ui: 'bdd', colors: !tfBuild }));
 }));
 
 gulp.task('prepublish:TaskModulePublish', function (done) {
@@ -827,7 +827,7 @@ gulp.task("test", gulp.series("testResources", function(){
         console.log(suitePath);
         var tfBuild = ('' + process.env['TF_BUILD']).toLowerCase() == 'true'
         return gulp.src([suitePath])
-            .pipe(mocha({ reporter: 'spec', ui: 'bdd', useColors: !tfBuild }));
+            .pipe(mocha({ reporter: 'spec', ui: 'bdd', colors: !tfBuild }));
     }
 
     if (options.suite.indexOf("ArtifactEngine") >= 0  && options.perf) {
@@ -835,7 +835,7 @@ gulp.task("test", gulp.series("testResources", function(){
         console.log(suitePath);
         var tfBuild = ('' + process.env['TF_BUILD']).toLowerCase() == 'true'
         return gulp.src([suitePath])
-            .pipe(mocha({ reporter: 'spec', ui: 'bdd', useColors: !tfBuild }));
+            .pipe(mocha({ reporter: 'spec', ui: 'bdd', colors: !tfBuild }));
     }
 
     var suitePath = path.join(_testRoot,"Extensions/" + options.suite + "/Tests/Tasks", options.suite + '/_suite.js');
@@ -845,7 +845,7 @@ gulp.task("test", gulp.series("testResources", function(){
     var tfBuild = ('' + process.env['TF_BUILD']).toLowerCase() == 'true'
     var ignorePath = "!" + path.join(_testRoot, "Extensions",  "/**/UIContribution{,/**}");
     return gulp.src([ suitePath, suitePath2, ignorePath ], { allowEmpty: true })
-        .pipe(mocha({ reporter: 'spec', ui: 'bdd', useColors: !tfBuild }));
+        .pipe(mocha({ reporter: 'spec', ui: 'bdd', colors: !tfBuild }));
 }));
 
 //-----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
**Description:**

## Summary

Fixes `gulp test --suite=ArtifactEngine` failing when run locally (outside CI).

## Problem

The tests pass in the CI pipeline but fail locally with two errors:

1. **`error: unknown option '--use-colors'`** — The gulpfile passes `useColors` to `gulp-mocha`, which gets converted to the invalid Mocha CLI flag `--use-colors`. In CI, `TF_BUILD=true` makes this value `false`, and `gulp-mocha` silently drops `false` options — so the flag is never sent. Locally, `TF_BUILD` is not set, so the flag is `true`, the invalid option is sent, and Mocha crashes before loading any test files.

2. **`TypeError: fs.statSync is not a function`** — webProviderTests.ts mocks the `fs` module with `useCleanCache: true` but does not include `statSync` in the mock. When `azure-pipelines-task-lib` internally calls `fs.statSync()`, it fails. This bug was hidden behind Bug 1 since Mocha crashed before ever loading the test file.

## Changes

| File | Change |
|---|---|
| gulpfile.js | Replaced `useColors` with `colors` (the correct Mocha CLI flag) in all 4 `gulp-mocha` calls |
| webProviderTests.ts | Added `statSync` to the `fs` mock, matching what filesystemProviderTests.ts already has |

## Testing

- Ran `gulp test --suite=ArtifactEngine` locally — **60 tests passing**
- Ran `gulp test --suite=ArtifactEngineV2` locally — **passing**