### PR TITLE
Add unit tests for webClientFactory proxy and decryption fixes

### DIFF
--- a/Extensions/ArtifactEngineV2/ProvidersTests/webClientFactoryTests.ts
+++ b/Extensions/ArtifactEngineV2/ProvidersTests/webClientFactoryTests.ts
@@ -1,0 +1,234 @@
+import * as assert from 'assert';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+import { WebClientFactory } from '../Providers/webClientFactory';
+
+describe('Unit Tests', () => {
+    describe('webClientFactory _readTaskLibSecrets tests', () => {
+
+        let tempDir: string;
+        let keyFilePath: string;
+
+        beforeEach(() => {
+            tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wcf-test-'));
+            keyFilePath = path.join(tempDir, '.taskkey');
+        });
+
+        afterEach(() => {
+            // Clean up temp files
+            if (fs.existsSync(keyFilePath)) {
+                fs.unlinkSync(keyFilePath);
+            }
+            if (fs.existsSync(tempDir)) {
+                fs.rmdirSync(tempDir);
+            }
+        });
+
+        /**
+         * Helper: encrypts a plaintext secret the same way task-lib
+         * _exposeTaskLibSecret() does (key:iv in file, AES-256-CTR).
+         * Returns the lookupKey in "base64(keyFilePath):base64(encryptedHex)" format.
+         */
+        function encryptSecret(plaintext: string): string {
+            const encryptKey = crypto.randomBytes(32);
+            const iv = crypto.randomBytes(16);
+
+            // Write key:iv to the key file (base64 encoded, colon-separated)
+            const keyFileContent = encryptKey.toString('base64') + ':' + iv.toString('base64');
+            fs.writeFileSync(keyFilePath, keyFileContent, 'utf8');
+
+            // Encrypt
+            const cipher = crypto.createCipheriv('aes-256-ctr', encryptKey, iv);
+            let encrypted = cipher.update(plaintext, 'utf8', 'hex');
+            encrypted += cipher.final('hex');
+
+            // Build lookupKey: base64(keyFilePath):base64(encryptedHex)
+            const lookupKey = Buffer.from(keyFilePath, 'utf8').toString('base64')
+                + ':'
+                + Buffer.from(encrypted, 'utf8').toString('base64');
+
+            return lookupKey;
+        }
+
+        it('should round-trip decrypt a secret encrypted with key:iv format', () => {
+            const originalSecret = 'myProxyP@ssw0rd!';
+            const lookupKey = encryptSecret(originalSecret);
+
+            // Access private static method via bracket notation
+            const decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
+
+            assert.strictEqual(decrypted, originalSecret, `Expected '${originalSecret}' but got '${decrypted}'`);
+        });
+
+        it('should decrypt secrets with special characters', () => {
+            const originalSecret = 'p@$$w0rd!#%^&*()_+-={}[]|\\:";\'<>?,./~`';
+            const lookupKey = encryptSecret(originalSecret);
+
+            const decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
+
+            assert.strictEqual(decrypted, originalSecret);
+        });
+
+        it('should decrypt an empty string', () => {
+            const originalSecret = '';
+            const lookupKey = encryptSecret(originalSecret);
+
+            const decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
+
+            assert.strictEqual(decrypted, originalSecret);
+        });
+
+        it('should decrypt a long secret', () => {
+            const originalSecret = 'a'.repeat(1024);
+            const lookupKey = encryptSecret(originalSecret);
+
+            const decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
+
+            assert.strictEqual(decrypted, originalSecret);
+        });
+
+        it('should return undefined for null lookupKey', () => {
+            const result = (WebClientFactory as any)._readTaskLibSecrets(null);
+            assert.strictEqual(result, undefined);
+        });
+
+        it('should return undefined for empty string lookupKey', () => {
+            const result = (WebClientFactory as any)._readTaskLibSecrets('');
+            assert.strictEqual(result, undefined);
+        });
+
+        it('should return undefined for lookupKey without colon separator', () => {
+            const result = (WebClientFactory as any)._readTaskLibSecrets('noColonHere');
+            assert.strictEqual(result, undefined);
+        });
+
+        it('should decrypt correctly with a different key and IV each time', () => {
+            const secret1 = 'secret-one';
+            const secret2 = 'secret-two';
+
+            const lookup1 = encryptSecret(secret1);
+            const lookup2 = encryptSecret(secret2);
+
+            // Both should decrypt independently (key file gets overwritten, so test sequentially)
+            // Re-encrypt secret1 last to verify
+            const lookup1b = encryptSecret(secret1);
+            const decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookup1b);
+            assert.strictEqual(decrypted, secret1);
+        });
+
+        it('should handle unicode secrets', () => {
+            const originalSecret = 'σ»åτáü≡ƒöæπâæπé╣πâ»πâ╝πâë';
+            const lookupKey = encryptSecret(originalSecret);
+
+            const decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
+
+            assert.strictEqual(decrypted, originalSecret);
+        });
+    });
+
+    describe('webClientFactory proxy port tests', () => {
+
+        it('getClient should return a client with numeric proxy port', () => {
+            // Set up global proxy variables as task-lib would
+            global['_vsts_task_lib_proxy'] = true;
+            global['_vsts_task_lib_proxy_url'] = 'http://proxy-server:8080';
+            global['_vsts_task_lib_proxy_username'] = '';
+            global['_vsts_task_lib_proxy_password'] = '';
+            global['_vsts_task_lib_proxy_bypass'] = '[]';
+
+            try {
+                const client = WebClientFactory.getClient([], {});
+                assert(client, 'client should not be null');
+            } finally {
+                // Clean up globals
+                delete global['_vsts_task_lib_proxy'];
+                delete global['_vsts_task_lib_proxy_url'];
+                delete global['_vsts_task_lib_proxy_username'];
+                delete global['_vsts_task_lib_proxy_password'];
+                delete global['_vsts_task_lib_proxy_bypass'];
+            }
+        });
+
+        it('initializeProxy should read proxy settings from globals', () => {
+            global['_vsts_task_lib_proxy'] = true;
+            global['_vsts_task_lib_proxy_url'] = 'http://myproxy:3128';
+            global['_vsts_task_lib_proxy_username'] = 'user';
+            global['_vsts_task_lib_proxy_password'] = '';
+            global['_vsts_task_lib_proxy_bypass'] = '["localhost"]';
+
+            try {
+                const options: any = {};
+                (WebClientFactory as any).initializeProxy(options);
+
+                assert.strictEqual(options.proxy.proxyUrl, 'http://myproxy:3128');
+                assert.strictEqual(options.proxy.proxyUsername, 'user');
+                assert.deepStrictEqual(options.proxy.proxyBypassHosts, ['localhost']);
+            } finally {
+                delete global['_vsts_task_lib_proxy'];
+                delete global['_vsts_task_lib_proxy_url'];
+                delete global['_vsts_task_lib_proxy_username'];
+                delete global['_vsts_task_lib_proxy_password'];
+                delete global['_vsts_task_lib_proxy_bypass'];
+            }
+        });
+
+        it('initializeProxy should not overwrite existing proxy options', () => {
+            global['_vsts_task_lib_proxy'] = true;
+            global['_vsts_task_lib_proxy_url'] = 'http://env-proxy:8080';
+
+            try {
+                const options: any = {
+                    proxy: {
+                        proxyUrl: 'http://explicit-proxy:9090'
+                    }
+                };
+                (WebClientFactory as any).initializeProxy(options);
+
+                // Should keep the explicit proxy, not override with env
+                assert.strictEqual(options.proxy.proxyUrl, 'http://explicit-proxy:9090');
+            } finally {
+                delete global['_vsts_task_lib_proxy'];
+                delete global['_vsts_task_lib_proxy_url'];
+            }
+        });
+
+        it('initializeProxy should read cert settings from globals', () => {
+            global['_vsts_task_lib_cert'] = true;
+            global['_vsts_task_lib_cert_ca'] = '/path/to/ca.pem';
+            global['_vsts_task_lib_cert_clientcert'] = '/path/to/cert.pem';
+            global['_vsts_task_lib_cert_key'] = '/path/to/key.pem';
+            global['_vsts_task_lib_cert_passphrase'] = '';
+
+            try {
+                const options: any = {};
+                (WebClientFactory as any).initializeProxy(options);
+
+                assert.strictEqual(options.cert.caFile, '/path/to/ca.pem');
+                assert.strictEqual(options.cert.certFile, '/path/to/cert.pem');
+                assert.strictEqual(options.cert.keyFile, '/path/to/key.pem');
+            } finally {
+                delete global['_vsts_task_lib_cert'];
+                delete global['_vsts_task_lib_cert_ca'];
+                delete global['_vsts_task_lib_cert_clientcert'];
+                delete global['_vsts_task_lib_cert_key'];
+                delete global['_vsts_task_lib_cert_passphrase'];
+            }
+        });
+
+        it('initializeProxy should set ignoreSslError from globals', () => {
+            global['_vsts_task_lib_skip_cert_validation'] = true;
+
+            try {
+                const options: any = {};
+                (WebClientFactory as any).initializeProxy(options);
+
+                assert.strictEqual(options.ignoreSslError, true);
+            } finally {
+                delete global['_vsts_task_lib_skip_cert_validation'];
+            }
+        });
+    });
+});

