### PR TITLE
Migrate from fs-extra to native fs module

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,13 +1,12 @@
 // node built-ins
 const cp = require('node:child_process');
-const { rmSync } = require('node:fs');
+const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { parseArgs } = require('node:util');
 
 // build/test script
 const admZip = require('adm-zip');
-const fs = require('fs-extra');
 const shell = require('shelljs');
 // @ts-ignore
 const syncRequest = require('sync-request');
@@ -69,7 +68,7 @@ const rootTsconfigPath = './base.tsconfig.json';
 
 gulp.task("clean", function (cb) {
     [_buildRoot, _packageRoot, nugetPath, _taskModuleBuildRoot].forEach(function (p) {
-        rmSync(p, { recursive: true, force: true });
+        fs.rmSync(p, { recursive: true, force: true });
     });
     cb();
 });
@@ -1074,7 +1073,7 @@ function createVsixPackage(extensionName) {
     const extnManifestPath = path.join(_extnBuildRoot, extensionName, "Src");
 
     if (fs.existsSync(extnManifestPath)) {
-        rmSync(extnOutputPath, { recursive: true, force: true });
+        fs.rmSync(extnOutputPath, { recursive: true, force: true });
 
         if (options.publisher) {
             const extensionManifestPath = path.join(extnManifestPath, "vss-extension.json");

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "devDependencies": {
         "@types/adm-zip": "^0.4.34",
-        "@types/fs-extra": "^8.0.0",
         "@types/gulp": "^4.0.17",
         "@types/gulp-mocha": "^0.0.37",
         "@types/node": "^20.19.41",
@@ -20,7 +19,6 @@
         "@types/xml2js": "^0.4.14",
         "adm-zip": "0.4.11",
         "azure-pipelines-task-lib": "^5.2.10",
-        "fs-extra": "^8.1.0",
         "gulp": "^5.0.1",
         "gulp-mocha": "^10.0.1",
         "gulp-typescript": "^5.0.1",
@@ -112,16 +110,6 @@
       "version": "1.20.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/fs-extra": {
-      "version": "8.1.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/fs-extra/-/fs-extra-8.1.5.tgz",
-      "integrity": "sha1-M6rili07Pskhm1rKJVXuACdPWSc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/glob-stream": {
       "version": "8.0.3",
@@ -1343,21 +1331,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
     "node_modules/fs-mkdirp-stream": {
       "version": "1.0.0",
       "dev": true,
@@ -2554,16 +2527,6 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
     },
     "node_modules/last-run": {
       "version": "2.0.0",
@@ -4218,16 +4181,6 @@
       "dependencies": {
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "through2-filter": "3.0.0"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/utf8-byte-length": {

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 const cp = require('child_process');
 const path = require('path');
 
-const fs = require('fs-extra');
+const fs = require('node:fs');
 const gulp = require('gulp');
 const shell = require('shelljs');
 const through = require('through2');
@@ -112,7 +112,7 @@ function copyCommonModules(currentExtnRoot, commonDeps, commonSrc, extensionSour
                     const src = path.join(commonSrc, dep.module, "Src/");
                     const dest = path.join(targetPath, dep.dest);
                     shell.mkdir('-p', dest);
-                    fs.copy(src, dest, function (err) {
+                    fs.cp(src, dest, { recursive: true }, function (err) {
                         if (err) return console.error(err)
                     });
                 })

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "devDependencies": {
     "@types/adm-zip": "^0.4.34",
-    "@types/fs-extra": "^8.0.0",
     "@types/gulp": "^4.0.17",
     "@types/gulp-mocha": "^0.0.37",
     "@types/node": "^20.19.41",
@@ -28,7 +27,6 @@
     "@types/xml2js": "^0.4.14",
     "adm-zip": "0.4.11",
     "azure-pipelines-task-lib": "^5.2.10",
-    "fs-extra": "^8.1.0",
     "gulp": "^5.0.1",
     "gulp-mocha": "^10.0.1",
     "gulp-typescript": "^5.0.1",


### PR DESCRIPTION
**Description**: Removes the `fs-extra` dependency from the build tooling and replaces its usage with Node.js's built-in `node:fs` module.

Changes:
- `gulpfile.js`: Replace `fs-extra` import with `node:fs`; switch the previously destructured `rmSync` call sites to `fs.rmSync` (clean task and `createVsixPackage`).
- `package.js`: Replace `fs-extra` import with `node:fs`; switch `fs.copy(src, dest, cb)` to `fs.cp(src, dest, { recursive: true }, cb)` in `copyCommonModules`.
- `package.json` / `package-lock.json`: Drop `fs-extra` and `@types/fs-extra` devDependencies and their transitive entries (`jsonfile`, `universalify`).

Rationale: `node:fs` (Node 16.7+) provides `rmSync` and recursive `cp`, making `fs-extra` redundant for these build scripts. Reduces dependency surface and supply-chain footprint.

**Documentation changes required:** N

**Added unit tests:** N – build-tooling refactor only; no product code or runtime behavior changed.

**Attached related issue:** N

**Checklist**:
- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.
- [ ] Checked that applied changes work as expected.
