### PR TITLE
Fix three typos in design and authoring docs

### DIFF
--- a/docs/authoring/endpoints/dataSources.md
+++ b/docs/authoring/endpoints/dataSources.md
@@ -337,7 +337,7 @@ Here’s the result after applying the data source binding corresponding to `Slo
 }
 ```
 
-**Note**: In case your response is an arrary of strings like `['value1','value2']` you can use template like `"{ Value : "{{defaultResultKey}}", DisplayValue : "{{defaultResultKey}}" }"`.`defaultResultKey` will take on values `value1`, `value2` e.t.c
+**Note**: In case your response is an array of strings like `['value1','value2']` you can use template like `"{ Value : "{{defaultResultKey}}", DisplayValue : "{{defaultResultKey}}" }"`.`defaultResultKey` will take on values `value1`, `value2` e.t.c
 
 ## Test service endpoint
 

--- a/docs/design/incrementaldownload.md
+++ b/docs/design/incrementaldownload.md
@@ -22,8 +22,8 @@ In Download Fileshare Artifact Task: under advanced options, there will be an op
 ## Artifact Engine Changes
 A CacheProvider will be initialized with a “Hash” that reads the old artifact-metadata.csv
 
-#### PsuedoCode
-The following psuedo-code is invoked in the `artifact-engine`
+#### Pseudocode
+The following pseudo-code is invoked in the `artifact-engine`
 ```
   If(deploymentInput.enableIncrementalDownload is false)
 	{


### PR DESCRIPTION
Cherrypicked from PR #1379 

Found while reading through the design docs. Three small typos fixed, no semantic changes:

- `docs/design/incrementaldownload.md`: "PsuedoCode" → "Pseudocode" (a heading) and the matching inline "psuedo-code" → "pseudo-code" one line below.
- `docs/authoring/endpoints/dataSources.md` line 340: "arrary" → "array".

All three were caught by `codespell` on the docs tree; only the high-confidence cases are included here (no identifier renames, no code changes).