### PR TITLE
Add check to verify version update

### DIFF
--- a/.pipelines/1es-migration/azure-pipelines-integration.yml
+++ b/.pipelines/1es-migration/azure-pipelines-integration.yml
@@ -111,13 +111,13 @@ extends:
 
         - task: AzureCLI@2
           displayName: 'Verify extension versions are bumped'
-          condition: eq(variables['Build.Reason'], 'PullRequest')
+          condition: and(eq(variables['Build.Reason'], 'PullRequest'), ne(variables['DetectedExtensions'], ''))
           inputs:
             azureSubscription: '1es-extensions-publication-secure-service-connection'
             scriptType: pscore
             scriptLocation: scriptPath
             scriptPath: '$(Build.SourcesDirectory)/scripts/VerifyExtensionVersions.ps1'
-            arguments: '-SourceDirectory "$(Build.SourcesDirectory)"'
+            arguments: '-Extensions "$(DetectedExtensions)" -SourceDirectory "$(Build.SourcesDirectory)"'
 
         - task: PowerShell@2
           displayName: 'Build test resources'

--- a/.pipelines/1es-migration/azure-pipelines-integration.yml
+++ b/.pipelines/1es-migration/azure-pipelines-integration.yml
@@ -234,7 +234,7 @@ extends:
         dependsOn:
         - Build_And_Package_Test_Extension
         - Publish_Test_Extension
-        condition: and(not(failed('Publish_Test_Extension')), eq(dependencies.Build_And_Package_Test_Extension.outputs['BuildAndPackage.DetectExtensions.HasExtensionChanges'], 'true'))
+        condition: and(succeeded('Publish_Test_Extension'), eq(dependencies.Build_And_Package_Test_Extension.outputs['BuildAndPackage.DetectExtensions.HasExtensionChanges'], 'true'))
         variables:
           CI_TESTS_ORG_URL: 'https://dev.azure.com/canarytest'
           CI_TESTS_PROJECT: 'PipelineTasks'

--- a/.pipelines/1es-migration/azure-pipelines-integration.yml
+++ b/.pipelines/1es-migration/azure-pipelines-integration.yml
@@ -109,6 +109,15 @@ extends:
           displayName: 'Auto-detect changed extensions'
           workingDirectory: '$(Build.SourcesDirectory)'
 
+        - task: AzureCLI@2
+          displayName: 'Verify extension versions are bumped'
+          inputs:
+            azureSubscription: '1es-extensions-publication-secure-service-connection'
+            scriptType: pscore
+            scriptLocation: scriptPath
+            scriptPath: '$(Build.SourcesDirectory)/scripts/VerifyExtensionVersions.ps1'
+            arguments: '-SourceDirectory "$(Build.SourcesDirectory)"'
+
         - task: PowerShell@2
           displayName: 'Build test resources'
           inputs:

--- a/.pipelines/1es-migration/azure-pipelines-integration.yml
+++ b/.pipelines/1es-migration/azure-pipelines-integration.yml
@@ -111,6 +111,7 @@ extends:
 
         - task: AzureCLI@2
           displayName: 'Verify extension versions are bumped'
+          condition: eq(variables['Build.Reason'], 'PullRequest')
           inputs:
             azureSubscription: '1es-extensions-publication-secure-service-connection'
             scriptType: pscore

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ While updating an extension or its tasks it is important to ensure that:
 
     - For any changed task, we need to update the version number for both, the changed task (in `task.json` file) and extension itself (in `vss-extension.json` file).
     - If only logic around the extension is changed, update the version number for extension only (in `vss-extension.json` file).
