### PR TITLE
Replace npm install with npm ci for consistent dependency installation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -669,7 +669,7 @@ function runNpmInstall(packagePath) {
     util.cd(packagePath);
     var packageJsonPath = util.rp('package.json');
     if (util.test('-f', packageJsonPath)) {
-        util.run(`npm install --userconfig ${path.join(artifactEngineSourcePath, ".npmrc")}`);
+        util.run(`npm ci --userconfig ${path.join(artifactEngineSourcePath, ".npmrc")}`);
     }
     util.cd(originalDir);
 }

--- a/package.js
+++ b/package.js
@@ -131,7 +131,7 @@ function copyCommonModules(currentExtnRoot, commonDeps, commonSrc, extensionSour
                     console.log(`⚒️  Building UI contribution for task: ${task.name}`);
                     var originalDir = shell.pwd();
                     util.cd(uiPath);
-                    util.run('npm install');
+                    util.run('npm ci');
                     util.cd(originalDir);
                 }
 
@@ -144,13 +144,13 @@ function copyCommonModules(currentExtnRoot, commonDeps, commonSrc, extensionSour
                         try {
                             util.cd(taskDirPath);
                             if (util.isDebug()) {
-                                cp.execSync(`npm install --verbose --userconfig ${path.join(taskSourcePath, ".npmrc")}`, { stdio: 'inherit' });
+                                cp.execSync(`npm ci --verbose --userconfig ${path.join(taskSourcePath, ".npmrc")}`, { stdio: 'inherit' });
                             } else {
-                                cp.execSync(`npm install --userconfig ${path.join(taskSourcePath, ".npmrc")}`, { stdio: 'ignore' });
+                                cp.execSync(`npm ci --userconfig ${path.join(taskSourcePath, ".npmrc")}`, { stdio: 'ignore' });
                             }
-                            console.log(`\x1b[A\x1b[K✅ npm install at ${taskDirPath} completed successfully.`);
+                            console.log(`\x1b[A\x1b[K✅ npm ci at ${taskDirPath} completed successfully.`);
                         } catch (err) {
-                            console.log(`\x1b[A\x1b[K❌ npm install at ${taskDirPath} failed. Error: ${err.message}`);
+                            console.log(`\x1b[A\x1b[K❌ npm ci at ${taskDirPath} failed. Error: ${err.message}`);
                             process.exit(1);
                         } finally {
                             util.cd(originalDir);

--- a/package.js
+++ b/package.js
@@ -143,10 +143,11 @@ function copyCommonModules(currentExtnRoot, commonDeps, commonSrc, extensionSour
 
                         try {
                             util.cd(taskDirPath);
+                            const npmrcPath = path.join(taskSourcePath, ".npmrc");
                             if (util.isDebug()) {
-                                cp.execSync(`npm ci --verbose --userconfig ${path.join(taskSourcePath, ".npmrc")}`, { stdio: 'inherit' });
+                                cp.execFileSync('npm', ['ci', '--verbose', '--userconfig', npmrcPath], { stdio: 'inherit' });
                             } else {
-                                cp.execSync(`npm ci --userconfig ${path.join(taskSourcePath, ".npmrc")}`, { stdio: 'ignore' });
+                                cp.execFileSync('npm', ['ci', '--userconfig', npmrcPath], { stdio: 'ignore' });
                             }
                             console.log(`\x1b[A\x1b[K✅ npm ci at ${taskDirPath} completed successfully.`);
                         } catch (err) {

--- a/package.js
+++ b/package.js
@@ -144,10 +144,13 @@ function copyCommonModules(currentExtnRoot, commonDeps, commonSrc, extensionSour
                         try {
                             util.cd(taskDirPath);
                             const npmrcPath = path.join(taskSourcePath, ".npmrc");
+                            const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+                            const npmArgs = ['ci', '--userconfig', `"${npmrcPath}"`];
                             if (util.isDebug()) {
-                                cp.execFileSync('npm', ['ci', '--verbose', '--userconfig', npmrcPath], { stdio: 'inherit' });
+                                npmArgs.splice(1, 0, '--verbose');
+                                cp.execFileSync(npmCmd, npmArgs, { stdio: 'inherit', shell: true });
                             } else {
-                                cp.execFileSync('npm', ['ci', '--userconfig', npmrcPath], { stdio: 'ignore' });
+                                cp.execFileSync(npmCmd, npmArgs, { stdio: 'ignore', shell: true });
                             }
                             console.log(`\x1b[A\x1b[K✅ npm ci at ${taskDirPath} completed successfully.`);
                         } catch (err) {


### PR DESCRIPTION
**Description**: This PR replaces `npm install` to `npm ci` to avoid packages updating unexpectedly

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.
- [ ] Checked that applied changes work as expected.
