### PR TITLE
Add support for opting specific tasks out of engine-strict in npm commands

### DIFF
--- a/externals.json
+++ b/externals.json
@@ -9,14 +9,17 @@
         }
     },
     "no-cache": [
-            "Ansible",
-            "DownloadCircleCIArtifacts",
-            "DownloadTeamCityArtifacts",
-            "DownloadExternalBuildArtifacts",
-            "DownloadArtifactsTfsVersionControl",
-            "DownloadArtifactsTfsGit",
-            "DownloadArtifactsBitbucket",
-            "OptimizelyX",
-            "CopyAgentJobVariableToReleaseVariable"
-        ]
+        "Ansible",
+        "DownloadCircleCIArtifacts",
+        "DownloadTeamCityArtifacts",
+        "DownloadExternalBuildArtifacts",
+        "DownloadArtifactsTfsVersionControl",
+        "DownloadArtifactsTfsGit",
+        "DownloadArtifactsBitbucket",
+        "OptimizelyX",
+        "CopyAgentJobVariableToReleaseVariable"
+    ],
+    "no-engine-strict": [
+        "DownloadArtifactsTfsGit"
+    ]
 }

--- a/package.js
+++ b/package.js
@@ -140,6 +140,13 @@ function copyCommonModules(currentExtnRoot, commonDeps, commonSrc, extensionSour
                         const npmrcPath = path.join(taskSourcePath, ".npmrc");
                         const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
                         const npmArgs = ['ci', '--userconfig', `"${npmrcPath}"`];
+                        // Opt specific tasks out of engine-strict. The outer `npx gulp build` loads
+                        // the root .npmrc and exports its settings as npm_config_* env vars, which
+                        // take precedence over any nested .npmrc. A CLI flag is the only thing that
+                        // overrides those inherited env vars without disabling engine-strict globally.
+                        if ((externals['no-engine-strict'] || []).includes(task.name)) {
+                            npmArgs.splice(1, 0, '--no-engine-strict');
+                        }
                         if (util.isDebug()) {
                             npmArgs.splice(1, 0, '--verbose');
                             cp.execFileSync(npmCmd, npmArgs, { stdio: 'inherit', shell: true });


### PR DESCRIPTION
**Description**: Adds a per-task opt-out for `engine-strict` when packaging tasks.

When the root `npx gulp build` runs, npm loads the root `.npmrc` and exports its settings as `npm_config_*` environment variables. Those env vars take precedence over any nested `.npmrc` in a task directory, so a task cannot locally disable `engine-strict` simply by overriding the setting in its own `.npmrc`. The only reliable override without disabling `engine-strict` globally is a CLI flag.

This PR introduces:
- A new `no-engine-strict` array in `externals.json` listing tasks that should be packaged with `engine-strict` disabled. `DownloadArtifactsTfsGit` is added as the first entry (its transitive deps declare engine ranges that fail against the build agent''s Node version).
- A small change in `package.js` that appends `--no-engine-strict` to the `npm ci` invocation when the current task is listed in `no-engine-strict`.

Also reformats the `no-cache` block in `externals.json` to consistent indentation (no functional change).

This is intended as a temporary mitigation until the affected tasks'' dependencies are updated.

**Documentation changes required:** N

**Added unit tests:** N - build-script change validated by running the packaging pipeline.

**Attached related issue:** N

**Checklist**:
- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.
- [ ] Checked that applied changes work as expected.
