### PR TITLE
Fix encoding for mixed binary content in gulp tasks

### DIFF
--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.275.32",
+  "version": "0.275.33",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.275.16",
+  "version": "0.275.17",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.275.17",
+  "version": "0.275.32",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/ArtifactEngine/Engine/artifactEngine.ts
+++ b/Extensions/ArtifactEngine/Engine/artifactEngine.ts
@@ -1,4 +1,4 @@
-﻿import * as path from 'path';
+import * as path from 'path';
 
 var tl = require('azure-pipelines-task-lib/task');
 

--- a/Extensions/ArtifactEngine/Engine/artifactEngineOptions.ts
+++ b/Extensions/ArtifactEngine/Engine/artifactEngineOptions.ts
@@ -1,4 +1,4 @@
-﻿export class ArtifactEngineOptions {
+export class ArtifactEngineOptions {
     retryLimit: number = 5;
     retryIntervalInSeconds: number = 5;
     fileProcessingTimeoutInMinutes: number = 5;

--- a/Extensions/ArtifactEngine/Engine/index.ts
+++ b/Extensions/ArtifactEngine/Engine/index.ts
@@ -1,2 +1,2 @@
-﻿export { ArtifactEngineOptions } from "./artifactEngineOptions";
+export { ArtifactEngineOptions } from "./artifactEngineOptions";
 export { ArtifactEngine } from "./artifactEngine";

--- a/Extensions/ArtifactEngine/EngineTests/artifactEngineTests.ts
+++ b/Extensions/ArtifactEngine/EngineTests/artifactEngineTests.ts
@@ -1,4 +1,4 @@
-﻿import * as assert from 'assert';
+import * as assert from 'assert';
 
 import * as engine from '../Engine';
 import * as providers from '../Providers';

--- a/Extensions/ArtifactEngine/Models/artifactItem.ts
+++ b/Extensions/ArtifactEngine/Models/artifactItem.ts
@@ -1,4 +1,4 @@
-﻿import { ItemType } from "./itemType"
+import { ItemType } from "./itemType"
 
 export class ArtifactItem {
     itemType: ItemType;

--- a/Extensions/ArtifactEngine/Models/artifactprovider.ts
+++ b/Extensions/ArtifactEngine/Models/artifactprovider.ts
@@ -1,4 +1,4 @@
-﻿import {ArtifactItem} from "./artifactItem";
+import {ArtifactItem} from "./artifactItem";
 import { ArtifactItemStore } from '../Store/artifactItemStore';
 
 export interface IArtifactProvider {

--- a/Extensions/ArtifactEngine/Models/index.ts
+++ b/Extensions/ArtifactEngine/Models/index.ts
@@ -1,4 +1,4 @@
-﻿export { ArtifactDownloadTicket } from './artifactDownloadTicket';
+export { ArtifactDownloadTicket } from './artifactDownloadTicket';
 export { ArtifactItem } from "./artifactItem";
 export { IArtifactProvider } from "./artifactprovider";
 export { ItemType } from './itemType';

--- a/Extensions/ArtifactEngine/Models/itemType.ts
+++ b/Extensions/ArtifactEngine/Models/itemType.ts
@@ -1,4 +1,4 @@
-﻿export enum ItemType {
+export enum ItemType {
     Any = <any>"any",
     Folder = <any>"folder",
     File = <any>"file"

--- a/Extensions/ArtifactEngine/Providers/index.ts
+++ b/Extensions/ArtifactEngine/Providers/index.ts
@@ -1,4 +1,4 @@
-﻿export { WebProvider } from "./webProvider";
+export { WebProvider } from "./webProvider";
 export { FilesystemProvider } from "./filesystemProvider";
 export { ZipProvider } from "./zipProvider"
 export { StubProvider } from "./stubProvider";

--- a/Extensions/ArtifactEngine/Providers/stubProvider.ts
+++ b/Extensions/ArtifactEngine/Providers/stubProvider.ts
@@ -1,4 +1,4 @@
-﻿import * as Stream from 'stream';
+import * as Stream from 'stream';
 
 import * as models from '../Models';
 import { ItemType } from '../Models';

--- a/Extensions/ArtifactEngine/Providers/webProvider.ts
+++ b/Extensions/ArtifactEngine/Providers/webProvider.ts
@@ -1,4 +1,4 @@
-﻿import * as fs from 'fs';
+import * as fs from 'fs';
 import * as path from 'path';
 import * as stream from 'stream';
 import * as zlib from 'zlib';

--- a/Extensions/ArtifactEngine/Store/index.ts
+++ b/Extensions/ArtifactEngine/Store/index.ts
@@ -1,1 +1,1 @@
-﻿export { ArtifactItemStore } from './artifactItemStore';
+export { ArtifactItemStore } from './artifactItemStore';

--- a/Extensions/ArtifactEngineV2/Engine/artifactEngine.ts
+++ b/Extensions/ArtifactEngineV2/Engine/artifactEngine.ts
@@ -1,4 +1,4 @@
-﻿import * as path from 'path';
+import * as path from 'path';
 
 var tl = require('azure-pipelines-task-lib/task');
 

--- a/Extensions/ArtifactEngineV2/Engine/artifactEngineOptions.ts
+++ b/Extensions/ArtifactEngineV2/Engine/artifactEngineOptions.ts
@@ -1,4 +1,4 @@
-﻿export class ArtifactEngineOptions {
+export class ArtifactEngineOptions {
     retryLimit: number = 5;
     retryIntervalInSeconds: number = 5;
     fileProcessingTimeoutInMinutes: number = 5;

--- a/Extensions/ArtifactEngineV2/Engine/index.ts
+++ b/Extensions/ArtifactEngineV2/Engine/index.ts
@@ -1,2 +1,2 @@
-﻿export { ArtifactEngineOptions } from "./artifactEngineOptions";
+export { ArtifactEngineOptions } from "./artifactEngineOptions";
 export { ArtifactEngine } from "./artifactEngine";

--- a/Extensions/ArtifactEngineV2/EngineTests/artifactEngineTests.ts
+++ b/Extensions/ArtifactEngineV2/EngineTests/artifactEngineTests.ts
@@ -1,4 +1,4 @@
-﻿import * as assert from 'assert';
+import * as assert from 'assert';
 
 import * as engine from '../Engine';
 import * as providers from '../Providers';

--- a/Extensions/ArtifactEngineV2/Models/artifactItem.ts
+++ b/Extensions/ArtifactEngineV2/Models/artifactItem.ts
@@ -1,4 +1,4 @@
-﻿import { ItemType } from "./itemType"
+import { ItemType } from "./itemType"
 
 export class ArtifactItem {
     itemType: ItemType;

--- a/Extensions/ArtifactEngineV2/Models/artifactprovider.ts
+++ b/Extensions/ArtifactEngineV2/Models/artifactprovider.ts
@@ -1,4 +1,4 @@
-﻿import {ArtifactItem} from "./artifactItem";
+import {ArtifactItem} from "./artifactItem";
 import { ArtifactItemStore } from '../Store/artifactItemStore';
 
 export interface IArtifactProvider {

--- a/Extensions/ArtifactEngineV2/Models/index.ts
+++ b/Extensions/ArtifactEngineV2/Models/index.ts
@@ -1,4 +1,4 @@
-﻿export { ArtifactDownloadTicket } from './artifactDownloadTicket';
+export { ArtifactDownloadTicket } from './artifactDownloadTicket';
 export { ArtifactItem } from "./artifactItem";
 export { IArtifactProvider } from "./artifactprovider";
 export { ItemType } from './itemType';

--- a/Extensions/ArtifactEngineV2/Models/itemType.ts
+++ b/Extensions/ArtifactEngineV2/Models/itemType.ts
@@ -1,4 +1,4 @@
-﻿export enum ItemType {
+export enum ItemType {
     Any = <any>"any",
     Folder = <any>"folder",
     File = <any>"file"

--- a/Extensions/ArtifactEngineV2/Providers/index.ts
+++ b/Extensions/ArtifactEngineV2/Providers/index.ts
@@ -1,4 +1,4 @@
-﻿export { WebProvider } from "./webProvider";
+export { WebProvider } from "./webProvider";
 export { FilesystemProvider } from "./filesystemProvider";
 export { ZipProvider } from "./zipProvider"
 export { StubProvider } from "./stubProvider";

--- a/Extensions/ArtifactEngineV2/Providers/stubProvider.ts
+++ b/Extensions/ArtifactEngineV2/Providers/stubProvider.ts
@@ -1,4 +1,4 @@
-﻿import * as Stream from 'stream';
+import * as Stream from 'stream';
 
 import * as models from '../Models';
 import { ItemType } from '../Models';

--- a/Extensions/ArtifactEngineV2/Providers/webProvider.ts
+++ b/Extensions/ArtifactEngineV2/Providers/webProvider.ts
@@ -1,4 +1,4 @@
-﻿import * as fs from 'fs';
+import * as fs from 'fs';
 import * as path from 'path';
 import * as stream from 'stream';
 import * as zlib from 'zlib';

--- a/Extensions/ArtifactEngineV2/Store/index.ts
+++ b/Extensions/ArtifactEngineV2/Store/index.ts
@@ -1,1 +1,1 @@
-﻿export { ArtifactItemStore } from './artifactItemStore';
+export { ArtifactItemStore } from './artifactItemStore';

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/Bitbucket.njsproj
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/Bitbucket.njsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.275.13",
+  "version": "15.275.36",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.275.36",
+  "version": "15.275.37",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.275.12",
+  "version": "15.275.13",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/CircleCI/Src/vss-extension.json
+++ b/Extensions/CircleCI/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-circleci-extension",
   "name": "CircleCI artifacts for Release Pipeline",
   "publisher": "ms-vscs-rm",
-  "version": "0.275.0",
+  "version": "0.275.3",
   "public": true,
   "description": "Tool for connecting with CircleCI",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/CircleCI/Src/vss-extension.json
+++ b/Extensions/CircleCI/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-circleci-extension",
   "name": "CircleCI artifacts for Release Pipeline",
   "publisher": "ms-vscs-rm",
-  "version": "0.274.0",
+  "version": "0.275.0",
   "public": true,
   "description": "Tool for connecting with CircleCI",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/CircleCI/Src/vss-extension.json
+++ b/Extensions/CircleCI/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-circleci-extension",
   "name": "CircleCI artifacts for Release Pipeline",
   "publisher": "ms-vscs-rm",
-  "version": "0.275.3",
+  "version": "0.275.4",
   "public": true,
   "description": "Tool for connecting with CircleCI",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/Common/DeploymentSDK/Src/InvokeRemoteDeployment.ps1
+++ b/Extensions/Common/DeploymentSDK/Src/InvokeRemoteDeployment.ps1
@@ -1,4 +1,4 @@
-﻿$InitializationScript = {
+$InitializationScript = {
     function Invoke-PsOnRemote
     {
         param(

--- a/Extensions/Common/DeploymentSDK/Src/VisualStudioRemoteDeployer.exe.config
+++ b/Extensions/Common/DeploymentSDK/Src/VisualStudioRemoteDeployer.exe.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup useLegacyV2RuntimeActivationPolicy="true"> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />

--- a/Extensions/Common/DeploymentSDK/Tests/InvokeRemoteDeployment.Tests.ps1
+++ b/Extensions/Common/DeploymentSDK/Tests/InvokeRemoteDeployment.Tests.ps1
@@ -1,4 +1,4 @@
-﻿$currentScriptPath = Split-Path -Parent $MyInvocation.MyCommand.Path
+$currentScriptPath = Split-Path -Parent $MyInvocation.MyCommand.Path
 $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
 $VerbosePreference = 'Continue'
 

--- a/Extensions/Common/DeploymentSDK/Tests/Utility.Tests.ps1
+++ b/Extensions/Common/DeploymentSDK/Tests/Utility.Tests.ps1
@@ -1,4 +1,4 @@
-﻿$currentScriptPath = Split-Path -Parent $MyInvocation.MyCommand.Path
+$currentScriptPath = Split-Path -Parent $MyInvocation.MyCommand.Path
 $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
 $VerbosePreference = 'Continue'
 

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.274.0",
+  "version": "16.275.0",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.275.0",
+  "version": "16.275.3",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,4 +1,4 @@
-﻿﻿{
+{
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
   "version": "16.274.0",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.275.3",
+  "version": "16.275.4",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppDeploy/IISWebAppDeployV1/DeployIISWebApp.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppDeploy/IISWebAppDeployV1/DeployIISWebApp.ps1
@@ -1,4 +1,4 @@
-﻿Import-Module $env:CURRENT_TASK_ROOTDIR\DeploymentSDK\InvokeRemoteDeployment.ps1
+Import-Module $env:CURRENT_TASK_ROOTDIR\DeploymentSDK\InvokeRemoteDeployment.ps1
 Import-Module $env:CURRENT_TASK_ROOTDIR\ps_modules\VstsTaskSdk
 Import-Module $env:CURRENT_TASK_ROOTDIR\ps_modules\Sanitizer
 

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppDeploy/IISWebAppDeployV1/MsDeployOnTargetMachines.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppDeploy/IISWebAppDeployV1/MsDeployOnTargetMachines.ps1
@@ -1,4 +1,4 @@
-﻿Write-Verbose "Entering script MsDeployOnTargetMachines.ps1"
+Write-Verbose "Entering script MsDeployOnTargetMachines.ps1"
 $MsDeployInstallPathRegKey = "HKLM:\SOFTWARE\Microsoft\IIS Extensions\MSDeploy"
 
 function Run-Command

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppDeploy/IISWebAppDeployV2/DeployIISWebApp.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppDeploy/IISWebAppDeployV2/DeployIISWebApp.ps1
@@ -1,4 +1,4 @@
-﻿Import-Module $env:CURRENT_TASK_ROOTDIR\DeploymentSDK\InvokeRemoteDeployment.ps1
+Import-Module $env:CURRENT_TASK_ROOTDIR\DeploymentSDK\InvokeRemoteDeployment.ps1
 Import-Module $env:CURRENT_TASK_ROOTDIR\ps_modules\Sanitizer
 
 Write-Verbose "Entering script DeployIISWebApp.ps1"

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppDeploy/IISWebAppDeployV2/MsDeployOnTargetMachines.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppDeploy/IISWebAppDeployV2/MsDeployOnTargetMachines.ps1
@@ -1,4 +1,4 @@
-﻿Write-Verbose "Entering script MsDeployOnTargetMachines.ps1"
+Write-Verbose "Entering script MsDeployOnTargetMachines.ps1"
 $MsDeployInstallPathRegKey = "HKLM:\SOFTWARE\Microsoft\IIS Extensions\MSDeploy"
 
 function Run-Command

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV1/AppCmdOnTargetMachines.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV1/AppCmdOnTargetMachines.ps1
@@ -1,4 +1,4 @@
-﻿Write-Verbose "Entering script AppCmdOnTargetMachines.ps1"
+Write-Verbose "Entering script AppCmdOnTargetMachines.ps1"
 $AppCmdRegKey = "HKLM:\SOFTWARE\Microsoft\InetStp"
 
 function Run-Command

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV1/ManageIISWebApp.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV1/ManageIISWebApp.ps1
@@ -1,4 +1,4 @@
-﻿Import-Module $env:CURRENT_TASK_ROOTDIR\DeploymentSDK\InvokeRemoteDeployment.ps1
+Import-Module $env:CURRENT_TASK_ROOTDIR\DeploymentSDK\InvokeRemoteDeployment.ps1
 Import-Module $env:CURRENT_TASK_ROOTDIR\ps_modules\VstsTaskSdk
 Import-Module $env:CURRENT_TASK_ROOTDIR\ps_modules\Sanitizer
 

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV2/AppCmdOnTargetMachines.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV2/AppCmdOnTargetMachines.ps1
@@ -1,4 +1,4 @@
-﻿﻿Write-Verbose "Entering script AppCmdOnTargetMachines.ps1"
+Write-Verbose "Entering script AppCmdOnTargetMachines.ps1"
 $AppCmdRegKey = "HKLM:\SOFTWARE\Microsoft\InetStp"
 
 function Run-Command

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV2/Utility.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV2/Utility.ps1
@@ -1,4 +1,4 @@
-﻿Import-Module $env:CURRENT_TASK_ROOTDIR\VstsTaskSdk
+Import-Module $env:CURRENT_TASK_ROOTDIR\VstsTaskSdk
 Import-Module $env:CURRENT_TASK_ROOTDIR\RemoteDeployer
 
 Write-Verbose "Entering script Utility.ps1"

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV3/AppCmdOnTargetMachines.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV3/AppCmdOnTargetMachines.ps1
@@ -1,4 +1,4 @@
-﻿Write-Verbose "Entering script AppCmdOnTargetMachines.ps1"
+Write-Verbose "Entering script AppCmdOnTargetMachines.ps1"
 $AppCmdRegKey = "HKLM:\SOFTWARE\Microsoft\InetStp"
 
 function Run-Command

--- a/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV3/Utility.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/IISWebAppMgmt/IISWebAppMgmtV3/Utility.ps1
@@ -1,4 +1,4 @@
-﻿Import-Module $env:CURRENT_TASK_ROOTDIR\ps_modules\VstsTaskSdk
+Import-Module $env:CURRENT_TASK_ROOTDIR\ps_modules\VstsTaskSdk
 Import-Module $env:CURRENT_TASK_ROOTDIR\RemoteDeployer
 
 Write-Verbose "Entering script Utility.ps1"

--- a/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV1/DeployToSqlServer.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV1/DeployToSqlServer.ps1
@@ -1,4 +1,4 @@
-﻿Import-Module $env:CURRENT_TASK_ROOTDIR\DeploymentSDK\InvokeRemoteDeployment.ps1
+Import-Module $env:CURRENT_TASK_ROOTDIR\DeploymentSDK\InvokeRemoteDeployment.ps1
 Import-Module $env:CURRENT_TASK_ROOTDIR\DeploymentSDK\Utility.ps1
 Import-Module $env:CURRENT_TASK_ROOTDIR\ps_modules\VstsTaskSdk
 Import-Module $env:CURRENT_TASK_ROOTDIR\ps_modules\Sanitizer

--- a/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV2/DeployToSqlServer.ps1
+++ b/Extensions/IISWebAppDeploy/Src/Tasks/SqlDacpacDeploy/SqlDacpacDeployV2/DeployToSqlServer.ps1
@@ -1,4 +1,4 @@
-﻿Import-Module $env:CURRENT_TASK_ROOTDIR\DeploymentSDK\InvokeRemoteDeployment.ps1
+Import-Module $env:CURRENT_TASK_ROOTDIR\DeploymentSDK\InvokeRemoteDeployment.ps1
 Import-Module $env:CURRENT_TASK_ROOTDIR\DeploymentSDK\Utility.ps1
 Import-Module $env:CURRENT_TASK_ROOTDIR\ps_modules\Sanitizer
 

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.274.21",
+  "version": "1.275.0",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.275.3",
+  "version": "1.275.4",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.275.0",
+  "version": "1.275.3",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/ServiceNow/Src/Tasks/CreateAndQueryChangeRequest/CreateAndQueryChangeRequestV0/task.json
+++ b/Extensions/ServiceNow/Src/Tasks/CreateAndQueryChangeRequest/CreateAndQueryChangeRequestV0/task.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "id": "539E1E16-0680-4F8E-85D0-95B6FDE76E8C",
   "name": "CreateAndQueryChangeRequest",
   "friendlyName": "ServiceNow Change Management",

--- a/Extensions/ServiceNow/Src/Tasks/CreateAndQueryChangeRequest/CreateAndQueryChangeRequestV1/task.json
+++ b/Extensions/ServiceNow/Src/Tasks/CreateAndQueryChangeRequest/CreateAndQueryChangeRequestV1/task.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "id": "539E1E16-0680-4F8E-85D0-95B6FDE76E8C",
   "name": "CreateAndQueryChangeRequest",
   "friendlyName": "ServiceNow Change Management",

--- a/Extensions/ServiceNow/Src/Tasks/CreateAndQueryChangeRequest/CreateAndQueryChangeRequestV2/task.json
+++ b/Extensions/ServiceNow/Src/Tasks/CreateAndQueryChangeRequest/CreateAndQueryChangeRequestV2/task.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "id": "539E1E16-0680-4F8E-85D0-95B6FDE76E8C",
   "name": "CreateAndQueryChangeRequest",
   "friendlyName": "ServiceNow Change Management",

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.274.0",
+  "version": "4.275.0",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.275.0",
+  "version": "4.275.8",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.275.8",
+  "version": "4.275.9",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.275.3",
+  "version": "15.275.4",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.275.0",
+  "version": "15.275.3",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.274.0",
+  "version": "15.275.0",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/ServerTaskHelper/AzureFunctionAdvancedHandler/AzureFunctionAdvancedHandler.csproj
+++ b/ServerTaskHelper/AzureFunctionAdvancedHandler/AzureFunctionAdvancedHandler.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>

--- a/ServerTaskHelper/AzureFunctionAdvancedHandler/WorkItemStatusHandler.cs
+++ b/ServerTaskHelper/AzureFunctionAdvancedHandler/WorkItemStatusHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using DistributedTask.ServerTask.Remote.Common.Request;

--- a/ServerTaskHelper/AzureFunctionAdvancedServiceBusTrigger/AzureFunctionAdvancedServiceBusTrigger.csproj
+++ b/ServerTaskHelper/AzureFunctionAdvancedServiceBusTrigger/AzureFunctionAdvancedServiceBusTrigger.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>

--- a/ServerTaskHelper/AzureFunctionAdvancedServiceBusTrigger/README.md
+++ b/ServerTaskHelper/AzureFunctionAdvancedServiceBusTrigger/README.md
@@ -1,4 +1,4 @@
-﻿# Advanced Invoke Azure Function Check Dependency Example
+# Advanced Invoke Azure Function Check Dependency Example
 
 This advanced example shows how to trigger an Azure Function that checks if an [Azure Boards](https://azure.microsoft.com/products/devops/boards/) work item is in a **Completed** state.
 

--- a/ServerTaskHelper/AzureFunctionAdvancedServiceBusTrigger/WorkItemStatusHandler.cs
+++ b/ServerTaskHelper/AzureFunctionAdvancedServiceBusTrigger/WorkItemStatusHandler.cs
@@ -1,4 +1,4 @@
-﻿using DistributedTask.ServerTask.Remote.Common.Request;
+using DistributedTask.ServerTask.Remote.Common.Request;
 using DistributedTask.ServerTask.Remote.Common.TaskProgress;
 using DistributedTask.ServerTask.Remote.Common.WorkItemProgress.Exceptions;
 using DistributedTask.ServerTask.Remote.Common.WorkItemProgress;

--- a/ServerTaskHelper/AzureFunctionBasicHandler/AzureFunctionBasicHandler.csproj
+++ b/ServerTaskHelper/AzureFunctionBasicHandler/AzureFunctionBasicHandler.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 	  <TargetFramework>net6.0</TargetFramework>
 	  <AzureFunctionsVersion>v4</AzureFunctionsVersion>

--- a/ServerTaskHelper/AzureFunctionBasicHandler/CmdLineTaskHandler.cs
+++ b/ServerTaskHelper/AzureFunctionBasicHandler/CmdLineTaskHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using DistributedTask.ServerTask.Remote.Common.Build;

--- a/ServerTaskHelper/AzureFunctionBasicHandler/README.md
+++ b/ServerTaskHelper/AzureFunctionBasicHandler/README.md
@@ -1,4 +1,4 @@
-﻿# Basic Invoke Azure Function Check Example
+# Basic Invoke Azure Function Check Example
  
 This basic example shows an Azure Function that checks if a pipeline run has executed at least one [`CmdLine` task](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/cmd-line-v2). 
 

--- a/ServerTaskHelper/AzureFunctionSample/AzureFunctionSample.csproj
+++ b/ServerTaskHelper/AzureFunctionSample/AzureFunctionSample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 	  <TargetFramework>net6.0</TargetFramework>
 	  <AzureFunctionsVersion>v4</AzureFunctionsVersion>

--- a/ServerTaskHelper/AzureFunctionSample/MyApp.cs
+++ b/ServerTaskHelper/AzureFunctionSample/MyApp.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/ServerTaskHelper/AzureFunctionSample/MyAppParameters.cs
+++ b/ServerTaskHelper/AzureFunctionSample/MyAppParameters.cs
@@ -1,4 +1,4 @@
-﻿namespace AzureFunctionSample
+namespace AzureFunctionSample
 {
     internal class MyAppParameters
     {

--- a/ServerTaskHelper/AzureFunctionSample/MyTaskExecutionHandler.cs
+++ b/ServerTaskHelper/AzureFunctionSample/MyTaskExecutionHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using DistributedTask.ServerTask.Remote.Common;

--- a/ServerTaskHelper/AzureFunctionSample/readme.md
+++ b/ServerTaskHelper/AzureFunctionSample/readme.md
@@ -1,4 +1,4 @@
-﻿﻿### Sample to create Azure DevOps Pipeline agent using Azure function
+### Sample to create Azure DevOps Pipeline agent using Azure function
 
 You need to provide following inputs in Azure function task body
 

--- a/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/Build/BuildClient.cs
+++ b/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/Build/BuildClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using DistributedTask.ServerTask.Remote.Common.Request;
 using Microsoft.TeamFoundation.Build.WebApi;

--- a/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/DistributedTask.ServerTask.Remote.Common.csproj
+++ b/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/DistributedTask.ServerTask.Remote.Common.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	<TargetFramework>net6.0</TargetFramework>

--- a/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/Exceptions/AzureFunctionEvaluationException.cs
+++ b/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/Exceptions/AzureFunctionEvaluationException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace DistributedTask.ServerTask.Remote.Common.Exceptions
 {

--- a/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/ITaskExecutionHandler.cs
+++ b/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/ITaskExecutionHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 using DistributedTask.ServerTask.Remote.Common.Request;
 using DistributedTask.ServerTask.Remote.Common.TaskProgress;

--- a/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/Request/TaskMessage.cs
+++ b/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/Request/TaskMessage.cs
@@ -1,4 +1,4 @@
-﻿namespace DistributedTask.ServerTask.Remote.Common.Request
+namespace DistributedTask.ServerTask.Remote.Common.Request
 {
     public class TaskMessage
     {

--- a/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/ServiceBus/ServiceBusClient.cs
+++ b/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/ServiceBus/ServiceBusClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using System;
 using DistributedTask.ServerTask.Remote.Common.Request;
 using Microsoft.Azure.ServiceBus;

--- a/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/WorkItemProgress/Exceptions/WorkItemNotCompletedException.cs
+++ b/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/WorkItemProgress/Exceptions/WorkItemNotCompletedException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace DistributedTask.ServerTask.Remote.Common.WorkItemProgress.Exceptions
 {

--- a/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/WorkItemProgress/WorkItemClient.cs
+++ b/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/WorkItemProgress/WorkItemClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using DistributedTask.ServerTask.Remote.Common.Build;
 using DistributedTask.ServerTask.Remote.Common.Request;

--- a/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/readme.md
+++ b/ServerTaskHelper/DistributedTask.ServerTask.Remote.Common/readme.md
@@ -1,4 +1,4 @@
-﻿### This library can be consumed by developers who wants to build new tasks/solutions on top of vsts server side task infrastructure. It provides the following capabilities:
+### This library can be consumed by developers who wants to build new tasks/solutions on top of vsts server side task infrastructure. It provides the following capabilities:
 
 1. Ability to report task status updates to vsts like task has started, task has completed with succeess or failure.
 2. Ability to report live logs update to vsts.

--- a/ServerTaskHelper/HttpRequestHandler/Http/Program.cs
+++ b/ServerTaskHelper/HttpRequestHandler/Http/Program.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore;
+using Microsoft.AspNetCore;
 
 namespace HttpRequestHandler.Http
 {

--- a/ServerTaskHelper/HttpRequestHandler/Http/Startup.cs
+++ b/ServerTaskHelper/HttpRequestHandler/Http/Startup.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 
 namespace HttpRequestHandler.Http
 {

--- a/ServerTaskHelper/HttpRequestHandler/HttpRequestHandler.csproj
+++ b/ServerTaskHelper/HttpRequestHandler/HttpRequestHandler.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>

--- a/ServerTaskHelper/HttpRequestHandler/MyTaskController.cs
+++ b/ServerTaskHelper/HttpRequestHandler/MyTaskController.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using DistributedTask.ServerTask.Remote.Common;
 using DistributedTask.ServerTask.Remote.Common.Request;
 using Microsoft.AspNetCore.Mvc;

--- a/ServerTaskHelper/HttpRequestHandler/MyTaskExecutionHandler.cs
+++ b/ServerTaskHelper/HttpRequestHandler/MyTaskExecutionHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 using DistributedTask.ServerTask.Remote.Common;
 using DistributedTask.ServerTask.Remote.Common.Request;

--- a/ServerTaskHelper/HttpRequestHandler/readme.md
+++ b/ServerTaskHelper/HttpRequestHandler/readme.md
@@ -1,4 +1,4 @@
-﻿### This is a sample app demonstrates how to plugin an execution handler for a HttpRequest server task using DistributedTask.ServerTask.Remote.Common library.
+### This is a sample app demonstrates how to plugin an execution handler for a HttpRequest server task using DistributedTask.ServerTask.Remote.Common library.
 
 #### Sample app does the following:
 1. Recieve VSTS Task related properties in Http request headers

--- a/ServerTaskHelper/HttpRequestSampleWithoutHandler/Http/Program.cs
+++ b/ServerTaskHelper/HttpRequestSampleWithoutHandler/Http/Program.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore;
+using Microsoft.AspNetCore;
 
 namespace HttpRequestSampleWithoutHandler.Http
 {

--- a/ServerTaskHelper/HttpRequestSampleWithoutHandler/Http/Startup.cs
+++ b/ServerTaskHelper/HttpRequestSampleWithoutHandler/Http/Startup.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 
 namespace HttpRequestSampleWithoutHandler.Http
 {

--- a/ServerTaskHelper/HttpRequestSampleWithoutHandler/MyApp.cs
+++ b/ServerTaskHelper/HttpRequestSampleWithoutHandler/MyApp.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;

--- a/ServerTaskHelper/HttpRequestSampleWithoutHandler/MyTaskController.cs
+++ b/ServerTaskHelper/HttpRequestSampleWithoutHandler/MyTaskController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/ServerTaskHelper/HttpRequestSampleWithoutHandler/Properties/launchSettings.json
+++ b/ServerTaskHelper/HttpRequestSampleWithoutHandler/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "iisSettings": {
     "windowsAuthentication": false,
     "anonymousAuthentication": true,

--- a/ServerTaskHelper/ServerTaskHelper.sln
+++ b/ServerTaskHelper/ServerTaskHelper.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.33110.190

--- a/ServerTaskHelper/ServiceBusMessageHandler/Program.cs
+++ b/ServerTaskHelper/ServiceBusMessageHandler/Program.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 using ServiceBusMessageHandler.ServiceBus;
 
 namespace ServiceBusMessageHandler

--- a/ServerTaskHelper/ServiceBusMessageHandler/ServiceBus/ServiceBusMessage.cs
+++ b/ServerTaskHelper/ServiceBusMessageHandler/ServiceBus/ServiceBusMessage.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using Microsoft.Azure.ServiceBus;
 
 namespace ServiceBusMessageHandler.ServiceBus

--- a/ServerTaskHelper/ServiceBusMessageHandler/ServiceBus/ServiceBusMessageListener.cs
+++ b/ServerTaskHelper/ServiceBusMessageHandler/ServiceBus/ServiceBusMessageListener.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using DistributedTask.ServerTask.Remote.Common;
 using Microsoft.Azure.ServiceBus;
 

--- a/ServerTaskHelper/ServiceBusMessageHandler/ServiceBusMessageHandler.csproj
+++ b/ServerTaskHelper/ServiceBusMessageHandler/ServiceBusMessageHandler.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>

--- a/ServerTaskHelper/ServiceBusMessageHandler/appsettings.json
+++ b/ServerTaskHelper/ServiceBusMessageHandler/appsettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "ServiceBus": {
         "ConnectionString": "<service bus queue connection string>",
         "QueueName": "<queue name>"

--- a/ServerTaskHelper/ServiceBusMessageHandler/readme.md
+++ b/ServerTaskHelper/ServiceBusMessageHandler/readme.md
@@ -1,4 +1,4 @@
-﻿### This is a sample app demonstrates how to plugin an execution handler for a ServiceBus server task using DistributedTask.ServerTask.Remote.Common library.
+### This is a sample app demonstrates how to plugin an execution handler for a ServiceBus server task using DistributedTask.ServerTask.Remote.Common library.
 
 #### Sample app does the following:
 1. Implement my own `ITaskExecutionHandler`, `MyTaskExecutionHandler`, which deserialize the input object and log a message to VSTS using TaskLogger.

--- a/TaskModules/powershell/Publish-PSModule.ps1
+++ b/TaskModules/powershell/Publish-PSModule.ps1
@@ -1,4 +1,4 @@
-﻿param([string] $baseDirectory,
+param([string] $baseDirectory,
       [string] $nugetAPIKey)
 
 $subDirectories = Get-ChildItem -Directory $baseDirectory 

--- a/TaskModules/powershell/Sanitizer/Sanitizer.psm1
+++ b/TaskModules/powershell/Sanitizer/Sanitizer.psm1
@@ -1,4 +1,4 @@
-﻿# Override the DebugPreference.
+# Override the DebugPreference.
 if ($global:DebugPreference -eq 'Continue') {
     Write-Verbose '$OVERRIDING $global:DebugPreference from ''Continue'' to ''SilentlyContinue''.'
     $global:DebugPreference = 'SilentlyContinue'

--- a/TaskModules/powershell/TaskModuleIISManageUtility/TaskModuleIISManageUtility.psm1
+++ b/TaskModules/powershell/TaskModuleIISManageUtility/TaskModuleIISManageUtility.psm1
@@ -1,4 +1,4 @@
-﻿[CmdletBinding()]
+[CmdletBinding()]
 param(
     [ValidateNotNull()]
     [Parameter()]

--- a/TaskModules/powershell/TaskModuleSqlUtility/SqlPackageOnTargetMachines.ps1
+++ b/TaskModules/powershell/TaskModuleSqlUtility/SqlPackageOnTargetMachines.ps1
@@ -1,4 +1,4 @@
-﻿function RunCommand
+function RunCommand
 {
     param(
         [string]$command,

--- a/TaskModules/powershell/TaskModuleSqlUtility/SqlQueryOnTargetMachines.ps1
+++ b/TaskModules/powershell/TaskModuleSqlUtility/SqlQueryOnTargetMachines.ps1
@@ -1,4 +1,4 @@
-﻿# Function to import SqlPS module & avoid directory switch
+# Function to import SqlPS module & avoid directory switch
 function Import-SqlPs {
     push-location
     Import-Module SqlPS -ErrorAction 'SilentlyContinue' | out-null

--- a/TaskModules/powershell/TaskModuleSqlUtility/TaskModuleSqlUtility.psm1
+++ b/TaskModules/powershell/TaskModuleSqlUtility/TaskModuleSqlUtility.psm1
@@ -1,4 +1,4 @@
-﻿[CmdletBinding()]
+[CmdletBinding()]
 param(
     [ValidateNotNull()]
     [Parameter()]

--- a/definitions/shelljs.d.ts
+++ b/definitions/shelljs.d.ts
@@ -1,4 +1,4 @@
-﻿// Type definitions for ShellJS v0.3.0
+// Type definitions for ShellJS v0.3.0
 // Project: http://shelljs.org
 // Definitions by: Niklas Mollenhauer <https://github.com/nikeee>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,7 +75,7 @@ gulp.task("clean", function (cb) {
 
 gulp.task("compilePS", gulp.series("clean", function () {
     if (options.testAreaPath === undefined) {
-        return gulp.src(sourcePaths, { base: "." }).pipe(gulp.dest(_buildRoot));
+        return gulp.src(sourcePaths, { base: ".", encoding: false }).pipe(gulp.dest(_buildRoot));
     } else {
         if (options.testAreaPath.length > 0) {
             console.log('Compiling updated modules - ' + options.testAreaPath);
@@ -86,11 +86,11 @@ gulp.task("compilePS", gulp.series("clean", function () {
                 filter.push(ExtensionFolder + '/' + areaPaths[n] + '/**/*')
             }
 
-            return gulp.src(filter, { base: "." }).pipe(gulp.dest(_buildRoot));
+            return gulp.src(filter, { base: ".", encoding: false }).pipe(gulp.dest(_buildRoot));
         } else {
             console.log('No module is updated with given change-set');
             // Create a _build/Extensions folder which will be empty
-            return gulp.src(ExtensionFolder, { base: "." }).pipe(gulp.dest(_buildRoot));
+            return gulp.src(ExtensionFolder, { base: ".", encoding: false }).pipe(gulp.dest(_buildRoot));
         }
     }
 }));
@@ -658,12 +658,12 @@ gulp.task('compileTests', function () {
 });
 
 gulp.task('testLib', gulp.series('compileTests', function () {
-    return gulp.src(['Extensions/Common/lib/**/*'])
+    return gulp.src(['Extensions/Common/lib/**/*'], { encoding: false })
         .pipe(gulp.dest(path.join(_testRoot, 'Extensions/Common/lib/')));
 }));
 
 gulp.task('copyTestData', gulp.series('compileTests', function () {
-    return gulp.src(['Extensions/**/Tests/**/data/**'], { dot: true })
+    return gulp.src(['Extensions/**/Tests/**/data/**'], { dot: true, encoding: false })
         .pipe(gulp.dest(_testRoot + "\\Extensions"));
 }));
 
@@ -678,7 +678,7 @@ gulp.task('ps1tests', gulp.series('compileTests', function () {
 }));
 
 gulp.task('testLib_NodeModules', gulp.series('testLib', function () {
-    return gulp.src(path.join(__dirname, 'node_modules/azure-pipelines-task-lib/**/*'))
+    return gulp.src(path.join(__dirname, 'node_modules/azure-pipelines-task-lib/**/*'), { encoding: false })
         .pipe(gulp.dest(path.join(_testRoot, 'Extensions/Common/lib/node_modules/azure-pipelines-task-lib')));
 }));
 


### PR DESCRIPTION
**Description**: This PR expands the original gulp encoding fix into a repo-wide UTF-8/BOM normalization pass for mixed content safety.

What changed:
- Kept the gulp copy pipelines binary-safe by using `encoding: false` where files are copied byte-for-byte.
- Hardened manifest parsing in gulp flow to tolerate BOM-prefixed JSON content.
- Normalized UTF-8 BOM usage in extension manifests:
  - `Extensions/ExternalTfs/Src/vss-extension.json`
  - `Extensions/IISWebAppDeploy/Src/vss-extension.json`
- Removed UTF-8 BOM from ASCII-only tracked files across the repo (PowerShell, TS/JS, JSON, csproj/sln/readme/config, etc.).
- Fixed two edge-case files that had duplicated leading BOM markers and converted them to BOM-free UTF-8.
- Intentionally left localization XLIFF files BOM-preserved where non-ASCII localized content exists.

Net result:
- BOM removed from 91 files safely.
- 18 localization `.xlf` files intentionally unchanged.

Why:
- Prevents mixed binary/text corruption and BOM-related parser issues during build/package flows.
- Improves cross-platform consistency by using UTF-8 without BOM for ASCII-only source/config files.

Validation performed:
- `npx gulp package --extension=ExternalTfs --publisher=ms-vscs-rm` completed successfully.

**Documentation changes required:** N

**Added unit tests:** N (build/packaging and encoding normalization change)

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
