### PR TITLE
Add explicit least-privilege permissions to release-ansible workflow

### DIFF
--- a/.github/workflows/release-ansible.yml
+++ b/.github/workflows/release-ansible.yml
@@ -3,6 +3,9 @@ name: Publish Ansible
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   node-version: 10
   extension-name: ms-vscs-rm.vss-services-ansible-0.258.3.vsix


### PR DESCRIPTION
## What

Cherrypicked from PR #1377 
Adds a workflow-level `permissions: contents: read` block to `.github/workflows/release-ansible.yml`.

## Why

`release-ansible.yml` only:
- checks out the repository
- installs `tfx-cli`
- publishes a prebuilt `.vsix` to the Visual Studio Marketplace via the `AZURE_DEVOPS_MARKETPLACE_PAT` secret

It performs no git push, no release creation, and no GitHub API write. The `GITHUB_TOKEN` here only needs read access for the checkout step, so declaring `contents: read` at the workflow level documents that explicitly and removes reliance on the repository/org default token scope.

The sibling workflow `release-iiswebapp.yml` in this repo already declares permissions; this PR brings `release-ansible.yml` in line with that pattern.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-ansible.yml'))"` passes.
- No change to job steps; only the workflow-level `permissions:` block is added.

## Reference

GitHub security guidance: [Automatic token authentication — Setting minimum permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token).