### PR TITLE
Add TypeScript compilation task and improve error handling in gulpfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ In order to build and package extensions you will need to install some dependenc
 
 - `npm install` will install all the node modules required to run gulp to package, build etc.
 - `gulp build`  will copy each task to "_build" folder, and install it's dependencies locally (wrt to the task) and copies the common modules required to run the task.
+  - `gulp build` also runs `gulp tscBuildTasks` to execute task-specific TypeScript validation (`tsc -p`) for selected task folders.
+  - The list of task folders included in this validation is configured in `externals.json` under `tsc-build-check`.
+  - Run `gulp tscBuildTasks` directly if you want to validate only the task-specific TypeScript checks without running the full build.
   - Use `--syncVersions` to automatically bump the `version` field in `vss-extension.json` so it is higher than what is currently published on the Marketplace. This avoids pipeline failures caused by version conflicts.
     - Single extension: `gulp build --syncVersions <ExtensionName>`. For example `gulp build --syncVersions Ansible`
     - Multiple extensions (comma-separated): `gulp build --syncVersions <ExtensionName1>,<ExtensionName2>`. For example `gulp build --syncVersions Ansible,IISWebAppDeploy`

--- a/externals.json
+++ b/externals.json
@@ -8,5 +8,7 @@
     "no-engine-strict": [
         "DownloadArtifactsTfsGit",
         "DownloadExternalBuildArtifacts"
+    ],
+    "tsc-build-check": [
     ]
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,7 +60,7 @@ const cultures = ['en-US', 'de-DE', 'es-ES', 'fr-FR', 'it-IT', 'ja-JP', 'ko-KR',
  * @returns {void}
  */
 function errorHandler(error) {
-    console.error(`Build failed ${error}`);
+    console.error(`Build failed ${error ? `with error: ${error}` : 'with an unknown error'}`);
     process.exit(1);
 }
 
@@ -638,7 +638,27 @@ gulp.task("syncVersions", function (cb) {
     processNext();
 });
 
-gulp.task("build", gulp.series("syncVersions", "compileNode", "updateTestIds"));
+gulp.task("tscBuildTasks", function (cb) {
+    const buildCheckList = JSON.parse(fs.readFileSync(path.join(__dirname, 'externals.json'), 'utf-8'))['tsc-build-check'];
+    const tscCliPath = require.resolve('typescript/bin/tsc');
+
+    fs.readdirSync(ExtensionFolder, { recursive: true, encoding: 'utf-8' })
+        .filter(x => buildCheckList.find((/** @type{string} */ check) => x.includes(check)) && path.parse(x).base == "tsconfig.json" && !x.includes("node_modules"))
+        .map(x => path.resolve(ExtensionFolder, x))
+        .forEach((configPath) => {
+            try {
+                cp.execFileSync(process.execPath, [tscCliPath, '-p', configPath], { stdio: 'ignore' });
+            } catch (err) {
+                console.error(`TypeScript compilation failed for ${configPath}: ${err.message}`);
+                console.error(`Execute manually the command:\nnpx tsc -p ${configPath}`);
+                cb();
+                errorHandler();
+            }
+        });
+    cb();
+});
+
+gulp.task("build", gulp.series("syncVersions", "compileNode", "tscBuildTasks", "updateTestIds"));
 
 gulp.task("default", gulp.series("build"));
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -640,6 +640,12 @@ gulp.task("syncVersions", function (cb) {
 
 gulp.task("tscBuildTasks", function (cb) {
     const buildCheckList = JSON.parse(fs.readFileSync(path.join(__dirname, 'externals.json'), 'utf-8'))['tsc-build-check'];
+
+    if (!buildCheckList || buildCheckList.length === 0) {
+        cb();
+        return;
+    }
+
     const tscCliPath = require.resolve('typescript/bin/tsc');
 
     fs.readdirSync(ExtensionFolder, { recursive: true, encoding: 'utf-8' })


### PR DESCRIPTION
**Description**: Adds a new `tscBuildTasks` Gulp task that runs TypeScript compilation (`tsc -p`) as a build-time validation check for selected extensions, and improves the `errorHandler` message to handle undefined errors.

> [!WARNING]
> It's intermediate step tsc build implementation that will be enabled by default with full log output after all extensions will be onboarded and functioning as expected

- Reads the list of extensions/tasks to validate from `externals.json` under the `tsc-build-check` key.
- Recursively scans `ExtensionFolder` for `tsconfig.json` files (excluding `node_modules`) matching the allow-list and runs `tsc -p <configPath>` against each using the locally resolved `typescript/bin/tsc`.
- On failure, logs the failing config path and the exact `npx tsc -p ...` command to reproduce locally, then triggers `errorHandler` to fail the build.
- Wires the new `tscBuildTasks` step into the main `build` series between `compileNode` and `updateTestIds`.
- `errorHandler` now prints `Build failed with error: <error>` or `Build failed with an unknown error` instead of `Build failed undefined` when no error object is passed.

**Documentation changes required:** N

**Added unit tests:** N — build/gulp infrastructure change; covered by existing CI build runs.

**Attached related issue:** N

**Checklist**:
- [ ] Version was bumped — N/A (no extension/task/library version affected; build script change only).
- [x] Checked that applied changes work as expected.
