### PR TITLE
Add ServiceNow and TeamCity CI test pipeline mappings

### DIFF
--- a/scripts/DetermineCiTestPipelineName.ps1
+++ b/scripts/DetermineCiTestPipelineName.ps1
@@ -14,6 +14,7 @@ switch ($ExtensionName) {
   'ExternalTfs'     { $pipelineName = 'AzDev-ReleaseManagement-ExternalTFS-CI-Test' }
   'IISWebAppDeploy' { $pipelineName = 'AzDev-ReleaseManagement-IIS-Test' }
   'ServiceNow'      { $pipelineName =  'AzDev-ReleaseManagement-ServiceNow-CI-Test' }
+  'TeamCity'        { $pipelineName = 'AzDev-ReleaseManagement-TeamCity-CI-Test' }
   default {
     throw "Pipeline name can't be determined for extension '$ExtensionName'. Update the mapping."
   }

--- a/scripts/DetermineCiTestPipelineName.ps1
+++ b/scripts/DetermineCiTestPipelineName.ps1
@@ -13,6 +13,7 @@ switch ($ExtensionName) {
   'BitBucket'       { $pipelineName = 'AzDev-ReleaseManagement-BitBucket-CI-Test' }
   'ExternalTfs'     { $pipelineName = 'AzDev-ReleaseManagement-ExternalTFS-CI-Test' }
   'IISWebAppDeploy' { $pipelineName = 'AzDev-ReleaseManagement-IIS-Test' }
+  'ServiceNow'      { $pipelineName =  'AzDev-ReleaseManagement-ServiceNow-CI-Test' }
   default {
     throw "Pipeline name can't be determined for extension '$ExtensionName'. Update the mapping."
   }

--- a/scripts/TriggerCiTestsForExtensions.ps1
+++ b/scripts/TriggerCiTestsForExtensions.ps1
@@ -29,6 +29,7 @@ $pipelineMapping = @{
     'BitBucket'       = 'AzDev-ReleaseManagement-BitBucket-CI-Test'
     'ExternalTfs'     = 'AzDev-ReleaseManagement-ExternalTFS-CI-Test'
     'IISWebAppDeploy' = 'AzDev-ReleaseManagement-IIS-Test'
+    'ServiceNow'      = 'AzDev-ReleaseManagement-ServiceNow-CI-Test'
 }
 
 # ── Parse extensions ──

--- a/scripts/TriggerCiTestsForExtensions.ps1
+++ b/scripts/TriggerCiTestsForExtensions.ps1
@@ -30,6 +30,7 @@ $pipelineMapping = @{
     'ExternalTfs'     = 'AzDev-ReleaseManagement-ExternalTFS-CI-Test'
     'IISWebAppDeploy' = 'AzDev-ReleaseManagement-IIS-Test'
     'ServiceNow'      = 'AzDev-ReleaseManagement-ServiceNow-CI-Test'
+    'TeamCity'        = 'AzDev-ReleaseManagement-TeamCity-CI-Test'
 }
 
 # ── Parse extensions ──


### PR DESCRIPTION
**Summary**
Adds the ServiceNow and TeamCity extensions to the CI test pipeline name mappings so that CI tests are automatically triggered when changes are made to these extensions.

**Changes**
DetermineCiTestPipelineName.ps1 — Added 'ServiceNow' and 'TeamCity' cases mapping to their respective CI test pipelines
TriggerCiTestsForExtensions.ps1 — Added 'ServiceNow' and 'TeamCity' entries to the $pipelineMapping hashtable
New mappings:
Extension	Pipeline
ServiceNow	AzDev-ReleaseManagement-ServiceNow-CI-Test
TeamCity	AzDev-ReleaseManagement-TeamCity-CI-Test

**Why**
Previously, changes to the ServiceNow or TeamCity extensions would not trigger CI tests because they were missing from the pipeline name mappings. This caused DetermineCiTestPipelineName.ps1 to throw an error and TriggerCiTestsForExtensions.ps1 to skip them. This PR closes that gap.

**Testing**
Verified DetermineCiTestPipelineName.ps1 -ExtensionName "ServiceNow" resolves correctly
Verified DetermineCiTestPipelineName.ps1 -ExtensionName "TeamCity" resolves correctly
