### PR TITLE
MSRC 115015 case fix in extensions

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleRemoteMachineInterface.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleRemoteMachineInterface.ts
@@ -77,12 +77,23 @@ export class ansibleRemoteMachineInterface extends ansibleCommandLineInterface {
         var sshEndpoint = this._taskParameters.sshEndpoint;
         var username: string = tl.getEndpointAuthorizationParameter(sshEndpoint, 'username', false);
         var password: string = tl.getEndpointAuthorizationParameter(sshEndpoint, 'password', true); //passphrase is optional
-        var privateKey: string = process.env['ENDPOINT_DATA_' + sshEndpoint + '_PRIVATEKEY']; //private key is optional, password can be used for connecting
+        var privateKeyEnvVar = 'ENDPOINT_DATA_' + sshEndpoint + '_PRIVATEKEY';
+        var privateKey: string = process.env[privateKeyEnvVar]; //private key is optional, password can be used for connecting
         var hostname: string = tl.getEndpointDataParameter(sshEndpoint, 'host', false);
         var port: string = tl.getEndpointDataParameter(sshEndpoint, 'port', true); //port is optional, will use 22 as default port if not specified
         if (!port || port === '') {
             ansibleUtils._writeLine(tl.loc('UseDefaultPort'));
             port = '22';
+        }
+
+        // Register credentials with the log masker so they are redacted in pipeline logs
+        if (password) {
+            tl.setSecret(password);
+        }
+        if (privateKey) {
+            tl.setSecret(privateKey);
+            // Remove private key from environment to prevent inheritance by child processes
+            delete process.env[privateKeyEnvVar];
         }
 
         //setup the SSH connection configuration based on endpoint details

--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleTowerInterface.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleTowerInterface.ts
@@ -35,6 +35,11 @@ export class ansibleTowerInterface extends ansibleInterface {
             this._username = endpointAuth.parameters["username"];
             this._password = endpointAuth.parameters["password"];
             this._hostname = tl.getEndpointUrl(connectedService, true);
+
+            // Register credentials with the log masker so they are redacted in pipeline logs
+            if (this._password) {
+                tl.setSecret(this._password);
+            }
             this._jobTemplateName = tl.getInput("jobTemplateName");
             this._lastPolledEvent = 0;
 
@@ -48,8 +53,10 @@ export class ansibleTowerInterface extends ansibleInterface {
     }
 
     private getBasicRequestHeader(): any {
+        var authToken = Buffer.from(this._username + ":" + this._password).toString('base64');
+        tl.setSecret(authToken);
         var requestHeader: any = {
-            "Authorization": "Basic " + new Buffer(this._username + ":" + this._password).toString('base64')
+            "Authorization": "Basic " + authToken
         };
         return requestHeader;
     }

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 273,
+        "Minor": 274,
         "Patch": 0
     },
     "demands": [],

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.273.0",
+  "version": "0.274.0",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.274.0",
+  "version": "0.274.9",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.274.20",
+  "version": "0.275.0",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.274.2",
+  "version": "0.274.20",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.274.9",
+  "version": "0.274.11",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.274.11",
+  "version": "0.274.12",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.274.12",
+  "version": "0.274.2",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
@@ -121,6 +121,7 @@ function getEndpointDetails(inputFieldName) {
         var token = getAuthParameter(bitbucketEndpoint, 'apitoken');
         var username = getAuthParameter(bitbucketEndpoint, 'email') || '';
         tl.debug('Using token authentication');
+        if (token) tl.setSecret(token);
         return {
             "Token": token,
             "Username": username
@@ -128,8 +129,8 @@ function getEndpointDetails(inputFieldName) {
     } else {
         var hostUsername = getAuthParameter(bitbucketEndpoint, 'username');
         var hostPassword = getAuthParameter(bitbucketEndpoint, 'password');
+        if (hostPassword) tl.setSecret(hostPassword);
         tl.debug('hostUsername: ' + hostUsername);
-        tl.debug('hostPassword: ' + hostPassword);
         return {
             "Username": hostUsername,
             "Password": hostPassword

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/sourcecontrolwrapper.js
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/sourcecontrolwrapper.js
@@ -62,6 +62,8 @@ var SourceControlWrapper = (function (_super) {
         tool.silent = true;
         var creds = this.username + ':' + this.password;
         var escapedCreds = encodeURIComponent(this.username) + ':' + encodeURIComponent(this.password);
+        if (this.password) tl.setSecret(this.password);
+        if (escapedCreds) tl.setSecret(escapedCreds);
         tool.on('debug', function (message) {
             if (options.debugOutput) {
                 var repl = message.replace(creds, '...');

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
@@ -13,7 +13,7 @@
   "demands": [],
   "version": {
     "Major": 15,
-    "Minor": 273,
+    "Minor": 274,
     "Patch": 0
   },
   "minimumAgentVersion": "1.99.0",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.273.0",
+  "version": "15.274.0",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.274.0",
+  "version": "15.275.1",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.275.9",
+  "version": "15.275.12",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.275.1",
+  "version": "15.275.2",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.275.3",
+  "version": "15.275.9",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.275.2",
+  "version": "15.275.3",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/download.ts
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/download.ts
@@ -65,6 +65,7 @@ async function main(): Promise<void> {
 
         var templatePath = path.join(__dirname, 'circleCI.handlebars.txt');
         var username = tl.getEndpointAuthorizationParameter(connection, 'username', false)!;
+        if (username) tl.setSecret(username);
         var circleciVariables = {
             "endpoint": {
                 "url": endpointUrl

--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/task.json
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/task.json
@@ -9,7 +9,7 @@
     "preview": true,
     "version": {
       "Major": 0,
-      "Minor": 273,
+      "Minor": 274,
       "Patch": 0
     },
     "demands": [],

--- a/Extensions/CircleCI/Src/vss-extension.json
+++ b/Extensions/CircleCI/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-circleci-extension",
   "name": "CircleCI artifacts for Release Pipeline",
   "publisher": "ms-vscs-rm",
-  "version": "0.273.0",
+  "version": "0.274.0",
   "public": true,
   "description": "Tool for connecting with CircleCI",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/auth.js
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/auth.js
@@ -29,6 +29,7 @@ async function getAccessTokenViaWorkloadIdentityFederation(serviceConnection) {
     }
 
     tl.debug(`Got federated token for service connection ${serviceConnection}`);
+    if (federatedToken) tl.setSecret(federatedToken);
 
     // Exchange federated token for service principal token
     return await getAccessTokenFromFederatedToken(servicePrincipalId, tenantId, federatedToken, authorityUrl);
@@ -66,6 +67,7 @@ async function getAccessTokenFromFederatedToken(servicePrincipalId, tenantId, fe
     };
 
     const result = await app.acquireTokenByClientCredential(request);
+    if (result?.accessToken) tl.setSecret(result.accessToken);
 
     tl.debug(`Got access token for service principal ${servicePrincipalId}`);
 

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/downloadTfGit.js
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/downloadTfGit.js
@@ -100,6 +100,7 @@ async function getServiceConnectionDetails() {
 
 async function getAdoScDetails(serviceConnection, hostUrl) {
     var accessToken = await auth.getAccessTokenViaWorkloadIdentityFederation(serviceConnection);
+    if (accessToken) tl.setSecret(accessToken);
     return {
         "Url": hostUrl,
         "Username": "oauth2",
@@ -123,6 +124,7 @@ function getReposOrTfsScDetails(serviceConnection, hostUrl) {
         hostUsername = getAuthParameter(auth, 'username');
         hostPassword = getAuthParameter(auth, 'password');
     }
+    if (hostPassword) tl.setSecret(hostPassword);
 
     return {
         "Url": hostUrl,

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
@@ -13,8 +13,8 @@
   "demands": [],
   "version": {
     "Major": 16,
-    "Minor": 273,
-    "Patch": 1
+    "Minor": 274,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "Download Artifacts - External TFS Git",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/downloadTfsVersionControl.js
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/downloadTfsVersionControl.js
@@ -61,6 +61,7 @@ function getEndpointDetails(inputFieldName) {
         hostUsername = getAuthParameter(auth, 'username');
         hostPassword = getAuthParameter(auth, 'password');
     }
+    if (hostPassword) tl.setSecret(hostPassword);
     return {
         "Url": hostUrl,
         "Username": hostUsername,

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/task.json
@@ -12,7 +12,7 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 15,
-    "Minor": 273,
+    "Minor": 274,
     "Patch": 0
   },
   "demands": [],

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/auth.ts
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/auth.ts
@@ -64,6 +64,8 @@ async function getAccessTokenFromFederatedToken(
     const result = await app.acquireTokenByClientCredential(request);
     if (!result?.accessToken) {
         tl.debug("MSAL did not return an access token.");
+    } else {
+        tl.setSecret(result.accessToken);
     }
     if(result?.expiresOn) {
         const minutesUntilExpiration = (result.expiresOn.getTime() - Date.now()) / 60000;

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/auth.ts
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/auth.ts
@@ -21,6 +21,7 @@ export async function getAccessTokenViaWorkloadIdentityFederation(serviceConnect
   tl.debug(`Getting federated token for service connection ${serviceConnection}`);
   var federatedToken: string = await getFederatedToken(serviceConnection);
   tl.debug(`Got federated token for service connection ${serviceConnection}`);
+  if (federatedToken) tl.setSecret(federatedToken);
 
   // Exchange federated token for service principal token
   return await getAccessTokenFromFederatedToken(servicePrincipalId, tenantId, federatedToken, authorityUrl);

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/download.ts
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/download.ts
@@ -186,6 +186,8 @@ function configureForTfsSc() : ConnectionDetails {
         tl.getEndpointAuthorizationParameter(serviceConnection, 'apitoken', true) ||
         tl.getEndpointAuthorizationParameter(serviceConnection, 'password', true);
 
+    if (accessToken) tl.setSecret(accessToken);
+
     return {
         serviceConnection,
         projectId,

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/download.ts
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/download.ts
@@ -166,6 +166,7 @@ async function configureForAdoSc(): Promise<ConnectionDetails> {
     validateInputs(serviceConnection, projectId, buildId);
 
     const accessToken: string = await auth.getAccessTokenViaWorkloadIdentityFederation(serviceConnection);
+    if (accessToken) tl.setSecret(accessToken);
     return {
         serviceConnection,
         projectId,

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
@@ -8,7 +8,7 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 16,
-    "Minor": 273,
+    "Minor": 274,
     "Patch": 0
   },
   "demands": [],

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 ﻿﻿{
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.273.0",
+  "version": "16.274.0",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.274.8",
+  "version": "1.274.9",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.274.6",
+  "version": "1.274.8",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.262.2",
+  "version": "1.274.6",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.274.12",
+  "version": "1.274.21",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.274.9",
+  "version": "1.274.12",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.273.4",
+  "version": "4.274.0",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.273.31382771",
+  "version": "4.273.31382772",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.272.1",
+  "version": "4.273.31382769",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.273.31382772",
+  "version": "4.273.4",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.273.31382769",
+  "version": "4.273.31382771",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/download.ts
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/download.ts
@@ -63,6 +63,7 @@ async function main(): Promise<void> {
         var templatePath = path.join(__dirname, 'teamcity.handlebars');
         var username = tl.getEndpointAuthorizationParameter(connection, 'username', false)!;
         var password = tl.getEndpointAuthorizationParameter(connection, 'password', false)!;
+        if (password) tl.setSecret(password);
         var teamcityVariables = {
             "endpoint": {
                 "url": endpointUrl

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
@@ -8,7 +8,7 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 15,
-    "Minor": 273,
+    "Minor": 274,
     "Patch": 0
   },
   "demands": [],

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.273.0",
+  "version": "15.274.0",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",


### PR DESCRIPTION
**Description**: [MSRC Case 115015] Added [tl.setSecret()](vscode-file://vscode-app/c:/Users/igortsoi/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) calls across Ansible, BitBucket, TeamCity, and ExternalTfs extensions to register SSH passwords, private keys, API tokens, and auth credentials with the Azure Pipelines log masker, preventing plaintext exposure in pipeline logs (CWE-532).
Removed the ENDPOINT_DATA_*_PRIVATEKEY environment variable after reading to block credential inheritance by child processes (CWE-214), and removed the explicit [tl.debug('hostPassword: ...')](vscode-file://vscode-app/c:/Users/igortsoi/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) call in BitBucket that was actively logging

**Documentation changes required:**N

**Added unit tests:** N

**Attached related issue:** https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2387832

**Checklist**:
- [X] Version was bumped - please check that version of the extension, task or library has been bumped.
- [ ] Checked that applied changes work as expected.
