### PR TITLE
Modify job dependencies in pipeline for publishing extensions

### DIFF
--- a/.pipelines/1es-migration/azure-pipelines.yml
+++ b/.pipelines/1es-migration/azure-pipelines.yml
@@ -313,7 +313,7 @@ extends:
 
           - task: AzureCLI@2
             displayName: 'Poll test extension validation status if primary publish fails'
-            condition: failed()
+            condition: in(variables['Agent.JobStatus'], 'SucceededWithIssues')
             inputs:
               azureSubscription: '1es-extensions-publication-secure-service-connection'
               scriptType: pscore
@@ -373,7 +373,9 @@ extends:
     # ======= Approve PROD extension publishing on Marketplace =======
     - stage: Approve_Prod_Extension_Publishing
       displayName: 'Approve PROD extension publishing on Marketplace'
-      dependsOn: Execute_CI_Tests
+      dependsOn:
+      - Execute_CI_Tests
+      - Sign_Vsix_Artifacts
       condition: succeeded()
       jobs:
       - job: ApproveProd
@@ -424,7 +426,7 @@ extends:
 
         - task: AzureCLI@2
           displayName: 'Poll PROD extension validation status if primary publish fails'
-          condition: failed()
+          condition: in(variables['Agent.JobStatus'], 'SucceededWithIssues')
           inputs:
             azureSubscription: '1es-extensions-publication-secure-service-connection'
             scriptType: pscore

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.276.0",
+  "version": "0.276.1",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.275.40",
+  "version": "15.276.0",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.275.8",
+  "version": "16.276.0",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.275.6",
+  "version": "1.276.0",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.275.11",
+  "version": "4.276.0",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.275.7",
+  "version": "15.276.0",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/scripts/PublishMarketplaceExtensions.ps1
+++ b/scripts/PublishMarketplaceExtensions.ps1
@@ -258,7 +258,10 @@ if ($RescueFailedPublish) {
     }
 
     if (-not (Test-LogIndicatesLongValidation -LogContent $publishLog)) {
-        Write-Host "##[error]Publish task '$PublishTaskDisplayName' failed for a reason unrelated to Marketplace validation timeout (for example: version already published, auth failure, malformed package). Refer to that task's log for the actual error."
+        Write-Host "##[error]Marketplace validation mode was invoked, but the log for task '$PublishTaskDisplayName' does not contain messages that indicate inability to verify status of an extension upload."
+        Write-Host "Two possibilities to investigate:"
+        Write-Host "  1. The publish task failed for an unrelated reason (for example: version already published, authentication failure, malformed package, etc.). The actual error should appear in the publish task log."
+        Write-Host "  2. The publish actually succeeded but emitted warnings that promoted its status to SucceededWithIssues, which falsely triggered this mode. In that case verify the extension's status on Marketplace directly - it may already be published correctly."
         Write-PublishLogTail -LogContent $publishLog
         exit 1
     }


### PR DESCRIPTION
**Description**: 
1. Tightened the rescue-step triggering so it only fires when the publish task itself ends in `SucceededWithIssues` (the result of its `continueOnError: true` failure), instead of the broader` failed()` that could be confused by other failures in the job.
2. Added `Sign_Vsix_Artifacts` as an explicit `dependsOn` for `Approve_Prod_Extension_Publishing` to avoid possible racing in some scenarios when test extension publishing is not needed. We need signed extension before we publish PROD extension to Marketplace
3. Updated the script's diagnostic message to explain both real-failure and false-trigger scenarios. The goal is to make the post-publish polling fire only for the intended Marketplace validation timeout case and avoid masking unrelated failures.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [ ] Checked that applied changes work as expected.
