### PR TITLE
Fix CredScan violations in webClientFactory tests

### DIFF
--- a/Extensions/ArtifactEngineV2/ProvidersTests/webClientFactoryTests.ts
+++ b/Extensions/ArtifactEngineV2/ProvidersTests/webClientFactoryTests.ts
@@ -81,7 +81,7 @@ describe('Unit Tests', () => {
     describe('webClientFactory _readTaskLibSecrets tests', () => {
 
         it('should round-trip decrypt a secret encrypted with key:iv format', () => {
-            var originalSecret = 'myProxyP@ssw0rd!';
+            var originalSecret = 'testvalue_not_a_real_secret_123';
             var lookupKey = encryptSecret(originalSecret);
 
             var decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
@@ -90,7 +90,7 @@ describe('Unit Tests', () => {
         });
 
         it('should decrypt secrets with special characters', () => {
-            var originalSecret = 'p@$$w0rd!#%^&*()_+-={}[]|\\:";\'<>?,./~`';
+            var originalSecret = 'x!#%^&*()_+-={}[]|\\:";\'<>?,./~`';
             var lookupKey = encryptSecret(originalSecret);
 
             var decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
@@ -145,7 +145,7 @@ describe('Unit Tests', () => {
         });
 
         it('should handle unicode secrets', () => {
-            var originalSecret = '\u03C3\u00BB\u00E5\u03C4\u00E1\u00FC';
+            var originalSecret = '\u03C3\u00BB\u00E5\u03C4\u00E1\u00FC'; // CredScan suppression: test-only unicode value, not a real credential
             var lookupKey = encryptSecret(originalSecret);
 
             var decrypted = (WebClientFactory as any)._readTaskLibSecrets(lookupKey);
@@ -293,7 +293,7 @@ describe('Unit Tests', () => {
                 proxy: {
                     proxyUrl: 'http://proxy-server:8080',
                     proxyUsername: 'admin',
-                    proxyPassword: 'p@ss:w0rd#!'
+                    proxyPassword: 'fake_proxy_test_value'
                 }
             });
 
@@ -301,7 +301,7 @@ describe('Unit Tests', () => {
             var proxyAgent = (httpClient as any)._proxyAgent;
 
             assert(proxyAgent, 'proxy agent should be created');
-            assert.strictEqual(proxyAgent.options.proxy.proxyAuth, 'admin:p@ss:w0rd#!');
+            assert.strictEqual(proxyAgent.options.proxy.proxyAuth, 'admin:fake_proxy_test_value');
         });
 
         it('initializeProxy should read proxy settings from globals', () => {

--- a/Extensions/ArtifactEngineV2/package-lock.json
+++ b/Extensions/ArtifactEngineV2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-engine",
-  "version": "2.275.0",
+  "version": "2.275.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-engine",
-      "version": "2.275.0",
+      "version": "2.275.1",
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.2.8",

--- a/Extensions/ArtifactEngineV2/package.json
+++ b/Extensions/ArtifactEngineV2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "2.275.0",
+  "version": "2.275.1",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
Fix CredScan violations (CSCAN-MSFT0090, CSCAN-GENERAL0060) in webClientFactoryTests.ts that were causing CI build failures.

## Changes
- Replace password-like test values with non-credential strings
- Preserve special character testing logic
- All 24 unit tests continue to pass

