### PR TITLE
Automatically update Test extension version in CI pipeline before publishing

### DIFF
--- a/.pipelines/1es-migration/azure-pipelines-integration.yml
+++ b/.pipelines/1es-migration/azure-pipelines-integration.yml
@@ -109,6 +109,27 @@ extends:
           displayName: 'Auto-detect changed extensions'
           workingDirectory: '$(Build.SourcesDirectory)'
 
+        - task: AzureCLI@2
+          displayName: 'Bump extension versions to exceed Marketplace'
+          inputs:
+            azureSubscription: '1es-extensions-publication-secure-service-connection'
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              $extensions = '$(DetectedExtensions)' -split ';'
+              foreach ($ext in $extensions) {
+                $ext = $ext.Trim()
+                if (-not $ext) { continue }
+
+                $manifestPath = Join-Path '$(Build.SourcesDirectory)' "Extensions/$ext/Src/vss-extension.json"
+                if (Test-Path $manifestPath) {
+                  Write-Host "--- Bumping version for: $ext ---"
+                  & '$(Build.SourcesDirectory)/scripts/BumpExtensionVersion.ps1' -ManifestPath $manifestPath
+                } else {
+                  Write-Host "##[warning]Manifest not found for '$ext' at $manifestPath — skipping version bump."
+                }
+              }
+
         - task: PowerShell@2
           displayName: 'Build test resources'
           inputs:

--- a/.pipelines/1es-migration/azure-pipelines-integration.yml
+++ b/.pipelines/1es-migration/azure-pipelines-integration.yml
@@ -111,11 +111,13 @@ extends:
 
         - task: AzureCLI@2
           displayName: 'Bump extension versions to exceed Marketplace'
+          condition: ne(variables['DetectedExtensions'], '')
           inputs:
             azureSubscription: '1es-extensions-publication-secure-service-connection'
             scriptType: pscore
             scriptLocation: inlineScript
             inlineScript: |
+              $ErrorActionPreference = 'Stop'
               $extensions = '$(DetectedExtensions)' -split ';'
               foreach ($ext in $extensions) {
                 $ext = $ext.Trim()
@@ -124,7 +126,11 @@ extends:
                 $manifestPath = Join-Path '$(Build.SourcesDirectory)' "Extensions/$ext/Src/vss-extension.json"
                 if (Test-Path $manifestPath) {
                   Write-Host "--- Bumping version for: $ext ---"
-                  & '$(Build.SourcesDirectory)/scripts/BumpExtensionVersion.ps1' -ManifestPath $manifestPath
+                  $scriptPath = Join-Path '$(Build.SourcesDirectory)' 'scripts/BumpExtensionVersion.ps1'
+                  & $scriptPath -ManifestPath $manifestPath
+                  if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
+                    throw "Version update failed for '$ext' with exit code $LASTEXITCODE"
+                  }
                 } else {
                   Write-Host "##[warning]Manifest not found for '$ext' at $manifestPath — skipping version bump."
                 }

--- a/scripts/PublishTestExtensions.ps1
+++ b/scripts/PublishTestExtensions.ps1
@@ -39,8 +39,7 @@ foreach ($vsix in $vsixFiles) {
 
     tfx extension publish --vsix $vsix.FullName `
         --service-url https://marketplace.visualstudio.com `
-        --auth-type pat --token $MarketplaceToken --no-color `
-        --force-update
+        --auth-type pat --token $MarketplaceToken --no-color
 
     if ($LASTEXITCODE -ne 0) {
         Write-Host "##[error]Failed to publish $($vsix.Name)"

--- a/scripts/PublishTestExtensions.ps1
+++ b/scripts/PublishTestExtensions.ps1
@@ -39,7 +39,8 @@ foreach ($vsix in $vsixFiles) {
 
     tfx extension publish --vsix $vsix.FullName `
         --service-url https://marketplace.visualstudio.com `
-        --auth-type pat --token $MarketplaceToken --no-color
+        --auth-type pat --token $MarketplaceToken --no-color `
+        --force-update
 
     if ($LASTEXITCODE -ne 0) {
         Write-Host "##[error]Failed to publish $($vsix.Name)"


### PR DESCRIPTION
**Description**: 

### Problem

CI test pipelines for extensions are triggered with every PR commit. This requires the updated extensions in PR to be installed in the org where CI pipelines exist. Thus, requiring the extensions from the PR to be built and published as TEST(private) extensions to marketplace.

If the extension version from a PR is already published as test to marketplace during one of the previous commits, CI pipeline fails at publish step with below error.

```
error: Version number must increase each time an extension is published.  Extension: 
ms-vscs-rm.vss-services-bitbucket-test  Current version: 15.275.14  Updated version: 15.275.12
##[error]Failed to publish ms-vscs-rm.vss-services-bitbucket-test-15.275.12.vsix
```

### Solution

This PR adds a step to call existing BumpExtensionVersion.ps1 script to automatically update versions for updated extensions in a PR before attempting to publish them.


**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** AB#2364503

**Checklist**:
- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
