### PR TITLE
Add DownloadExternalBuildArtifacts to no-engine-strict list in externals.json

### DIFF
--- a/externals.json
+++ b/externals.json
@@ -6,6 +6,7 @@
         }
     },
     "no-engine-strict": [
-        "DownloadArtifactsTfsGit"
+        "DownloadArtifactsTfsGit",
+        "DownloadExternalBuildArtifacts"
     ]
 }


### PR DESCRIPTION
**Description**: Adds `DownloadExternalBuildArtifacts` to the `no-engine-strict` list in `externals.json` so its `npm ci` runs without `--engine-strict`.

This is needed because the task's dependency tree includes packages whose `engines` field declares a Node range that excludes the Node version the gulp build uses. With `engine-strict` enabled, `npm ci` fails on engine mismatch even though the packages work correctly at runtime. `DownloadArtifactsTfsGit` was already in this list for the same reason.

**Documentation changes required:** N

**Added unit tests:** N — build-config change, no runtime behavior affected.

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - N/A; build-config only, no extension/task/library version change.
- [x] Checked that applied changes work as expected - `gulp build` succeeds for `DownloadExternalBuildArtifacts`.