### PR TITLE
Add TypeScript configuration and enhance JavaScript files with JSDoc comments in DownloadArtifactsTfsVersionControl

### DIFF
--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/downloadTfsVersionControl.js
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/downloadTfsVersionControl.js
@@ -1,67 +1,76 @@
-var shell = require('shelljs');
-var path = require('path');
-var tl = require('azure-pipelines-task-lib/task');
-var Q = require('q');
-var url = require('url');
-var tfvcwm = require('./tfvcwrapper');
+const path = require('path');
+const shell = require('shelljs');
 
-var projectId = tl.getInput("project");
-var repositoryId = tl.getInput("definition");
-var changesetId = tl.getInput("version");
-var downloadPath = tl.getInput("downloadPath");
-var tfsEndpoint = getEndpointDetails("connection");
+const tl = require('azure-pipelines-task-lib/task');
 
-console.log("project: " + projectId.toString());
-console.log("definition: " + repositoryId.toString());
-console.log("version: " + (!!changesetId ? changesetId.toString() : "Latest"));
-console.log("downloadPath: " + downloadPath.toString());
-console.log("tfsEndpoint:" + JSON.stringify(tfsEndpoint.Url));
+const tfvcwm = require('./tfvcwrapper');
 
-var tfvcw = new tfvcwm.TfvcWrapper();
-tfvcw.on('stdout', function (data) {
-    console.log(data.toString());
-});
-tfvcw.on('stderr', function (data) {
-    console.log(data.toString());
-});
-tfvcw.on('debug', function (data) {
-    console.log(data.toString());
-});
+const projectId = /** @type {string} */ (tl.getInput("project", true));
+const repositoryId = /** @type {string} */ (tl.getInput("definition", true));
+const changesetId = tl.getInput("version");
+const downloadPath = /** @type {string} */ (tl.getInput("downloadPath", true));
+const tfsEndpoint = getEndpointDetails("connection");
+
+console.log("project: " + String(projectId));
+console.log("definition: " + String(repositoryId));
+console.log("version: " + (!!changesetId ? String(changesetId) : "Latest"));
+console.log("downloadPath: " + String(downloadPath));
+console.log("tfsEndpoint:" + JSON.stringify(tfsEndpoint && tfsEndpoint.Url));
+
+/** @type {any} */
+const tfvcw = new tfvcwm.TfvcWrapper();
+
+tfvcw.on('stdout', (/** @type {any} */ data) => console.log(data.toString()));
+tfvcw.on('stderr', (/** @type {any} */ data) => console.log(data.toString()));
+tfvcw.on('debug', (/** @type {any} */ data) => console.log(data.toString()));
 tfvcw.setTfvcConnOptions({
     username: tfsEndpoint.Username,
     password: tfsEndpoint.Password,
     collection: tfsEndpoint.Url
 });
+
 getCode();
 