--- a/Extensions/ArtifactEngineV2/ProvidersTests/webClientFactoryTests.ts
+++ b/Extensions/ArtifactEngineV2/ProvidersTests/webClientFactoryTests.ts
@@ -1,155 +1,205 @@
+var libMocker = require("azure-pipelines-task-lib/lib-mocker");
+var crypto = require("crypto");
+// `node:fs` bypasses any mocks registered for the plain `fs` key, so this
+// reference is guaranteed to be the real fs even if other test files have
+// already enabled the mocker.
+var realFs = require("node:fs");
+
 import * as assert from 'assert';
-import * as crypto from 'crypto';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+
+// Mock fs to intercept readFileSync calls for key file reads while
+// delegating everything else to the real fs so task-lib can initialize.
+var mockKeyFileContent: string = '';
+libMocker.registerMock('fs', {
+    readFileSync: (filePath, encoding) => {
+        // If reading our fake key file path, return mocked content
+        if (typeof filePath === 'string' && filePath.indexOf('.taskkey') >= 0) {
+            return mockKeyFileContent;
+        }
+        return realFs.readFileSync(filePath, encoding);
+    },
+    writeFileSync: (filePath, data, options) => {
+        return realFs.writeFileSync(filePath, data, options);
+    },
+    existsSync: (filePath) => {
+        return realFs.existsSync(filePath);
+    },
+    statSync: (filePath) => {
+        return realFs.statSync(filePath);
+    },
+    mkdirSync: (dirPath, options) => {
+        return realFs.mkdirSync(dirPath, options);
+    },
+    unlinkSync: (filePath) => {
+        return realFs.unlinkSync(filePath);
+    },
+    chmodSync: (filePath, mode) => {
+        return realFs.chmodSync(filePath, mode);
+    }
+});
+libMocker.enable({
+    warnOnReplace: false,
+    warnOnUnregistered: false,
+    useCleanCache: true
+});
 
 import { WebClientFactory } from '../Providers/webClientFactory';
