### PR TITLE
Update package-lock.json: Remove artifact-engine linked dependency

### DIFF
--- a/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package-lock.json
+++ b/Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package-lock.json
@@ -13,32 +13,6 @@
         "underscore": "1.13.8"
       }
     },
-    "../../../../ArtifactEngine": {
-      "name": "artifact-engine",
-      "version": "1.272.0",
-      "license": "MIT",
-      "dependencies": {
-        "azure-pipelines-task-lib": "^5.2.8",
-        "handlebars": "4.7.9",
-        "minimatch": "3.1.5",
-        "tunnel": "0.0.4"
-      },
-      "devDependencies": {
-        "@types/minimatch": "^2.0.29",
-        "@types/mocha": "^10.0.10",
-        "@types/node": "^10.17.0",
-        "@types/xml2js": "^0.4.8",
-        "assert": "1.4.1",
-        "mocha": "^11.7.5",
-        "mocha-tap-reporter": "0.1.3",
-        "nconf": "^0.12.0",
-        "nock": "9.1.0",
-        "nyc": "^15.0.0",
-        "sinon": "4.0.1",
-        "typescript": "4.0.2",
-        "xml2js": "^0.6.2"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -81,9 +55,9 @@
       "license": "MIT"
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk=",
+      "version": "0.5.17",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha1-XAtl83ruxcKpSZXAJPkx9i5LvFo=",
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
@@ -102,13 +76,21 @@
       }
     },
     "node_modules/artifact-engine": {
-      "resolved": "../../../../ArtifactEngine",
-      "link": true
+      "version": "1.273.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/artifact-engine/-/artifact-engine-1.273.0.tgz",
+      "integrity": "sha1-HY+J8JFzStgYLxuPDqmezu4lEmo=",
+      "license": "MIT",
+      "dependencies": {
+        "azure-pipelines-task-lib": "^5.2.8",
+        "handlebars": "4.7.9",
+        "minimatch": "3.1.5",
+        "tunnel": "0.0.4"
+      }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
-      "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
+      "version": "5.2.10",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
+      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -127,9 +109,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
+      "version": "1.1.15",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha1-ptkNVAZyNuX0JXCjtzeNWU2bdzg=",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -246,9 +228,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha1-d31z1yqS+OxNLkEOtHNSpWuOg0A=",
+      "version": "1.16.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha1-KEdKFZ07nRHvYgUKFO1g5N9tYbw=",
       "funding": [
         {
           "type": "individual",
@@ -287,6 +269,27 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha1-bxOQgqtY3E5aDlHv59ta6JDVag8=",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -429,10 +432,25 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
       "license": "MIT"
     },
     "node_modules/nodejs-file-downloader": {
@@ -560,9 +578,9 @@
       }
     },
     "node_modules/sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha1-dV69dSBFkxl34wsgJdNA18kJA3g=",
+      "version": "1.6.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha1-trOevtm9GhiYuFxcAwidp0WQ1vg=",
       "license": "WTFPL OR ISC",
       "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"
@@ -617,6 +635,15 @@
       "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
       "license": "ISC"
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -645,6 +672,28 @@
       "license": "WTFPL",
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.4.tgz",
+      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha1-gjFem7xvKyWIiFis0f/4RBA1t38=",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/underscore": {
@@ -683,6 +732,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "license": "MIT"
     }
   }
 }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
@@ -16,32 +16,6 @@
         "typescript": "5.1.6"
       }
     },
