### PR TITLE
Fix CI tests for ExternalTFS

### DIFF
--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
@@ -8,8 +8,8 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 16,
-    "Minor": 274,
-    "Patch": 0
+    "Minor": 275,
+    "Patch": 5
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.loc.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.loc.json
@@ -8,8 +8,8 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 16,
-    "Minor": 267,
-    "Patch": 1
+    "Minor": 275,
+    "Patch": 5
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",


### PR DESCRIPTION
**Description**: The `task.loc.json` file for the `DownloadExternalBuildArtifacts` task had its version stuck at `16.267.1`, while `task.json` was already at `16.274.0`.

When the VSIX is packaged, Azure DevOps uses `task.loc.json` as the canonical task definition, so the task gets registered in the org at the old version `16.267.1` and not the current one.

This caused the CI test pipeline to fail at agent initialization because it tried to download task version `16.267.1`, which no longer existed as a valid package on the server.

This fix aligns `task.loc.json` version with `task.json` so the packaged VSIX registers the correct task version.

**Documentation changes required:** N

**Added unit tests:** N

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
