### PR TITLE
Fix file not found error in  iis extension

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -298,7 +298,7 @@ var copyGroup = function (group, sourceRoot, destRoot) {
     // build the source array
     var source = typeof group.source == 'string' ? [group.source] : group.source;
     source = source.map(function (val) { // root the paths
-        // Use forward slashes for glob compatibility (shelljs 0.10 + fast-glob
+        // shelljs 0.10 uses fast-glob which treats backslashes as escape characters
         return path.join(sourceRoot, val).split(path.sep).join('/');
     });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -298,7 +298,8 @@ var copyGroup = function (group, sourceRoot, destRoot) {
     // build the source array
     var source = typeof group.source == 'string' ? [group.source] : group.source;
     source = source.map(function (val) { // root the paths
-        return path.join(sourceRoot, val);
+        // Use forward slashes for glob compatibility (shelljs 0.10 + fast-glob
+        return path.join(sourceRoot, val).split(path.sep).join('/');
     });
 
     // create the destination directory


### PR DESCRIPTION
**Description**: 

**Problem**

VstsTaskSdk files not copied during build on Windows

After upgrading shelljs from 0.3.0 to 0.10.0, the gulp build silently fails to copy PowerShell module files(*.ps1, *.psd1, *.psm1) into task output directories. This results in the IIS extension failing at runtime with:

##[error]File not found: ...\ps_modules\VstsTaskSdk\VstsTaskSdk.psd1'

[Failing pipeline run](https://dev.azure.com/canarytest/PipelineTasks/_build/results?buildId=297246&view=results) 

**Root Cause**

shelljs 0.10.0 replaced node-glob with fast-glob for pattern expansion. fast-glob treats backslashes (\) as escape characters rather than path separators (https://github.com/shelljs/shelljs/issues/1246). On Windows, path.join() produces backslash paths (e.g., C:\temp\archive\*.ps1), so fast-glob interprets \* as an escaped literal asterisk — returning zero matches.

**Fix**

Normalize paths to use forward slashes before passing to shell.cp(), which is valid on all platforms in Node.js.
[Test pipeline run after fix](https://dev.azure.com/canarytest/PipelineTasks/_build/results?buildId=299745&view=results)

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