+
+var sinon = require('sinon');
+
+/**
+ * Helper: encrypts a plaintext secret the same way task-lib
+ * _exposeTaskLibSecret() does (key:iv in file, AES-256-CTR).
+ * Sets up the mock key file content and returns the lookupKey.
+ */
+function encryptSecret(plaintext: string): string {
+    var encryptKey = crypto.randomBytes(32);
+    var iv = crypto.randomBytes(16);
+
+    // Set mock key file content (key:iv in base64, colon-separated)
+    mockKeyFileContent = encryptKey.toString('base64') + ':' + iv.toString('base64');
+
+    // Encrypt
+    var cipher = crypto.createCipheriv('aes-256-ctr', encryptKey, iv);
+    var encrypted = cipher.update(plaintext, 'utf8', 'hex');
+    encrypted += cipher.final('hex');
+
+    // Build lookupKey: base64(keyFilePath):base64(encryptedHex)
+    var lookupKey = Buffer.from('/fake/path/.taskkey', 'utf8').toString('base64')
+        + ':'
+        + Buffer.from(encrypted, 'utf8').toString('base64');
+
+    return lookupKey;
+}
+
+beforeEach(() => {
+    mockKeyFileContent = '';
+});
 
 describe('Unit Tests', () => {
     describe('webClientFactory _readTaskLibSecrets tests', () => {
 
-        let tempDir: string;
-        let keyFilePath: string;
-
-        beforeEach(() => {
-            tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wcf-test-'));
-            keyFilePath = path.join(tempDir, '.taskkey');
-        });
-
-        afterEach(() => {
-            // Clean up temp files
-            if (fs.existsSync(keyFilePath)) {
-                fs.unlinkSync(keyFilePath);
-            }
-            if (fs.existsSync(tempDir)) {
-                fs.rmdirSync(tempDir);
-            }
-        });
-
-        /**
-         * Helper: encrypts a plaintext secret the same way task-lib
-         * _exposeTaskLibSecret() does (key:iv in file, AES-256-CTR).
-         * Returns the lookupKey in "base64(keyFilePath):base64(encryptedHex)" format.
-         */
-        function encryptSecret(plaintext: string): string {
-            const encryptKey = crypto.randomBytes(32);
-            const iv = crypto.randomBytes(16);
-
-            // Write key:iv to the key file (base64 encoded, colon-separated)
-            const keyFileContent = encryptKey.toString('base64') + ':' + iv.toString('base64');
-            fs.writeFileSync(keyFilePath, keyFileContent, 'utf8');
-
-            // Encrypt
-            const cipher = crypto.createCipheriv('aes-256-ctr', encryptKey, iv);
-            let encrypted = cipher.update(plaintext, 'utf8', 'hex');
-            encrypted += cipher.final('hex');
-
-            // Build lookupKey: base64(keyFilePath):base64(encryptedHex)
-            const lookupKey = Buffer.from(keyFilePath, 'utf8').toString('base64')
-                + ':'
-                + Buffer.from(encrypted, 'utf8').toString('base64');
-
-            return lookupKey;
-        }
-
         it('should round-trip decrypt a secret encrypted with key:iv format', () => {
-            const originalSecret = 'myProxyP@ssw0rd!';
-            const lookupKey = encryptSecret(originalSecret);
+            var originalSecret = 'myProxyP@ssw0rd!';
+            var lookupKey = encryptSecret(originalSecret);
 
-            // Access private static method via bracket notation
-            const decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
+            var decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
 
-            assert.strictEqual(decrypted, originalSecret, `Expected '${originalSecret}' but got '${decrypted}'`);
+            assert.strictEqual(decrypted, originalSecret, 'Expected \'' + originalSecret + '\' but got \'' + decrypted + '\'');
         });
 
         it('should decrypt secrets with special characters', () => {
-            const originalSecret = 'p@$$w0rd!#%^&*()_+-={}[]|\\:";\'<>?,./~`';
-            const lookupKey = encryptSecret(originalSecret);
+            var originalSecret = 'p@$$w0rd!#%^&*()_+-={}[]|\\:";\'<>?,./~`';
+            var lookupKey = encryptSecret(originalSecret);
 
-            const decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
+            var decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
 
             assert.strictEqual(decrypted, originalSecret);
         });
 
         it('should decrypt an empty string', () => {
-            const originalSecret = '';
-            const lookupKey = encryptSecret(originalSecret);
+            var originalSecret = '';
+            var lookupKey = encryptSecret(originalSecret);
 
-            const decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
+            var decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
 
             assert.strictEqual(decrypted, originalSecret);
         });
 
         it('should decrypt a long secret', () => {
-            const originalSecret = 'a'.repeat(1024);
-            const lookupKey = encryptSecret(originalSecret);
+            var originalSecret = 'a'.repeat(1024);
+            var lookupKey = encryptSecret(originalSecret);
 
-            const decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
+            var decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
 
             assert.strictEqual(decrypted, originalSecret);
         });
 
         it('should return undefined for null lookupKey', () => {
-            const result = (WebClientFactory as any)._readTaskLibSecrets(null);
+            var result = (WebClientFactory as any)._readTaskLibSecrets(null);
             assert.strictEqual(result, undefined);
         });
 
         it('should return undefined for empty string lookupKey', () => {
-            const result = (WebClientFactory as any)._readTaskLibSecrets('');
+            var result = (WebClientFactory as any)._readTaskLibSecrets('');
             assert.strictEqual(result, undefined);
         });
 
         it('should return undefined for lookupKey without colon separator', () => {
-            const result = (WebClientFactory as any)._readTaskLibSecrets('noColonHere');
+            var result = (WebClientFactory as any)._readTaskLibSecrets('noColonHere');
             assert.strictEqual(result, undefined);
         });
 
         it('should decrypt correctly with a different key and IV each time', () => {
-            const secret1 = 'secret-one';
-            const secret2 = 'secret-two';
+            var secret1 = 'secret-one';
 
-            const lookup1 = encryptSecret(secret1);
-            const lookup2 = encryptSecret(secret2);
-
-            // Both should decrypt independently (key file gets overwritten, so test sequentially)
-            // Re-encrypt secret1 last to verify
-            const lookup1b = encryptSecret(secret1);
-            const decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookup1b);
+            var lookup1 = encryptSecret(secret1);
+            var decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookup1);
             assert.strictEqual(decrypted, secret1);
+
+            var secret2 = 'secret-two';
+            var lookup2 = encryptSecret(secret2);
+            var decrypted2 = (WebClientFactory as any)._readTaskLibSecrets(lookup2);
+            assert.strictEqual(decrypted2, secret2);
         });
 
         it('should handle unicode secrets', () => {
-            const originalSecret = 'σ»åτáü≡ƒöæπâæπé╣πâ»πâ╝πâë';
-            const lookupKey = encryptSecret(originalSecret);
+            var originalSecret = '\u03C3\u00BB\u00E5\u03C4\u00E1\u00FC';
+            var lookupKey = encryptSecret(originalSecret);
 
-            const decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
+            var decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
 
             assert.strictEqual(decrypted, originalSecret);
+        });
+
+        it('should fall back to zero IV for older task-lib format (key only, no IV)', () => {
+            var encryptKey = crypto.randomBytes(32);
+            var zeroIv = Buffer.alloc(16, 0);
+
+            // Older task-lib writes only the key (no colon, no IV)
+            mockKeyFileContent = encryptKey.toString('base64');
+
+            // Encrypt with zero IV (what older task-lib does)
+            var cipher = crypto.createCipheriv('aes-256-ctr', encryptKey, zeroIv);
+            var encrypted = cipher.update('oldSecret', 'utf8', 'hex');
+            encrypted += cipher.final('hex');
+
+            var lookupKey = Buffer.from('/fake/path/.taskkey', 'utf8').toString('base64')
+                + ':'
+                + Buffer.from(encrypted, 'utf8').toString('base64');
+
+            var decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
+
+            assert.strictEqual(decrypted, 'oldSecret');
         });
     });
 
     describe('webClientFactory proxy port tests', () => {
 
+        afterEach(() => {
+            // Clean up globals
+            delete global['_vsts_task_lib_proxy'];
+            delete global['_vsts_task_lib_proxy_url'];
+            delete global['_vsts_task_lib_proxy_username'];
+            delete global['_vsts_task_lib_proxy_password'];
+            delete global['_vsts_task_lib_proxy_bypass'];
+            delete global['_vsts_task_lib_cert'];
+            delete global['_vsts_task_lib_cert_ca'];
+            delete global['_vsts_task_lib_cert_clientcert'];
+            delete global['_vsts_task_lib_cert_key'];
+            delete global['_vsts_task_lib_cert_passphrase'];
+            delete global['_vsts_task_lib_skip_cert_validation'];
+        });
+
         it('getClient should return a client with numeric proxy port', () => {
-            // Set up global proxy variables as task-lib would
             global['_vsts_task_lib_proxy'] = true;
             global['_vsts_task_lib_proxy_url'] = 'http://proxy-server:8080';
             global['_vsts_task_lib_proxy_username'] = '';
             global['_vsts_task_lib_proxy_password'] = '';
             global['_vsts_task_lib_proxy_bypass'] = '[]';
 
-            try {
-                const client = WebClientFactory.getClient([], {});
-                assert(client, 'client should not be null');
-            } finally {
-                // Clean up globals
-                delete global['_vsts_task_lib_proxy'];
-                delete global['_vsts_task_lib_proxy_url'];
-                delete global['_vsts_task_lib_proxy_username'];
-                delete global['_vsts_task_lib_proxy_password'];
-                delete global['_vsts_task_lib_proxy_bypass'];
-            }
+            var client = WebClientFactory.getClient([], {});
+            assert(client, 'client should not be null');
         });
 
         it('initializeProxy should read proxy settings from globals', () => {
@@ -159,40 +209,26 @@ describe('Unit Tests', () => {
             global['_vsts_task_lib_proxy_password'] = '';
             global['_vsts_task_lib_proxy_bypass'] = '["localhost"]';
 
-            try {
-                const options: any = {};
-                (WebClientFactory as any).initializeProxy(options);
+            var options: any = {};
+            (WebClientFactory as any).initializeProxy(options);
 
-                assert.strictEqual(options.proxy.proxyUrl, 'http://myproxy:3128');
-                assert.strictEqual(options.proxy.proxyUsername, 'user');
-                assert.deepStrictEqual(options.proxy.proxyBypassHosts, ['localhost']);
-            } finally {
-                delete global['_vsts_task_lib_proxy'];
-                delete global['_vsts_task_lib_proxy_url'];
-                delete global['_vsts_task_lib_proxy_username'];
-                delete global['_vsts_task_lib_proxy_password'];
-                delete global['_vsts_task_lib_proxy_bypass'];
-            }
+            assert.strictEqual(options.proxy.proxyUrl, 'http://myproxy:3128');
+            assert.strictEqual(options.proxy.proxyUsername, 'user');
+            assert.deepStrictEqual(options.proxy.proxyBypassHosts, ['localhost']);
         });
 
         it('initializeProxy should not overwrite existing proxy options', () => {
             global['_vsts_task_lib_proxy'] = true;
             global['_vsts_task_lib_proxy_url'] = 'http://env-proxy:8080';
 
-            try {
-                const options: any = {
-                    proxy: {
-                        proxyUrl: 'http://explicit-proxy:9090'
-                    }
-                };
-                (WebClientFactory as any).initializeProxy(options);
+            var options: any = {
+                proxy: {
+                    proxyUrl: 'http://explicit-proxy:9090'
+                }
+            };
+            (WebClientFactory as any).initializeProxy(options);
 
-                // Should keep the explicit proxy, not override with env
-                assert.strictEqual(options.proxy.proxyUrl, 'http://explicit-proxy:9090');
-            } finally {
-                delete global['_vsts_task_lib_proxy'];
-                delete global['_vsts_task_lib_proxy_url'];
-            }
+            assert.strictEqual(options.proxy.proxyUrl, 'http://explicit-proxy:9090');
         });
 
         it('initializeProxy should read cert settings from globals', () => {
@@ -202,33 +238,24 @@ describe('Unit Tests', () => {
             global['_vsts_task_lib_cert_key'] = '/path/to/key.pem';
             global['_vsts_task_lib_cert_passphrase'] = '';
 
-            try {
-                const options: any = {};
-                (WebClientFactory as any).initializeProxy(options);
+            var options: any = {};
+            (WebClientFactory as any).initializeProxy(options);
 
-                assert.strictEqual(options.cert.caFile, '/path/to/ca.pem');
-                assert.strictEqual(options.cert.certFile, '/path/to/cert.pem');
-                assert.strictEqual(options.cert.keyFile, '/path/to/key.pem');
-            } finally {
-                delete global['_vsts_task_lib_cert'];
-                delete global['_vsts_task_lib_cert_ca'];
-                delete global['_vsts_task_lib_cert_clientcert'];
-                delete global['_vsts_task_lib_cert_key'];
-                delete global['_vsts_task_lib_cert_passphrase'];
-            }
+            assert.strictEqual(options.cert.caFile, '/path/to/ca.pem');
+            assert.strictEqual(options.cert.certFile, '/path/to/cert.pem');
+            assert.strictEqual(options.cert.keyFile, '/path/to/key.pem');
         });
 
         it('initializeProxy should set ignoreSslError from globals', () => {
             global['_vsts_task_lib_skip_cert_validation'] = true;
 
-            try {
-                const options: any = {};
-                (WebClientFactory as any).initializeProxy(options);
+            var options: any = {};
+            (WebClientFactory as any).initializeProxy(options);
 
-                assert.strictEqual(options.ignoreSslError, true);
-            } finally {
-                delete global['_vsts_task_lib_skip_cert_validation'];
-            }
+            assert.strictEqual(options.ignoreSslError, true);
         });
     });
+});
+after(() => {
+    libMocker.deregisterAll();
 });

--- a/Extensions/ArtifactEngineV2/ProvidersTests/webClientFactoryTests.ts
+++ b/Extensions/ArtifactEngineV2/ProvidersTests/webClientFactoryTests.ts
@@ -263,7 +263,7 @@ describe('Unit Tests', () => {
                 }
             });
 
-            var agent = (httpClient as any)._getAgent('https://artifacts.dev.azure.com/download');
+            var agent = (httpClient as any)._getAgent('https://artifacts.example.com/download');
             var proxyAgent = (httpClient as any)._proxyAgent;
 
             assert(proxyAgent, 'proxy agent should be created for HTTPS target through HTTP proxy');
@@ -280,7 +280,7 @@ describe('Unit Tests', () => {
                 }
             });
 
