### PR TITLE
Fix SSH credential exposure in Ansible extension pipeline logs

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleRemoteMachineInterface.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleRemoteMachineInterface.ts
@@ -78,6 +78,14 @@ export class ansibleRemoteMachineInterface extends ansibleCommandLineInterface {
         var username: string = tl.getEndpointAuthorizationParameter(sshEndpoint, 'username', false);
         var password: string = tl.getEndpointAuthorizationParameter(sshEndpoint, 'password', true); //passphrase is optional
         var privateKey: string = process.env['ENDPOINT_DATA_' + sshEndpoint + '_PRIVATEKEY']; //private key is optional, password can be used for connecting
+
+        // Register credentials with the log masker to prevent exposure in pipeline logs
+        if (password) {
+            tl.setSecret(password);
+        }
+        if (privateKey) {
+            tl.setSecret(privateKey);
+        }
         var hostname: string = tl.getEndpointDataParameter(sshEndpoint, 'host', false);
         var port: string = tl.getEndpointDataParameter(sshEndpoint, 'port', true); //port is optional, will use 22 as default port if not specified
         if (!port || port === '') {

--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleTowerInterface.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleTowerInterface.ts
@@ -34,6 +34,11 @@ export class ansibleTowerInterface extends ansibleInterface {
             var endpointAuth = tl.getEndpointAuthorization(connectedService, true);
             this._username = endpointAuth.parameters["username"];
             this._password = endpointAuth.parameters["password"];
+
+            // Register credentials with the log masker to prevent exposure in pipeline logs
+            if (this._password) {
+                tl.setSecret(this._password);
+            }
             this._hostname = tl.getEndpointUrl(connectedService, true);
             this._jobTemplateName = tl.getInput("jobTemplateName");
             this._lastPolledEvent = 0;

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 273,
+        "Minor": 274,
         "Patch": 0
     },
     "demands": [],

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.273.0",
+  "version": "0.274.0",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",


### PR DESCRIPTION
Add tl.setSecret() calls for SSH passwords, private keys, and Ansible Tower API passwords to register them with the Azure Pipelines log masking system.

Without these calls, credentials retrieved from service connection endpoints appear in plaintext in pipeline logs whenever they are included in error messages, debug output, or downstream command output.

Fixes:
- ansibleRemoteMachineInterface.ts: mask password and privateKey after retrieval
- ansibleTowerInterface.ts: mask Tower API password after retrieval

Resolves: MSRC Case 115015 / VULN-185147
CWE-532: Insertion of Sensitive Information into Log File
CWE-214: Invocation of Process Using Visible Sensitive Information

**Description**: <Describe your changes here>

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.
- [ ] Checked that applied changes work as expected.
