### PR TITLE
Move engine definitions to package.json and update npm configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 registry=https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/
+engine-strict=true

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,14 +1,13 @@
 // node built-ins
-const path = require('path');
-const os = require('os');
-const cp = require('child_process');
+const path = require('node:path');
+const os = require('node:os');
+const cp = require('node:child_process');
 
 // build/test script
 const admZip = require('adm-zip');
 const del = require('del');
 const fs = require('fs-extra');
 const minimist = require('minimist');
-const semver = require('semver');
 const shell = require('shelljs');
 // @ts-ignore
 const syncRequest = require('sync-request');
@@ -21,15 +20,6 @@ const gulp = require('gulp');
 
 const pkgm = require('./package');
 const util = require('./package-utils');
-
-// validation
-var NPM_MIN_VER = '9.0.0';
-var MIN_NODE_VER = '18.0.0';
-
-if (semver.lt(process.versions.node, MIN_NODE_VER)) {
-    console.error('requires node >= ' + MIN_NODE_VER + '.  installed: ' + process.versions.node);
-    process.exit(1);
-}
 
 const options = minimist(process.argv.slice(2), {
     string: ['suite', 'testAreaPath', 'publisher', 'extension', 'syncVersions'],
@@ -1204,10 +1194,7 @@ function cacheNpmPackage(name, version) {
     // Validate the version of npm.
     const versionOutput = cp.execSync('"' + npmPath + '" --version');
     const npmVersion = versionOutput.toString().replace(/[\n\r]+/g, '')
-    console.log('npm version: "' + npmVersion + '"');
-    if (semver.lt(npmVersion, NPM_MIN_VER)) {
-        throw new Error('npm version must be at least ' + NPM_MIN_VER + '. Found ' + npmVersion);
-    }
+    console.log(`npm version: ${npmVersion}`);
 
     // Make a node_modules directory. Otherwise the modules will be installed in a node_modules
     // directory further up the directory hierarchy.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@types/gulp": "^4.0.17",
         "@types/gulp-mocha": "^0.0.37",
         "@types/minimist": "^1.2.5",
-        "@types/semver": "^4.3.27",
         "@types/shelljs": "^0.8.17",
         "@types/through2": "^2.0.41",
         "@types/validator": "^5.7.35",
@@ -29,13 +28,16 @@
         "gulp-typescript": "^5.0.1",
         "minimatch": "3.1.5",
         "minimist": "1.2.6",
-        "semver": "^5.7.2",
         "shelljs": "^0.10.0",
         "sync-request": "3.0.1",
         "through2": "^2.0.1",
         "typescript": "^4.9.5",
         "validator": "^13.15.22",
         "xml2js": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@gulpjs/messages": {
@@ -196,11 +198,6 @@
     },
     "node_modules/@types/picomatch": {
       "version": "4.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/semver": {
-      "version": "4.3.27",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "type": "git",
     "url": "https://github.com/microsoft/azure-pipelines-extensions.git"
   },
+  "engines": {
+    "npm": ">=9.0.0",
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "build": "gulp build",
     "test": "gulp test"
@@ -19,7 +23,6 @@
     "@types/gulp": "^4.0.17",
     "@types/gulp-mocha": "^0.0.37",
     "@types/minimist": "^1.2.5",
-    "@types/semver": "^4.3.27",
     "@types/shelljs": "^0.8.17",
     "@types/through2": "^2.0.41",
     "@types/validator": "^5.7.35",
@@ -33,7 +36,6 @@
     "gulp-typescript": "^5.0.1",
     "minimatch": "3.1.5",
     "minimist": "1.2.6",
-    "semver": "^5.7.2",
     "shelljs": "^0.10.0",
     "sync-request": "3.0.1",
     "through2": "^2.0.1",


### PR DESCRIPTION
**Description**: Move Node.js and npm version requirements from manual `semver` checks in `gulpfile.js` to the standard `engines` field in `package.json`, and enforce them via `engine-strict=true` in `.npmrc`. This lets npm itself validate the runtime versions at install time instead of relying on custom code.

Changes:
- `package.json`: added `engines` block requiring `node >=18.0.0` and `npm >=9.0.0`.
- `.npmrc`: added `engine-strict=true` so npm enforces the `engines` constraints.
- `gulpfile.js`: removed the manual `semver`-based node/npm version checks (`MIN_NODE_VER` / `NPM_MIN_VER`) now that npm enforces them; switched node built-in imports to the `node:` protocol and simplified the npm version log line.
- `package.json` / `package-lock.json`: dropped the now-unused `semver` and `@types/semver` dev dependencies.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