-            var agent = (httpClient as any)._getAgent('http://artifacts.dev.azure.com/download');
+            var agent = (httpClient as any)._getAgent('http://artifacts.example.com/download');
             var proxyAgent = (httpClient as any)._proxyAgent;
 
             assert(proxyAgent, 'proxy agent should be created for HTTP target through HTTP proxy');

--- a/Extensions/ArtifactEngineV2/ProvidersTests/webClientFactoryTests.ts
+++ b/Extensions/ArtifactEngineV2/ProvidersTests/webClientFactoryTests.ts
@@ -44,6 +44,7 @@ libMocker.enable({
 });
 
 import { WebClientFactory } from '../Providers/webClientFactory';
+import { HttpClient } from '../Providers/typed-rest-client/HttpClient';
 
 var sinon = require('sinon');
 
@@ -202,6 +203,107 @@ describe('Unit Tests', () => {
             assert(client, 'client should not be null');
         });
 
+        it('tunnel agent should receive numeric port from explicit proxy port', () => {
+            var httpClient = new HttpClient('test-agent', [], {
+                proxy: {
+                    proxyUrl: 'http://proxy-server:8080',
+                    proxyUsername: '',
+                    proxyPassword: ''
+                }
+            });
+
+            var agent = (httpClient as any)._getAgent('http://target-server/artifact');
+            var proxyAgent = (httpClient as any)._proxyAgent;
+
+            assert(proxyAgent, 'proxy agent should be created');
+            assert.strictEqual(proxyAgent.options.proxy.port, 8080, 'port should be numeric 8080');
+            assert.strictEqual(typeof proxyAgent.options.proxy.port, 'number', 'port should be of type number');
+        });
+
+        it('tunnel agent should default to port 80 for HTTP proxy without explicit port', () => {
+            var httpClient = new HttpClient('test-agent', [], {
+                proxy: {
+                    proxyUrl: 'http://proxy-server',
+                    proxyUsername: '',
+                    proxyPassword: ''
+                }
+            });
+
+            var agent = (httpClient as any)._getAgent('http://target-server/artifact');
+            var proxyAgent = (httpClient as any)._proxyAgent;
+
+            assert(proxyAgent, 'proxy agent should be created');
+            assert.strictEqual(proxyAgent.options.proxy.port, 80, 'port should default to 80 for HTTP proxy');
+            assert.strictEqual(typeof proxyAgent.options.proxy.port, 'number', 'port should be of type number');
+        });
+
+        it('tunnel agent should default to port 443 for HTTPS proxy without explicit port', () => {
+            var httpClient = new HttpClient('test-agent', [], {
+                proxy: {
+                    proxyUrl: 'https://secure-proxy',
+                    proxyUsername: '',
+                    proxyPassword: ''
+                }
+            });
+
+            var agent = (httpClient as any)._getAgent('https://target-server/artifact');
+            var proxyAgent = (httpClient as any)._proxyAgent;
+
+            assert(proxyAgent, 'proxy agent should be created');
+            assert.strictEqual(proxyAgent.options.proxy.port, 443, 'port should default to 443 for HTTPS proxy');
+            assert.strictEqual(typeof proxyAgent.options.proxy.port, 'number', 'port should be of type number');
+        });
+
+        it('HTTPS target through HTTP proxy should create tunnel agent', () => {
+            var httpClient = new HttpClient('test-agent', [], {
+                proxy: {
+                    proxyUrl: 'http://proxy-server:3128',
+                    proxyUsername: '',
+                    proxyPassword: ''
+                }
+            });
+
+            var agent = (httpClient as any)._getAgent('https://artifacts.dev.azure.com/download');
+            var proxyAgent = (httpClient as any)._proxyAgent;
+
+            assert(proxyAgent, 'proxy agent should be created for HTTPS target through HTTP proxy');
+            assert.strictEqual(proxyAgent.options.proxy.host, 'proxy-server', 'proxy host should be set');
+            assert.strictEqual(proxyAgent.options.proxy.port, 3128, 'proxy port should be numeric 3128');
+        });
+
+        it('HTTP target through HTTP proxy should create tunnel agent', () => {
+            var httpClient = new HttpClient('test-agent', [], {
+                proxy: {
+                    proxyUrl: 'http://proxy-server:3128',
+                    proxyUsername: '',
+                    proxyPassword: ''
+                }
+            });
+
+            var agent = (httpClient as any)._getAgent('http://artifacts.dev.azure.com/download');
+            var proxyAgent = (httpClient as any)._proxyAgent;
+
+            assert(proxyAgent, 'proxy agent should be created for HTTP target through HTTP proxy');
+            assert.strictEqual(proxyAgent.options.proxy.host, 'proxy-server', 'proxy host should be set');
+            assert.strictEqual(proxyAgent.options.proxy.port, 3128, 'proxy port should be numeric 3128');
+        });
+
+        it('tunnel agent should include proxy auth credentials with special characters', () => {
+            var httpClient = new HttpClient('test-agent', [], {
+                proxy: {
+                    proxyUrl: 'http://proxy-server:8080',
+                    proxyUsername: 'admin',
+                    proxyPassword: 'p@ss:w0rd#!'
+                }
+            });
+
+            var agent = (httpClient as any)._getAgent('http://target-server/artifact');
+            var proxyAgent = (httpClient as any)._proxyAgent;
+
+            assert(proxyAgent, 'proxy agent should be created');
+            assert.strictEqual(proxyAgent.options.proxy.proxyAuth, 'admin:p@ss:w0rd#!');
+        });
+
         it('initializeProxy should read proxy settings from globals', () => {
             global['_vsts_task_lib_proxy'] = true;
             global['_vsts_task_lib_proxy_url'] = 'http://myproxy:3128';
@@ -253,6 +355,62 @@ describe('Unit Tests', () => {
             (WebClientFactory as any).initializeProxy(options);
 
             assert.strictEqual(options.ignoreSslError, true);
+        });
+    });
+
+    describe('webClientFactory _readTaskLibSecrets error handling', () => {
+
+        it('should throw ENOENT for corrupted base64 in lookupKey', () => {
+            var corruptedLookup = 'validBase64Path:!!!invalid-base64!!!';
+            var thrownError = null;
+
+            try {
+                (WebClientFactory as any)._readTaskLibSecrets(corruptedLookup);
+            } catch (e) {
+                thrownError = e;
+            }
+
+            assert(thrownError, 'should have thrown an error');
+            assert(thrownError.message.indexOf('ENOENT') >= 0 || thrownError.message.indexOf('no such file') >= 0,
+                'Expected ENOENT error but got: ' + thrownError.message);
+        });
+
+        it('should throw invalid key length when key file content is empty', () => {
+            mockKeyFileContent = '';
+
+            var lookupKey = Buffer.from('/fake/path/.taskkey', 'utf8').toString('base64')
+                + ':'
+                + Buffer.from('deadbeef', 'utf8').toString('base64');
+            var thrownError = null;
+
+            try {
+                (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
+            } catch (e) {
+                thrownError = e;
+            }
+
+            assert(thrownError, 'should have thrown an error');
+            assert(thrownError.message.indexOf('Invalid key length') >= 0,
+                'Expected Invalid key length error but got: ' + thrownError.message);
+        });
+
+        it('should throw invalid key length when key file has only whitespace', () => {
+            mockKeyFileContent = '   \n  ';
+
+            var lookupKey = Buffer.from('/fake/path/.taskkey', 'utf8').toString('base64')
+                + ':'
+                + Buffer.from('deadbeef', 'utf8').toString('base64');
+            var thrownError = null;
+
+            try {
+                (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
+            } catch (e) {
+                thrownError = e;
+            }
+
+            assert(thrownError, 'should have thrown an error');
+            assert(thrownError.message.indexOf('Invalid key length') >= 0,
+                'Expected Invalid key length error but got: ' + thrownError.message);
         });
     });
 });

