### PR TITLE
Update shell-quote lib version

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@types/ssh2-sftp-client": "5.2.0",
         "azure-pipelines-task-lib": "^5.2.8",
-        "shell-quote": "^1.8.2",
+        "shell-quote": "^1.8.4",
         "shelljs": "^0.10.0",
         "ssh2": "1.4.0",
         "ssh2-sftp-client": "^8.1.0",
@@ -748,9 +748,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha1-VeQO8zz1xomQI1Oj2M0aZyXwi0s=",
+      "version": "1.8.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha1-Lt2aTc78lmSeLiyxL2N7Hx2SoZA=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/Extensions/Ansible/Src/Tasks/Ansible/package.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@types/ssh2-sftp-client": "5.2.0",
     "azure-pipelines-task-lib": "^5.2.8",
-    "shell-quote": "^1.8.2",
+    "shell-quote": "^1.8.4",
     "shelljs": "^0.10.0",
     "ssh2": "1.4.0",
     "ssh2-sftp-client": "^8.1.0",

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 276,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [],
     "instanceNameFormat": "Run playbook",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.276.2",
+  "version": "0.276.3",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",


### PR DESCRIPTION
**Description**: Vulnerabilities reported in shell-quote <= 1.8.3. Safe version as per https://github.com/advisories/GHSA-w7jw-789q-3m8p is 1.8.4.

This PR updates shell-quote version to 1.8.4 for ansible extension.

Associated WI: 

[AB#2429296](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2429296)
[AB#2429306](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2429306)

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** Y

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
