### PR TITLE
Migrate from minimist to parseArgs for argument parsing

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ const { values: options } = parseArgs({
         syncVersions: { type: 'string' },
         perf: { type: 'boolean', default: false },
         e2e: { type: 'boolean', default: false },
-        runAllSuites: { type: 'boolean', default: false },
+        runAllSuites: { type: 'string' },
         test: { type: 'boolean', default: false },
     },
     strict: true,
@@ -957,7 +957,7 @@ function discoverPublishableExtensions() {
 //   []    -> filter resolved to no extensions; caller should skip mocha entirely
 //   [...] -> exact list of extension names to test
 function resolveSuitesToRun() {
-    if (options.runAllSuites === true || String(options.runAllSuites).toLowerCase() === 'true') {
+    if (String(options.runAllSuites).toLowerCase() === 'true') {
         console.log("runAllSuites=true -> running all suites.");
         return null;
     }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,7 +26,7 @@ const { values: options } = parseArgs({
     options: {
         gulpfile: { type: 'string' },
         suite: { type: 'string', default: '**' },
-        testAreaPath: { type: 'string', default: '' },
+        testAreaPath: { type: 'string' },
         publisher: { type: 'string' },
         extension: { type: 'string' },
         syncVersions: { type: 'string' },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,13 +1,13 @@
 // node built-ins
-const path = require('node:path');
-const os = require('node:os');
 const cp = require('node:child_process');
+const os = require('node:os');
+const path = require('node:path');
+const { parseArgs } = require('node:util');
 
 // build/test script
 const admZip = require('adm-zip');
 const del = require('del');
 const fs = require('fs-extra');
-const minimist = require('minimist');
 const shell = require('shelljs');
 // @ts-ignore
 const syncRequest = require('sync-request');
@@ -21,10 +21,21 @@ const gulp = require('gulp');
 const pkgm = require('./package');
 const util = require('./package-utils');
 
-const options = minimist(process.argv.slice(2), {
-    string: ['suite', 'testAreaPath', 'publisher', 'extension', 'syncVersions'],
-    boolean: ['perf', 'e2e', 'runAllSuites'],
-    default: { suite: '**', perf: false, e2e: false, runAllSuites: false }
+const { values: options } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+        suite: { type: 'string', default: '**' },
+        testAreaPath: { type: 'string', default: '' },
+        publisher: { type: 'string' },
+        extension: { type: 'string' },
+        syncVersions: { type: 'string' },
+        perf: { type: 'boolean', default: false },
+        e2e: { type: 'boolean', default: false },
+        runAllSuites: { type: 'boolean', default: false },
+        test: { type: 'boolean', default: false },
+    },
+    strict: true,
+    allowPositionals: true,
 });
 
 const _buildRoot = path.join(__dirname, "_build");

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,6 +24,7 @@ const util = require('./package-utils');
 const { values: options } = parseArgs({
     args: process.argv.slice(2),
     options: {
+        gulpfile: { type: 'string' },
         suite: { type: 'string', default: '**' },
         testAreaPath: { type: 'string', default: '' },
         publisher: { type: 'string' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@types/fs-extra": "^8.0.0",
         "@types/gulp": "^4.0.17",
         "@types/gulp-mocha": "^0.0.37",
-        "@types/minimist": "^1.2.5",
         "@types/shelljs": "^0.8.17",
         "@types/through2": "^2.0.41",
         "@types/validator": "^5.7.35",
@@ -27,7 +26,6 @@
         "gulp-mocha": "^10.0.1",
         "gulp-typescript": "^5.0.1",
         "minimatch": "3.1.5",
-        "minimist": "1.2.6",
         "shelljs": "^0.10.0",
         "sync-request": "3.0.1",
         "through2": "^2.0.1",
@@ -36,8 +34,8 @@
         "xml2js": "^0.6.2"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=9.0.0"
+        "node": ">=20.0.0",
+        "npm": ">=10.8.2"
       }
     },
     "node_modules/@gulpjs/messages": {
@@ -175,11 +173,6 @@
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/minimist": {
-      "version": "1.2.5",
       "dev": true,
       "license": "MIT"
     },
@@ -2956,11 +2949,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.6",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/minipass": {
       "version": "7.1.3",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "url": "https://github.com/microsoft/azure-pipelines-extensions.git"
   },
   "engines": {
-    "npm": ">=9.0.0",
-    "node": ">=18.0.0"
+    "npm": ">=10.8.2",
+    "node": ">=20.0.0"
   },
   "scripts": {
     "build": "gulp build",
@@ -22,7 +22,6 @@
     "@types/fs-extra": "^8.0.0",
     "@types/gulp": "^4.0.17",
     "@types/gulp-mocha": "^0.0.37",
-    "@types/minimist": "^1.2.5",
     "@types/shelljs": "^0.8.17",
     "@types/through2": "^2.0.41",
     "@types/validator": "^5.7.35",
@@ -35,7 +34,6 @@
     "gulp-mocha": "^10.0.1",
     "gulp-typescript": "^5.0.1",
     "minimatch": "3.1.5",
-    "minimist": "1.2.6",
     "shelljs": "^0.10.0",
     "sync-request": "3.0.1",
     "through2": "^2.0.1",


### PR DESCRIPTION
**Description**: Replaces the third-party `minimist` dependency with Node.js's built-in `node:util` `parseArgs` for CLI argument parsing in `gulpfile.js`.

Changes:
- `gulpfile.js`: Swap `minimist(...)` for `parseArgs({ ... })`. Options are declared per-flag (`suite`, `testAreaPath`, `publisher`, `extension`, `syncVersions`, `perf`, `e2e`, `runAllSuites`, `test`) with explicit `type` and `default`. Uses `strict: true` and `allowPositionals: true`, and destructures `values` as `options` to preserve the existing call sites.
- `package.json` / `package-lock.json`:
  - Remove `minimist` and `@types/minimist` from `devDependencies` (no longer needed; `parseArgs` ships with Node).
  - Bump `engines` to `node >=20.0.0` and `npm >=10.8.2` (previously `>=18.0.0` / `>=9.0.0`). `parseArgs` is stable as of Node 18.3+, but the bump aligns with the Node 20.x runtime used by the 1ES pipelines.

Motivation: drops a transitive dependency (and its `@types`), reduces supply-chain surface, and leverages the standard library. Behavior of accepted flags is unchanged; `test` was added to the schema because `strict: true` would otherwise reject the `--test` flag passed by some scripts.

**Documentation changes required:** (N)

**Added unit tests:** (N) — build-script change; covered by running gulp tasks in CI.

**Attached related issue:** (N)

**Checklist**:
- [x] Version was bumped - N/A (build tooling change, no extension/task/library version impacted).
- [x] Checked that applied changes work as expected.