--- a/Extensions/ArtifactEngineV2/package-lock.json
+++ b/Extensions/ArtifactEngineV2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-engine",
-  "version": "2.274.1",
+  "version": "2.275.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-engine",
-      "version": "2.274.1",
+      "version": "2.275.0",
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.2.8",

--- a/Extensions/ArtifactEngineV2/package-lock.json
+++ b/Extensions/ArtifactEngineV2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-engine",
-  "version": "2.273.0",
+  "version": "2.274.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-engine",
-      "version": "2.273.0",
+      "version": "2.274.1",
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.2.8",

--- a/Extensions/ArtifactEngineV2/package.json
+++ b/Extensions/ArtifactEngineV2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "2.274.1",
+  "version": "2.275.0",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",

--- a/Extensions/ArtifactEngineV2/package.json
+++ b/Extensions/ArtifactEngineV2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "2.274.0",
+  "version": "2.274.1",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Adds 24 unit tests for the proxy tunneling and IV decryption fixes merged in PR #1375. These tests validate the correctness of the fixes for ICM 792049165.

## Tests Added

### Secret Decryption (\_readTaskLibSecrets)
- Round-trip encrypt/decrypt with \key:iv\ format
- Special characters, unicode, empty string, long secrets
- Null/empty/invalid lookupKey edge cases
- Different key+IV each invocation

### Proxy & Client Configuration
- Proxy port numeric cast verification
- Proxy/cert/SSL settings read from agent globals
- Preservation of existing proxy options

## Related
- PR #1375 (merged) — Fix proxy tunneling: cast port to Number and read IV from key file
- ICM 792049165 — DownloadBuildArtifacts proxy regression