-    "../../../../ArtifactEngine": {
-      "name": "artifact-engine",
-      "version": "1.272.0",
-      "license": "MIT",
-      "dependencies": {
-        "azure-pipelines-task-lib": "^5.2.8",
-        "handlebars": "4.7.9",
-        "minimatch": "3.1.5",
-        "tunnel": "0.0.4"
-      },
-      "devDependencies": {
-        "@types/minimatch": "^2.0.29",
-        "@types/mocha": "^10.0.10",
-        "@types/node": "^10.17.0",
-        "@types/xml2js": "^0.4.8",
-        "assert": "1.4.1",
-        "mocha": "^11.7.5",
-        "mocha-tap-reporter": "0.1.3",
-        "nconf": "^0.12.0",
-        "nock": "9.1.0",
-        "nyc": "^15.0.0",
-        "sinon": "4.0.1",
-        "typescript": "4.0.2",
-        "xml2js": "^0.6.2"
-      }
-    },
     "node_modules/@azure/abort-controller": {
       "version": "2.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
@@ -131,9 +105,9 @@
       }
     },
     "node_modules/@azure/identity": {
-      "version": "4.13.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/identity/-/identity-4.13.0.tgz",
-      "integrity": "sha1-sr5jZGlkq1ng3A6tyo5PVi/DH5Y=",
+      "version": "4.13.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha1-vcCRZYuqWaR+6furSHpLsBhym8M=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
@@ -143,13 +117,35 @@
         "@azure/core-tracing": "^1.0.0",
         "@azure/core-util": "^1.11.0",
         "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^4.2.0",
-        "@azure/msal-node": "^3.5.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
         "open": "^10.1.0",
         "tslib": "^2.2.0"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/@azure/msal-common": {
+      "version": "16.6.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-16.6.2.tgz",
+      "integrity": "sha1-SqeR2yxPN/UDv+EPWux2/VUtr44=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/@azure/msal-node": {
+      "version": "5.2.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-5.2.2.tgz",
+      "integrity": "sha1-D8joICfV95U417PxuFTsDv/xzqI=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.6.2",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@azure/logger": {
@@ -166,33 +162,42 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "4.29.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-browser/-/msal-browser-4.29.1.tgz",
-      "integrity": "sha1-AdwdL27TJeMsA9OTnBcfT00gpW0=",
+      "version": "5.11.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-browser/-/msal-browser-5.11.0.tgz",
+      "integrity": "sha1-As8ggkpKGBWrtQ74jYkQh7cwCcc=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.16.1"
+        "@azure/msal-common": "16.6.2"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
+    "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
+      "version": "16.6.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-16.6.2.tgz",
+      "integrity": "sha1-SqeR2yxPN/UDv+EPWux2/VUtr44=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@azure/msal-common": {
-      "version": "15.16.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-15.16.1.tgz",
-      "integrity": "sha1-XfNpfsDVPQgnjyU21TvVIhTlLDk=",
+      "version": "15.17.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-15.17.0.tgz",
+      "integrity": "sha1-rjwDN4yFJkKxyaMDOA6UXCuJfwI=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.8.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-3.8.9.tgz",
-      "integrity": "sha1-3lRiiscI4wqk1RubmbM60Tn3Jaw=",
+      "version": "3.8.10",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-3.8.10.tgz",
+      "integrity": "sha1-RMkAkFsCPmMUbOrSmZcg8JBsdMo=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.16.1",
+        "@azure/msal-common": "15.17.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -263,9 +268,9 @@
       "license": "MIT"
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.4.tgz",
-      "integrity": "sha1-xfI26lkkyFrY/5bWDs3woiWFQRw=",
+      "version": "0.3.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+      "integrity": "sha1-zMmzVGSqjakJgtAFU9SaXFkdlfM=",
       "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^7.0.0",
@@ -274,15 +279,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@typespec/ts-http-runtime/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/@typespec/ts-http-runtime/node_modules/https-proxy-agent": {
@@ -299,29 +295,34 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk=",
+      "version": "0.5.17",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha1-XAtl83ruxcKpSZXAJPkx9i5LvFo=",
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+      "version": "7.1.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
       "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/artifact-engine": {
-      "resolved": "../../../../ArtifactEngine",
-      "link": true
+      "version": "1.273.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/artifact-engine/-/artifact-engine-1.273.0.tgz",
+      "integrity": "sha1-HY+J8JFzStgYLxuPDqmezu4lEmo=",
+      "license": "MIT",
+      "dependencies": {
+        "azure-pipelines-task-lib": "^5.2.8",
+        "handlebars": "4.7.9",
+        "minimatch": "3.1.5",
+        "tunnel": "0.0.4"
+      }
     },
     "node_modules/async-mutex": {
       "version": "0.4.1",
@@ -355,9 +356,9 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
-      "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
+      "version": "5.2.10",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
+      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -367,15 +368,6 @@
         "semver": "^5.7.2",
         "shelljs": "^0.10.0",
         "uuid": "^3.0.1"
-      }
-    },
-    "node_modules/azure-pipelines-task-lib/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/azure-pipelines-task-lib/node_modules/uuid": {
@@ -389,12 +381,12 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.271.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.271.2.tgz",
-      "integrity": "sha1-lK3Yaxn+x7CSUHpaTdub8HQqPlU=",
+      "version": "3.274.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.274.0.tgz",
+      "integrity": "sha1-b7Zug9HepCuIlzCMhBzboQw+uyI=",
       "license": "MIT",
       "dependencies": {
-        "@azure/identity": "^4.2.1",
+        "@azure/identity": "^4.13.1",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -411,24 +403,6 @@
         "q": "1.5.1",
         "typed-rest-client": "^2.2.0",
         "xml2js": "0.6.2"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/@azure/msal-common": {
-      "version": "13.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-13.3.1.tgz",
-      "integrity": "sha1-ASRlv5QNEjddxHOHt1TM+da5IYA=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/agent-base": {
-      "version": "5.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-5.1.1.tgz",
-      "integrity": "sha1-6Ps/JClZ20TWO+Zl23qOc5U3oyw=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0"
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-devops-node-api": {
@@ -460,68 +434,19 @@
         "node": ">= 16.0.0"
       }
     },
-    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/https-proxy-agent": {
-      "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-      "integrity": "sha1-cCtx+1UgoTKmbeH2dUHZ5iFU2Cs=",
-      "license": "MIT",
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha1-vbVa7Qa/rCV6kMRKRGpz+6VXXI8=",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "agent-base": "5",
-        "debug": "4"
+        "side-channel": "^1.1.0"
       },
       "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/msalv1": {
-      "name": "@azure/msal-node",
-      "version": "1.18.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-1.18.4.tgz",
-      "integrity": "sha1-ySGwRHyS+zsMsev1qadvytLsfCE=",
-      "dependencies": {
-        "@azure/msal-common": "13.3.1",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/msalv2": {
-      "name": "@azure/msal-node",
-      "version": "2.16.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-2.16.3.tgz",
-      "integrity": "sha1-i4BRUq14CwSNbCszsdTibXtGM2g=",
-      "dependencies": {
-        "@azure/msal-common": "14.16.1",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/msalv2/node_modules/@azure/msal-common": {
-      "version": "14.16.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-14.16.1.tgz",
-      "integrity": "sha1-0j7M5AgjpNA610Fg3IGdYuDAp4c=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/msalv3": {
-      "name": "@azure/msal-node",
-      "version": "3.8.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-3.8.9.tgz",
-      "integrity": "sha1-3lRiiscI4wqk1RubmbM60Tn3Jaw=",
-      "dependencies": {
-        "@azure/msal-common": "15.16.1",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/msalv3/node_modules/@azure/msal-common": {
-      "version": "15.16.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-15.16.1.tgz",
-      "integrity": "sha1-XfNpfsDVPQgnjyU21TvVIhTlLDk=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/tunnel": {
@@ -534,16 +459,16 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/typed-rest-client": {
-      "version": "2.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.2.0.tgz",
-      "integrity": "sha1-2gcn5AiEm9tpgg2G7mZK/KNHd6M=",
+      "version": "2.3.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.3.1.tgz",
+      "integrity": "sha1-in5IjaFdo4HoLVy73t0LCIKOiX0=",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",
         "js-md4": "^0.3.2",
-        "qs": "^6.14.1",
+        "qs": "6.15.1",
         "tunnel": "0.0.6",
-        "underscore": "^1.12.1"
+        "underscore": "^1.13.8"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -556,9 +481,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
+      "version": "1.1.15",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha1-ptkNVAZyNuX0JXCjtzeNWU2bdzg=",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -756,9 +681,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha1-HE8sSDcydZfOadLKGQp/3RcjOME=",
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -828,9 +753,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha1-d31z1yqS+OxNLkEOtHNSpWuOg0A=",
+      "version": "1.16.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha1-KEdKFZ07nRHvYgUKFO1g5N9tYbw=",
       "funding": [
         {
           "type": "individual",
@@ -929,6 +854,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha1-bxOQgqtY3E5aDlHv59ta6JDVag8=",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -966,26 +912,26 @@
         "node": ">= 14"
       }
     },
-    "node_modules/http-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+      "integrity": "sha1-cCtx+1UgoTKmbeH2dUHZ5iFU2Cs=",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "5",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/agent-base": {
+      "version": "5.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-5.1.1.tgz",
+      "integrity": "sha1-6Ps/JClZ20TWO+Zl23qOc5U3oyw=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/human-signals": {
@@ -1125,6 +1071,18 @@
       "engines": {
         "node": ">=12",
         "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha1-v0lwtecP2gaGNjzBi/6IBdXtlX4=",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jwa": {
@@ -1275,10 +1233,89 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
+    },
+    "node_modules/msalv1": {
+      "name": "@azure/msal-node",
+      "version": "1.18.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-1.18.4.tgz",
+      "integrity": "sha1-ySGwRHyS+zsMsev1qadvytLsfCE=",
+      "deprecated": "A newer major version of this library is available. Please upgrade to the latest available version.",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "13.3.1",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": "10 || 12 || 14 || 16 || 18"
+      }
+    },
+    "node_modules/msalv1/node_modules/@azure/msal-common": {
+      "version": "13.3.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-13.3.1.tgz",
+      "integrity": "sha1-ASRlv5QNEjddxHOHt1TM+da5IYA=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/msalv2": {
+      "name": "@azure/msal-node",
+      "version": "2.16.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-2.16.3.tgz",
+      "integrity": "sha1-i4BRUq14CwSNbCszsdTibXtGM2g=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "14.16.1",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/msalv2/node_modules/@azure/msal-common": {
+      "version": "14.16.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-14.16.1.tgz",
+      "integrity": "sha1-0j7M5AgjpNA610Fg3IGdYuDAp4c=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/msalv3": {
+      "name": "@azure/msal-node",
+      "version": "3.8.10",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-3.8.10.tgz",
+      "integrity": "sha1-RMkAkFsCPmMUbOrSmZcg8JBsdMo=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "15.17.0",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
       "license": "MIT"
     },
     "node_modules/node-fetch": {
@@ -1311,6 +1348,31 @@
         "https-proxy-agent": "^5.0.0",
         "mime-types": "^2.1.27",
         "sanitize-filename": "^1.6.3"
+      }
+    },
+    "node_modules/nodejs-file-downloader/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/nodejs-file-downloader/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/npm-run-path": {
@@ -1403,9 +1465,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha1-24/V0bHS1rWzOtr4dCmAXxkJ57M=",
+      "version": "6.15.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha1-/VVCbXEEA93MxF4PnqsW23cn7Ok=",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -1503,33 +1565,30 @@
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha1-dV69dSBFkxl34wsgJdNA18kJA3g=",
+      "version": "1.6.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha1-trOevtm9GhiYuFxcAwidp0WQ1vg=",
       "license": "WTFPL OR ISC",
       "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"
       }
     },
     "node_modules/sax": {
-      "version": "1.5.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sax/-/sax-1.5.0.tgz",
-      "integrity": "sha1-tVSbZxBpt6o5LfVex1dM9BEXnrg=",
+      "version": "1.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha1-2lljdikwe5fnxMso4ICnvDhWDVs=",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha1-KEZONgYOmR+noR0CedLT87V6foo=",
+      "version": "5.7.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
       "license": "ISC",
       "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "semver": "bin/semver"
       }
     },
     "node_modules/shebang-command": {
@@ -1586,13 +1645,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha1-EMtZhCYxFdO3oOM2WR4pCoMK+K0=",
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha1-wuC1oUpUCuvuO7xsP4ZmzJtQkSc=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1644,6 +1703,15 @@
       "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
       "license": "ISC"
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -1686,6 +1754,15 @@
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "license": "0BSD"
     },
+    "node_modules/tunnel": {
+      "version": "0.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.4.tgz",
+      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/typed-rest-client": {
       "version": "2.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
@@ -1723,6 +1800,19 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha1-gjFem7xvKyWIiFis0f/4RBA1t38=",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/underscore": {
@@ -1776,6 +1866,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "license": "MIT"
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package-lock.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package-lock.json
@@ -11,32 +11,6 @@
         "underscore": "^1.13.8"
       }
     },
-    "../../../../ArtifactEngine": {
-      "name": "artifact-engine",
-      "version": "1.272.0",
-      "license": "MIT",
-      "dependencies": {
-        "azure-pipelines-task-lib": "^5.2.8",
-        "handlebars": "4.7.9",
-        "minimatch": "3.1.5",
-        "tunnel": "0.0.4"
-      },
-      "devDependencies": {
-        "@types/minimatch": "^2.0.29",
-        "@types/mocha": "^10.0.10",
-        "@types/node": "^10.17.0",
-        "@types/xml2js": "^0.4.8",
-        "assert": "1.4.1",
-        "mocha": "^11.7.5",
-        "mocha-tap-reporter": "0.1.3",
-        "nconf": "^0.12.0",
-        "nock": "9.1.0",
-        "nyc": "^15.0.0",
-        "sinon": "4.0.1",
-        "typescript": "4.0.2",
-        "xml2js": "^0.6.2"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -73,9 +47,9 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk=",
+      "version": "0.5.17",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha1-XAtl83ruxcKpSZXAJPkx9i5LvFo=",
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
@@ -94,13 +68,21 @@
       }
     },
     "node_modules/artifact-engine": {
-      "resolved": "../../../../ArtifactEngine",
-      "link": true
+      "version": "1.273.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/artifact-engine/-/artifact-engine-1.273.0.tgz",
+      "integrity": "sha1-HY+J8JFzStgYLxuPDqmezu4lEmo=",
+      "license": "MIT",
+      "dependencies": {
+        "azure-pipelines-task-lib": "^5.2.8",
+        "handlebars": "4.7.9",
+        "minimatch": "3.1.5",
+        "tunnel": "0.0.4"
+      }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
-      "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
+      "version": "5.2.10",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
+      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -119,9 +101,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
+      "version": "1.1.15",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha1-ptkNVAZyNuX0JXCjtzeNWU2bdzg=",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -238,9 +220,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha1-d31z1yqS+OxNLkEOtHNSpWuOg0A=",
+      "version": "1.16.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha1-KEdKFZ07nRHvYgUKFO1g5N9tYbw=",
       "funding": [
         {
           "type": "individual",
@@ -279,6 +261,27 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha1-bxOQgqtY3E5aDlHv59ta6JDVag8=",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -421,10 +424,25 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
       "license": "MIT"
     },
     "node_modules/nodejs-file-downloader": {
@@ -552,9 +570,9 @@
       }
     },
     "node_modules/sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha1-dV69dSBFkxl34wsgJdNA18kJA3g=",
+      "version": "1.6.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha1-trOevtm9GhiYuFxcAwidp0WQ1vg=",
       "license": "WTFPL OR ISC",
       "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"
@@ -609,6 +627,15 @@
       "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
       "license": "ISC"
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -637,6 +664,28 @@
       "license": "WTFPL",
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.4.tgz",
+      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha1-gjFem7xvKyWIiFis0f/4RBA1t38=",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/underscore": {
@@ -675,6 +724,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "license": "MIT"
     }
   }
 }


### PR DESCRIPTION
**Description**: Regenerates `package-lock.json` for three tasks so `artifact-engine` resolves from the internal npm feed instead of the in-repo sibling at `Extensions/ArtifactEngine`.

Affected lockfiles:
- `Extensions/CircleCI/Src/Tasks/DownloadCircleCIArtifacts/package-lock.json`
- `Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package-lock.json`
- `Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json`

**Why**: npm previously recorded `artifact-engine` as a linked sibling (`"resolved": "../../../../ArtifactEngine", "link": true`) because the local folder satisfied `^1.271.1`. On Windows this materialized as a directory junction inside each task's `node_modules`. `tfx extension create` (0.23.1) does not follow junctions and fails with `EISDIR` while zipping the VSIX. The `--install-links` flag does not help because it only affects `file:` specifiers in `package.json`, not `"link": true` entries already present in the lockfile.

**How**: Lockfiles were regenerated with `Extensions/ArtifactEngine` temporarily renamed so npm fell back to the registry. `artifact-engine` now resolves to `artifact-engine-1.273.0.tgz` from `pkgs.dev.azure.com/.../PipelineTools_PublicPackages`. Several transitive dependencies got refreshed to the latest cached versions on the feed at the same time (`adm-zip`, `brace-expansion`, `follow-redirects`, `sanitize-filename`, `azure-pipelines-task-lib`, plus `handlebars 4.7.9` and its deps now hoisted under each task's `node_modules`).

**Trade-off**: Local edits to `Extensions/ArtifactEngine` no longer automatically flow into these tasks during `gulp build` - to test changes contributors must publish a new `artifact-engine` version to the feed (or use `npm link` manually).

**Documentation changes required:** N

**Added unit tests:** N - lockfile-only change.

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - N/A; lockfile-only change.
- [x] Checked that applied changes work as expected - `gulp clean && gulp build && gulp package --extension=ExternalTfs` produces the VSIX, and `node_modules/artifact-engine` is a real directory (no junction).