+    - **If a shared/common file is changed, update the version number for ALL publishable extensions.** Shared infrastructure files can introduce regressions across all extensions, so a version bump ensures each extension is re-validated and re-published. Shared files include:
+      - `Extensions/Common/`, `Extensions/ArtifactEngine/`, `Extensions/ArtifactEngineV2/`
+      - Root config files: `package.json`, `package-lock.json`, `gulpfile.js`, `tsconfig.json`, `common.json`, `externals.json`, `package.js`, `package-utils.js`, `base.tsconfig.json`
+      - Directories: `definitions/`, `TaskModules/`, `scripts/`, `.pipelines/`, `ci/`
+      - Note: Documentation files (`.md`, `.txt`) and images (`.png`, `.jpg`, `.gif`) in these paths are excluded from this rule.
     - The version number consist of three parts (major, minor, patch). Be aware that minor number should reflect [the current sprint](https://whatsprintis.it/) of Azure DevOps team in which change is being made. Patch number starts from 0 for the initial version, and increments for every change.
 
 2. The changed extension is published to [Marketplace](https://marketplace.visualstudio.com/azuredevops/).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -904,7 +904,25 @@ function getChangedFiles() {
     return files;
 }
 
-const SHARED_INFRA_PREFIXES = ['Extensions/Common/', 'package.json', 'gulpfile.js', 'scripts/', '.pipelines/', 'ci/'];
+const SHARED_INFRA_PREFIXES = [
+    'Extensions/Common/',
+    'Extensions/ArtifactEngine/',
+    'Extensions/ArtifactEngineV2/',
+    'common.json',
+    'externals.json',
+    'package.json',
+    'package-lock.json',
+    'package.js',
+    'package-utils.js',
+    'base.tsconfig.json',
+    'tsconfig.json',
+    'gulpfile.js',
+    'definitions/',
+    'TaskModules/',
+    'scripts/',
+    '.pipelines/',
+    'ci/'
+];
 const SHARED_INFRA_IGNORE_EXTENSIONS = ['.md', '.txt', '.png', '.jpg', '.gif'];
 
 /**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -905,14 +905,18 @@ function getChangedFiles() {
 }
 
 const SHARED_INFRA_PREFIXES = ['Extensions/Common/', 'package.json', 'gulpfile.js', 'scripts/', '.pipelines/', 'ci/'];
+const SHARED_INFRA_IGNORE_EXTENSIONS = ['.md', '.txt', '.png', '.jpg', '.gif'];
 
 /**
  * Returns true if any changed file touches shared infrastructure.
+ * Documentation and image files (.md, .txt, .png, .jpg, .gif) are excluded.
  * @param {string[]} files
  * @returns {boolean}
  */
 function hitsSharedInfra(files) {
     return files.some(function (f) {
+        var dotIndex = f.lastIndexOf('.');
+        if (dotIndex >= 0 && SHARED_INFRA_IGNORE_EXTENSIONS.indexOf(f.substring(dotIndex).toLowerCase()) >= 0) return false;
         return SHARED_INFRA_PREFIXES.some(function (p) { return f === p || f.indexOf(p) === 0; });
     });
 }

--- a/scripts/BumpExtensionVersion.ps1
+++ b/scripts/BumpExtensionVersion.ps1
@@ -23,7 +23,9 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)]
-    [string]$ManifestPath
+    [string]$ManifestPath,
+
+    [switch]$VerifyOnly
 )
 
 $ErrorActionPreference = 'Stop'