+/**
+ * @param {string} inputFieldName
+ */
 function getEndpointDetails(inputFieldName) {
-    var errorMessage = "Could not decode the External Tfs endpoint. Please ensure you are running the latest agent";
+    const errorMessage = "Could not decode the External Tfs endpoint. Please ensure you are running the latest agent";
     if (!tl.getEndpointUrl) {
         throw new Error(errorMessage);
     }
-    var externalTfsEndpoint = tl.getInput(inputFieldName);
+    const externalTfsEndpoint = tl.getInput(inputFieldName);
     if (!externalTfsEndpoint) {
         throw new Error(errorMessage);
     }
-    var hostUrl = tl.getEndpointUrl(externalTfsEndpoint, false);
+    const hostUrl = tl.getEndpointUrl(externalTfsEndpoint, false);
     if (!hostUrl) {
         throw new Error(errorMessage);
     }
-    var auth = tl.getEndpointAuthorization(externalTfsEndpoint, false);
+    const auth = tl.getEndpointAuthorization(externalTfsEndpoint, false);
+
+    if (!auth) {
+        throw new Error(errorMessage);
+    }
+
     if (auth.scheme != "UsernamePassword" && auth.scheme != "Token") {
         throw new Error("The authorization scheme " + auth.scheme + " is not supported for a External Tfs endpoint.");
     }
 
-    var hostUsername = ".";
-    var hostPassword = "";
-    if(auth.scheme == "Token") {
+    let hostUsername = ".";
+    let hostPassword = "";
+
+    if (auth.scheme === "Token") {
         hostPassword = getAuthParameter(auth, 'apitoken');
-    }
-    else {
+    } else {
         hostUsername = getAuthParameter(auth, 'username');
         hostPassword = getAuthParameter(auth, 'password');
     }
-    if (hostPassword) tl.setSecret(hostPassword);
+
+    if (hostPassword) {
+        tl.setSecret(hostPassword);
+    }
+
     return {
         "Url": hostUrl,
         "Username": hostUsername,
@@ -69,81 +78,89 @@ function getEndpointDetails(inputFieldName) {
     };
 }
 
+/**
+ * @param {{ parameters: Record<string, string> }} auth
+ * @param {string} paramName
+ * @returns {string}
+ */
 function getAuthParameter(auth, paramName) {
-    var paramValue = null;
-    var parameters = Object.getOwnPropertyNames(auth['parameters']);
-    var keyName;
+    const parameters = Object.getOwnPropertyNames(auth['parameters']);
+    let keyName;
     parameters.some(function (key) {
         if (key.toLowerCase() === paramName.toLowerCase()) {
             keyName = key;
             return true;
         }
     });
-    paramValue = auth['parameters'][keyName];
-    return paramValue;
+
+    if (!keyName) {
+        return "";
+    }
+
+    return auth['parameters'][keyName];
 }
 
 function getCode() {
-    var workspaceName = getWorkspaceName();
-    var workspaceMappings = getDefaultTfvcMappings();
+    const workspaceName = getWorkspaceName();
+    const workspaceMappings = getDefaultTfvcMappings();
 
-    var newWorkspace = {
+    const newWorkspace = {
         name: workspaceName,
         mappings: []
     };
 
     console.log("Try deleting workspace if it already exists");
     return tfvcw.deleteWorkspace(newWorkspace)
-        .then(function(retCode) {
+        .then(function (/** @type {number} */ retCode) {
             if (retCode === 0) {
                 console.log("Successfully deleted workspace");
             }
             if (IsPathExists(downloadPath)) {
                 console.log("Cleaning up artifacts download path");
                 return utilExec('rm -fr ' + downloadPath)
-                    .then(function(ret) {
+                    .then(function (/** @type {{ code: number, output: string }} */ ret) {
                         if (ret.code === 0) {
                             console.log("Successfully cleaned up artifacts download path");
                         }
-                        return Q(ret.code);
+                        return ret.code;
                     });
             } else {
-                return Q(0);
+                return 0;
             }
-        }, function(error) {
+        }, function (/** @type {unknown} */ error) {
             console.log("Warning: Failed to delete Workspace. Ignoring it as this could happen due to non existent workspace. " + error);
             if (IsPathExists(downloadPath)) {
                 console.log("Artifacts download path exists. Cleaning up");
                 return utilExec('rm -fr ' + downloadPath)
-                    .then(function(ret) {
+                    .then(function (/** @type {{ code: number, output: string }} */ ret) {
                         if (ret.code === 0) {
                             console.log("Successfully cleaned up artifacts download path");
                         }
-                        return Q(ret.code);
+                        return ret.code;
                     });
             } else {
-                return Q(0);
+                return 0;
             }
         })
-        .then(function() {
+        .then(function () {
             ensurePathExist(downloadPath);
             shell.cd(downloadPath);
             console.log("Creating new workspace: " + newWorkspace.name);
             return tfvcw.newWorkspace(newWorkspace)
-                .then(function(retCode) {
+                .then(function (/** @type {number} */ retCode) {
                     if (retCode === 0) {
                         console.log("Successfully created workspace");
                     }
-                    return Q(retCode);
-                }, function(error) {
+                    return retCode;
+                }, function (/** @type {unknown} */ error) {
                     tl.error("Failed to Create a new Workspace. " + error);
-                    tl.exit(1);
+                    process.exit(1);
                 });
         })
-        .then(function() {
+        .then(function () {
             // workspace must exist now
             // Sometime the job fails with:
-            //   An argument error occurred: Unable to determine the workspace. 
+            //   An argument error occurred: Unable to determine the workspace.
             //   You may be able to correct this by running 'tf workspaces -collection:TeamProjectCollectionUrl'.
             // when getting the source.  Preemptively run this to be safe.
             console.log("List workspaces");
@@ -152,45 +169,48 @@ function getCode() {
             console.log("Current working directory: " + process.cwd());
             console.log("Add default workspace mappings: " + JSON.stringify(workspaceMappings));
             return tfvcw.mapFolder(workspaceMappings.serverPath, workspaceMappings.localPath, newWorkspace)
-                .then(function(retCode) {
+                .then(function (/** @type {number} */ retCode) {
                     if (retCode === 0) {
                         console.log("Successfully added default mapping");
                     }
-                    return Q(retCode);
-                }, function(error) {
+                    return retCode;
+                }, function (/** @type {unknown} */ error) {
                     tl.error("Failed to add default mapping. " + error);
-                    tl.exit(1);
+                    process.exit(1);
                 });
         })
-        .then(function() {
+        .then(function () {
             shell.cd(downloadPath);
             console.log("Sync workspace: " + newWorkspace.name);
-            
+
             if (!changesetId) {
                 console.log("Getting latest changeset as no changeset is specified");
             }
 
             return tfvcw.get(changesetId)
-                .then(function(retCode) {
+                .then(function (/** @type {number} */ retCode) {
                     if (retCode === 0) {
                         console.log("Successfully synced workspace");
                     }
-                    return Q(retCode);
-                }, function(error) {
+                    return retCode;
+                }, function (/** @type {unknown} */ error) {
                     tl.error("Failed to sync workspace. " + error);
-                    tl.exit(1);
+                    process.exit(1);
                 });
         });
 };
 
-function IsPathExists(path) {
-    return shell.test('-d', path);
+/**
+ * @param {string} folderPath
+ */
+function IsPathExists(folderPath) {
+    return shell.test('-d', folderPath);
 }
 
 function getWorkspaceName() {
-    var downloadFolderName = getDownloadFolder();
+    const downloadFolderName = getDownloadFolder();
     console.log("Download artifact folder: " + downloadFolderName);
-    var workspaceName = ("ws_" + downloadFolderName).slice(0, 60);
+    const workspaceName = ("ws_" + downloadFolderName).slice(0, 60);
     console.log("workspace name: " + workspaceName);
     return workspaceName;
 };
@@ -207,18 +227,24 @@ function getDefaultTfvcMappings() {
     };
 };
 
-function ensurePathExist(path) {
-    if (!shell.test('-d', path)) {
-        shell.mkdir("-p", path);
-        console.log("Successfully created directory: " + path);
+/**
+ * @param {string} folderPath
+ */
+function ensurePathExist(folderPath) {
+    if (!shell.test('-d', folderPath)) {
+        shell.mkdir("-p", folderPath);
+        console.log("Successfully created directory: " + folderPath);
     }
 };
 
-// ret is { output: string, code: number }
+/**
+ * @param {string} cmdLine
+ * @returns {Promise<{ code: number, output: string }>}
+ */
 function utilExec(cmdLine) {
-    var defer = Q.defer();
-    shell.exec(cmdLine, function (code, output) {
-        defer.resolve({ code: code, output: output });
+    return new Promise(function (resolve) {
+        shell.exec(cmdLine, function (/** @type {number} */ code, /** @type {string} */ output) {
+            resolve({ code: code, output: output });
+        });
     });
-    return defer.promise;
 };

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/task.json
@@ -65,7 +65,7 @@
       "helpMarkDown": "Path on the agent machine where the artifacts will be downloaded"
     }
   ],
-    "dataSourceBindings": [
+  "dataSourceBindings": [
     {
       "target": "project",
       "endpointId": "$(connection)",
@@ -73,23 +73,23 @@
       "resultTemplate": "{ \"Value\" : \"{{{id}}}\", \"DisplayValue\" : \"{{{name}}}\" }"
     },
     {
-        "target": "definition",
-        "endpointId": "$(connection)",
-        "dataSourceName": "TfvcProjects",
-        "parameters": {
-            "project": "$(project)"
-        },
-        "resultTemplate": "{ \"Value\" : \"{{#if supportsTFVC}}{{{project.id}}}{{else}}{{/if}}\", \"DisplayValue\" : \"{{#if supportsTFVC}}$/{{{project.name}}}{{else}}{{/if}}\" }"
+      "target": "definition",
+      "endpointId": "$(connection)",
+      "dataSourceName": "TfvcProjects",
+      "parameters": {
+        "project": "$(project)"
+      },
+      "resultTemplate": "{ \"Value\" : \"{{#if supportsTFVC}}{{{project.id}}}{{else}}{{/if}}\", \"DisplayValue\" : \"{{#if supportsTFVC}}$/{{{project.name}}}{{else}}{{/if}}\" }"
     },
     {
-        "target": "version",
-        "endpointId": "$(connection)",
-        "dataSourceName": "TfvcChangesets",
-        "parameters":{
+      "target": "version",
+      "endpointId": "$(connection)",
+      "dataSourceName": "TfvcChangesets",
+      "parameters": {
         "project": "$(project)",
         "definition": "$(definition)"
-        },
-        "resultTemplate": "{ \"Value\" : \"{{{changesetId}}}\", \"DisplayValue\" : \"Changeset {{{changesetId}}}\" }"
+      },
+      "resultTemplate": "{ \"Value\" : \"{{{changesetId}}}\", \"DisplayValue\" : \"Changeset {{{changesetId}}}\" }"
     }
   ],
   "instanceNameFormat": "Download Artifacts - External TFS Version Control",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/tfvcwrapper.js
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/tfvcwrapper.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 "use strict";
 
 var __extends = (this && this.__extends) || function (d, b) {
@@ -27,13 +28,13 @@ var TfvcWrapper = (function (_super) {
         var rootDirectory = path.dirname(path.dirname(path.dirname(path.dirname(path.dirname(require.main.filename)))));
         var nonWindows = ['darwin', 'linux'];
         if (nonWindows.indexOf(process.platform) == -1) {
-            var agentTf = path.join(rootDirectory, "externals", "vstsom" , "tf.exe");
+            var agentTf = path.join(rootDirectory, "externals", "vstsom", "tf.exe");
             if (fs.existsSync(agentTf)) {
                 tfp = agentTf;
             }
         }
         else {
-            var agentTee = path.join(rootDirectory, "externals", "tee" , "tf");
+            var agentTee = path.join(rootDirectory, "externals", "tee", "tf");
             if (fs.existsSync(agentTee)) {
                 tfp = agentTee;
                 isTEE = true;
@@ -70,7 +71,7 @@ var TfvcWrapper = (function (_super) {
     TfvcWrapper.prototype.get = function (version) {
         if (isTEE === true) {
             if (!version) {
-                return this._exec('get', ['.', '-recursive', '-noprompt'], true);    
+                return this._exec('get', ['.', '-recursive', '-noprompt'], true);
             } else {
                 return this._exec('get', ['.', '-recursive', '-version:' + version, '-noprompt'], true);
             }
@@ -84,7 +85,7 @@ var TfvcWrapper = (function (_super) {
     };
 
     TfvcWrapper.prototype.listWorkspaces = function () {
-            return this._execSync("workspaces", [], true);
+        return this._execSync("workspaces", [], true);
     };
 
     TfvcWrapper.prototype._execSync = function (cmd, args, addDefaultArgs, options) {
@@ -124,20 +125,20 @@ var TfvcWrapper = (function (_super) {
         tf.silent = true;
         // cmd
         tf.arg(cmd, true);
-		
-		if (addDefaultArgs === true) {
+
+        if (addDefaultArgs === true) {
             // default connection related args
             var collectionArg = '-collection:' + connOptions.collection;
             var loginArg = '-login:' + connOptions.username + ',' + connOptions.password;
 
             args = args.concat([collectionArg, loginArg]);
-        } 
-		        
+        }
+
         // args
         args.map(function (arg) {
             tf.arg(arg, true); // raw arg
         });
-		
+
         return tf;
     };
 

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/tsconfig.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "ES6",
         "module": "node16",
         "esModuleInterop": true,
         "moduleResolution": "node16",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/tsconfig.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/tsconfig.json
@@ -8,11 +8,9 @@
         "noEmit": true,
         "checkJs": true,
         "useUnknownInCatchVariables": false,
-        "strict": true,
-        "ignoreDeprecations": "6.0"
+        "strict": true
     },
-    "files": [
-        "downloadTfsVersionControl.js",
-        "tfvcwrapper.js"
+    "include": [
+        "*.js"
     ]
 }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/tsconfig.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsVersionControl/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "module": "node16",
+        "esModuleInterop": true,
+        "moduleResolution": "node16",
+        "skipLibCheck": true,
+        "noEmit": true,
+        "checkJs": true,
+        "useUnknownInCatchVariables": false,
+        "strict": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "files": [
+        "downloadTfsVersionControl.js",
+        "tfvcwrapper.js"
+    ]
+}

--- a/externals.json
+++ b/externals.json
@@ -10,5 +10,6 @@
         "DownloadExternalBuildArtifacts"
     ],
     "tsc-build-check": [
+        "DownloadArtifactsTfsVersionControl"
     ]
 }


### PR DESCRIPTION
**Description**:

Enables strict TypeScript checking (via `checkJs`) for the `DownloadArtifactsTfsVersionControl` task and annotates the JS files with JSDoc types to satisfy it.

Changes:
- **`tsconfig.json`** (new) — strict tsc config for this JS-only task:
  - `target: es6`, `module`/`moduleResolution: node16`, `esModuleInterop`, `skipLibCheck`, `noEmit`.
  - `checkJs: true`, `strict: true`, `useUnknownInCatchVariables: false`, `ignoreDeprecations: "6.0"`.
  - Explicit `files` list: `downloadTfsVersionControl.js`, `tfvcwrapper.js`.
- **`externals.json`** — add `DownloadArtifactsTfsVersionControl` to the `tsc-build-check` list so the new strict check runs in CI.
- **`downloadTfsVersionControl.js`** — make the file pass `checkJs` + `strict`:
  - Add JSDoc `@param`/`@returns`/`@type` annotations on every function and on the module-level `tl.getInput` calls (cast required inputs to `string`).
  - Switch `var` → `const`/`let`, arrow callbacks where applicable, consistent formatting.
  - Replace the `Q` promise library with native `Promise`s; `utilExec` now returns a real `Promise<{ code, output }>` and intermediate `.then` handlers return plain values instead of `Q(...)`. Remove the `Q` and unused `url` requires.
  - Null-check the result of `tl.getEndpointAuthorization` and throw the same decode error when missing.
  - `getAuthParameter` now returns `""` when the parameter is not found (instead of leaving `paramValue` undefined).
  - Replace `tl.exit(1)` with `process.exit(1)` in the error branches so the typed signature matches.
  - Rename shadowed `path` parameters to `folderPath` in `IsPathExists` / `ensurePathExist`.
  - Tighten `tfsEndpoint.Url` logging to guard against `undefined`.
- **`tfvcwrapper.js`** — add `// @ts-nocheck` at the top (legacy compiled TS output kept as-is) plus minor whitespace cleanup (tabs → spaces, trailing-space removal, single-line `listWorkspaces` body).
- **`task.json`** — indentation-only cleanup inside `dataSourceBindings`. No functional change.

**Documentation changes required:** N

**Added unit tests:** N — no behavior changes; the goal of this PR is to enable strict `tsc --checkJs` for the task and fix the resulting type errors.

**Attached related issue:** N

**Checklist**:
- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