@@ -161,6 +163,11 @@ $newVersionStr = $localVersionStr
 
 if ($marketplaceVersion) {
     if ($localVersion -le $marketplaceVersion) {
+        if ($VerifyOnly) {
+            Write-Host "##[error]Version NOT bumped: local ($localVersion) <= Marketplace ($marketplaceVersion)"
+            exit 1
+        }
+
         $newVersionStr = "$($marketplaceVersion.Major).$($marketplaceVersion.Minor).$($marketplaceVersion.Build + 1)"
         Write-Host "Bumping   : $localVersion -> $newVersionStr  (local <= Marketplace max)"
 

--- a/scripts/BumpExtensionVersion.ps1
+++ b/scripts/BumpExtensionVersion.ps1
@@ -19,6 +19,10 @@
 
 .PARAMETER ManifestPath
     Path to the vss-extension.json file to check and update if necessary.
+
+.PARAMETER VerifyOnly
+    If specified, the script will only verify if the local version is greater than
+    the Marketplace version and will return an error if a bump is needed.
 #>
 [CmdletBinding()]
 param(

--- a/scripts/VerifyExtensionVersions.ps1
+++ b/scripts/VerifyExtensionVersions.ps1
@@ -1,0 +1,88 @@
+<#
+.SYNOPSIS
+    Verifies that all extensions with actual file changes have their manifest
+    version bumped above the current Marketplace version.
+
+.DESCRIPTION
+    Uses git diff to detect which extensions have file changes (ignoring shared
+    infra), then calls BumpExtensionVersion.ps1 -VerifyOnly for each.
+    Fails the pipeline if any extension version is not bumped.
+
+.PARAMETER SourceDirectory
+    Root of the repository checkout (contains the Extensions/ folder).
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$SourceDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Determine changed extensions via git diff (only Extensions/<name>/ paths)
+# ---------------------------------------------------------------------------
+$targetBranch = $env:SYSTEM_PULLREQUEST_TARGETBRANCH -replace '^refs/heads/', ''
+if (-not $targetBranch) {
+    Write-Host "Not a PR build — skipping version verification."
+    exit 0
+}
+
+try {
+    git fetch --no-tags --quiet --depth=200 origin "${targetBranch}:refs/remotes/origin/$targetBranch" 2>$null
+} catch {
+    Write-Warning "git fetch failed: $($_.Exception.Message)"
+}
+
+$changedFiles = git diff --name-only "origin/$targetBranch...HEAD" 2>$null
+if ($LASTEXITCODE -ne 0) {
+    $changedFiles = git diff --name-only "origin/$targetBranch" HEAD 2>$null
+}
+
+$changedExtensions = $changedFiles |
+    Where-Object { $_ -match '^Extensions/([^/]+)/' } |
+    ForEach-Object { $Matches[1] } |
+    Select-Object -Unique |
+    Where-Object { $_ -ne 'Common' }
+
+if (-not $changedExtensions -or $changedExtensions.Count -eq 0) {
+    Write-Host "No extension-specific file changes detected — skipping version verification."
+    exit 0
+}
+
+Write-Host "Extensions with file changes: $($changedExtensions -join ', ')"
+Write-Host ""
+
+# ---------------------------------------------------------------------------
+# Verify each extension by calling BumpExtensionVersion.ps1 -VerifyOnly
+# ---------------------------------------------------------------------------
+$scriptPath = Join-Path $SourceDirectory 'scripts/BumpExtensionVersion.ps1'
+$failures = @()
+
+foreach ($ext in $changedExtensions) {
+    $manifestPath = Join-Path $SourceDirectory "Extensions/$ext/Src/vss-extension.json"
+    if (-not (Test-Path $manifestPath)) {
+        Write-Host "##[warning]No manifest for '$ext' — skipping (not a publishable extension)."
+        continue
+    }
+
+    Write-Host "--- Verifying: $ext ---"
+    & $scriptPath -ManifestPath $manifestPath -VerifyOnly
+
+    if ($LASTEXITCODE -ne 0) {
+        $failures += $ext
+    }
+    Write-Host ""
+}
+
+# ---------------------------------------------------------------------------
+# Report result
+# ---------------------------------------------------------------------------
+if ($failures.Count -gt 0) {
+    Write-Host "##[error]Version not bumped for: $($failures -join ', ')"
+    Write-Host "##[error]Please update the 'version' field in vss-extension.json to exceed the Marketplace version."
+    Write-Host "##[error]Run: scripts/BumpExtensionVersion.ps1 -ManifestPath Extensions/<name>/Src/vss-extension.json"
+    exit 1
+}
+
+Write-Host "All extension versions are valid."

--- a/scripts/VerifyExtensionVersions.ps1
+++ b/scripts/VerifyExtensionVersions.ps1
@@ -28,6 +28,7 @@ if (-not $targetBranch) {
     exit 0
 }
 
+$ErrorActionPreference = 'Continue'
 try {
     git fetch --no-tags --quiet --depth=200 origin "${targetBranch}:refs/remotes/origin/$targetBranch" 2>$null
 } catch {
@@ -38,14 +39,20 @@ $changedFiles = git diff --name-only "origin/$targetBranch...HEAD" 2>$null
 if ($LASTEXITCODE -ne 0) {
     $changedFiles = git diff --name-only "origin/$targetBranch" HEAD 2>$null
 }
+$ErrorActionPreference = 'Stop'
 
-$changedExtensions = $changedFiles |
+if (-not $changedFiles) {
+    Write-Host "No changed files detected — skipping version verification."
+    exit 0
+}
+
+[array]$changedExtensions = $changedFiles |
     Where-Object { $_ -match '^Extensions/([^/]+)/' } |
     ForEach-Object { $Matches[1] } |
     Select-Object -Unique |
     Where-Object { $_ -ne 'Common' }
 
-if (-not $changedExtensions -or $changedExtensions.Count -eq 0) {
+if ($changedExtensions.Count -eq 0) {
     Write-Host "No extension-specific file changes detected — skipping version verification."
     exit 0
 }
@@ -67,7 +74,9 @@ foreach ($ext in $changedExtensions) {
     }
 
     Write-Host "--- Verifying: $ext ---"
+    $ErrorActionPreference = 'Continue'
     & $scriptPath -ManifestPath $manifestPath -VerifyOnly
+    $ErrorActionPreference = 'Stop'
 
     if ($LASTEXITCODE -ne 0) {
         $failures += $ext

--- a/scripts/VerifyExtensionVersions.ps1
+++ b/scripts/VerifyExtensionVersions.ps1
@@ -1,12 +1,16 @@
 <#
 .SYNOPSIS
-    Verifies that all extensions with actual file changes have their manifest
-    version bumped above the current Marketplace version.
+    Verifies that all detected extensions have their manifest version bumped
+    above the current Marketplace version.
 
 .DESCRIPTION
-    Uses git diff to detect which extensions have file changes (ignoring shared
-    infra), then calls BumpExtensionVersion.ps1 -VerifyOnly for each.
-    Fails the pipeline if any extension version is not bumped.
+    Accepts a semicolon-separated list of extension names (from the
+    detectChangedExtensions gulp task) and calls BumpExtensionVersion.ps1
+    -VerifyOnly for each. Fails the pipeline if any extension version is
+    not bumped.
+
+.PARAMETER Extensions
+    Semicolon-separated list of extension folder names to verify.
 
 .PARAMETER SourceDirectory
     Root of the repository checkout (contains the Extensions/ folder).
@@ -14,50 +18,22 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)]
+    [string]$Extensions,
+
+    [Parameter(Mandatory)]
     [string]$SourceDirectory
 )
 
 $ErrorActionPreference = 'Stop'
 
-# ---------------------------------------------------------------------------
-# Determine changed extensions via git diff (only Extensions/<name>/ paths)
-# ---------------------------------------------------------------------------
-$targetBranch = $env:SYSTEM_PULLREQUEST_TARGETBRANCH -replace '^refs/heads/', ''
-if (-not $targetBranch) {
-    Write-Host "Not a PR build — skipping version verification."
+[array]$extensionList = $Extensions -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+
+if ($extensionList.Count -eq 0) {
+    Write-Host "No extensions to verify — skipping."
     exit 0
 }
 
-$ErrorActionPreference = 'Continue'
-try {
-    git fetch --no-tags --quiet --depth=200 origin "${targetBranch}:refs/remotes/origin/$targetBranch" 2>$null
-} catch {
-    Write-Warning "git fetch failed: $($_.Exception.Message)"
-}
-
-$changedFiles = git diff --name-only "origin/$targetBranch...HEAD" 2>$null
-if ($LASTEXITCODE -ne 0) {
-    $changedFiles = git diff --name-only "origin/$targetBranch" HEAD 2>$null
-}
-$ErrorActionPreference = 'Stop'
-
-if (-not $changedFiles) {
-    Write-Host "No changed files detected — skipping version verification."
-    exit 0
-}
-
-[array]$changedExtensions = $changedFiles |
-    Where-Object { $_ -match '^Extensions/([^/]+)/' } |
-    ForEach-Object { $Matches[1] } |
-    Select-Object -Unique |
-    Where-Object { $_ -ne 'Common' }
-
-if ($changedExtensions.Count -eq 0) {
-    Write-Host "No extension-specific file changes detected — skipping version verification."
-    exit 0
-}
-
-Write-Host "Extensions with file changes: $($changedExtensions -join ', ')"
+Write-Host "Extensions to verify: $($extensionList -join ', ')"
 Write-Host ""
 
 # ---------------------------------------------------------------------------
@@ -66,7 +42,7 @@ Write-Host ""
 $scriptPath = Join-Path $SourceDirectory 'scripts/BumpExtensionVersion.ps1'
 $failures = @()
 
-foreach ($ext in $changedExtensions) {
+foreach ($ext in $extensionList) {
     $manifestPath = Join-Path $SourceDirectory "Extensions/$ext/Src/vss-extension.json"
     if (-not (Test-Path $manifestPath)) {
         Write-Host "##[warning]No manifest for '$ext' — skipping (not a publishable extension)."
@@ -90,7 +66,7 @@ foreach ($ext in $changedExtensions) {
 if ($failures.Count -gt 0) {
     Write-Host "##[error]Version not bumped for: $($failures -join ', ')"
     Write-Host "##[error]Please update the 'version' field in vss-extension.json to exceed the Marketplace version."
-    Write-Host "##[error]Run: scripts/BumpExtensionVersion.ps1 -ManifestPath Extensions/<name>/Src/vss-extension.json"
+    Write-Host "##[error]Run: gulp build --syncVersions $($failures -join ',')"
     exit 1
 }
 


### PR DESCRIPTION
**Description**: Adds a version verification step to the CI pipeline that checks whether all affected extensions have their vss-extension.json version bumped above the current Marketplace version. If any extension version is not bumped, the pipeline fails and blocks the PR from merging. 

**Changes:** 

-  Added an AzureCLI@2 step in .pipelines/1es-migration/azure-pipelines-integration.yml after extension detection and before the build step, gated on PR builds only.
 - Added -VerifyOnly switch to scripts/BumpExtensionVersion.ps1 — exits with code 1 if the local version ≤ Marketplace version,without modifying any files.
 - Added `scripts/VerifyExtensionVersions.ps1` — accepts the list of detected extensions (from the `detectChangedExtensions` gulptask) and calls `BumpExtensionVersion.ps1 -VerifyOnly`  to validate if versions are updated for affected extensions.

 -   Updated `gulpfile.js` to exclude documentation/image files (`.md`, `.txt`, `.png`, `.jpg`, `.gif`) from shared infrastructure detection. Version update will not be required if any of these files are updated. Also extended list of common files in `SHARED_INFRA_PREFIXES ` array to include all the common files changing which may affect extensions.
 - Updated `README.md` — documents when and why version bumps are required, including shared infrastructure changes.


Flow:

 1. `gulp detectChangedExtensions` identifies which extensions have changes (uses git diff internally)
 2. If shared/common files are changed (e.g., `Extensions/Common/`, `package.json`, `gulpfile.js`, etc.), ALL publishable extensions are flagged — as common file changes can introduce regressions across all extensions.
 3. Documentation/image files in shared paths are excluded from this rule
 4. For each detected extension, verifies local manifest version > Marketplace max
 5. Fails with actionable error messages listing all extensions that need a version bump and the command to fix them 


**Added unit tests:** N

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
