### PR TITLE
Add unit tests for Bitbucket Download Artifacts task

### DIFF
--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
@@ -16,12 +16,10 @@ var bitbucketEndpoint = getEndpointDetails("connection");
 
 removePathRecursive(downloadPath);
 
-
-var path = "/2.0/repositories/" + repositoryId;
 var options = {
     host: "api.bitbucket.org",
     method: "GET",
-    path: path
+    path: "/2.0/repositories/" + repositoryId
 };
 
 // Set authentication based on the endpoint type

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
@@ -1,27 +1,20 @@
 var tl = require('azure-pipelines-task-lib/task');
+var fs = require('fs');
 var path = require('path');
-var webApim = require('vso-node-api/WebApi');
-var gitInterfaces = require('vso-node-api/interfaces/GitInterfaces');
 var Q = require('q');
 var url = require('url');
-var shell = require("shelljs");
 var scw = require('./sourcecontrolwrapper.js');
 var https = require("https");
 
 var BITBUCKET_API_TOKEN_AUTH_USERNAME = 'x-bitbucket-api-token-auth';
 
-var repositoryId = tl.getInput("definition");
-var branch = tl.getInput("branch");
-var commitId = tl.getInput("version");
-var downloadPath = tl.getInput("downloadPath");
+var repositoryId = tl.getInput("definition", true);
+var branch = tl.getInput("branch", true);
+var commitId = tl.getInput("version", true);
+var downloadPath = tl.getInput("downloadPath", true);
 var bitbucketEndpoint = getEndpointDetails("connection");
 
-shell.rm('-rf', downloadPath);
-var error = shell.error();
-if (error) {
-    tl.error(error);
-    tl.exit(1);
-}
+removePathRecursive(downloadPath);
 
 
 var path = "/2.0/repositories/" + repositoryId;
@@ -50,17 +43,17 @@ https.request(options, function (rs) {
         result = JSON.parse(response);
         tl.debug("result:" + JSON.stringify(result));
         var sch = new scw.SourceControlWrapper(result.scm);
-        
+
         sch.on('stdout', function (data) {
             console.log(data.toString());
         });
         sch.on('stderr', function (data) {
             console.log(data.toString());
         });
-        
+
         var remoteUrl = result.links.clone[0].href;
         tl.debug("Remote Url:" + remoteUrl);
-        
+
         // encodes projects and repo names with spaces
         var repoUrl = url.parse(remoteUrl);
         if (bitbucketEndpoint.Token) {
@@ -69,7 +62,7 @@ https.request(options, function (rs) {
         } else if (bitbucketEndpoint.Username && bitbucketEndpoint.Password) {
             repoUrl.auth = bitbucketEndpoint.Username + ':' + bitbucketEndpoint.Password;
         }
-        
+
         // if branch, we want to clone remote branch name to avoid tracking etc.. ('/refs/remotes/...')
         var ref;
         var brPre = 'refs/heads/';
@@ -79,7 +72,7 @@ https.request(options, function (rs) {
         else {
             ref = branch;
         }
-        
+
         var options = {
             creds: true,
             debugOutput: this.debugOutput
@@ -94,17 +87,14 @@ https.request(options, function (rs) {
 
         Q(0).then(function (code) {
             return sch.clone(repoUrl.format(repoUrl), false, downloadPath, options)
-                       .then(
-                function (code) {
-                    shell.cd(downloadPath);
+                .then(function (code) {
+                    process.chdir(downloadPath);
                     return sch.checkout(ref, options);
                 })
-                       .then(
-                function (code) {
+                .then(function (code) {
                     return sch.checkout(commitId);
                 })
-                       .fail(
-                function (error) {
+                .catch(function (error) {
                     tl.error(error);
                     tl.exit(1);
                 });
@@ -113,17 +103,17 @@ https.request(options, function (rs) {
 }).end();
 
 function getEndpointDetails(inputFieldName) {
-    var bitbucketEndpoint = tl.getInput(inputFieldName);
+    var bitbucketEndpoint = tl.getInput(inputFieldName, true);
     var auth = tl.getEndpointAuthorization(bitbucketEndpoint, false);
     var scheme = auth.scheme.toLowerCase().trim();
-    
+
     if (scheme === "token") {
         var token = getAuthParameter(bitbucketEndpoint, 'apitoken');
         var username = getAuthParameter(bitbucketEndpoint, 'email') || '';
         tl.debug('Using token authentication');
         try {
             tl.setSecret(token);
-        } catch {
+        } catch (err) {
             tl.warning('Failed to mask API token for log redaction.');
         }
         return {
@@ -135,7 +125,7 @@ function getEndpointDetails(inputFieldName) {
         var hostPassword = getAuthParameter(bitbucketEndpoint, 'password');
         try {
             tl.setSecret(hostPassword);
-        } catch {
+        } catch (err) {
             tl.warning('Failed to mask password for log redaction.');
         }
         tl.debug('hostUsername: ' + hostUsername);
@@ -150,11 +140,11 @@ function getAuthParameter(endpoint, paramName) {
     var paramValue = null;
     var auth = tl.getEndpointAuthorization(endpoint, false);
     var scheme = auth.scheme.toLowerCase().trim();
-    
+
     if (scheme !== "usernamepassword" && scheme !== "token") {
         throw new Error("The authorization scheme " + auth.scheme + " is not supported for a bitbucket endpoint. Please use either 'usernamepassword' or 'token'.");
     }
-    
+
     var keyName = getCaseInsensitiveKeyMatch(auth['parameters'], paramName);
     paramValue = auth['parameters'][keyName];
 
@@ -170,6 +160,24 @@ function getCaseInsensitiveKeyMatch(data, paramName) {
             return true;
         }
     });
-    
+
     return keyName;
+}
+
+function removePathRecursive(targetPath) {
+    if (!targetPath || !fs.existsSync(targetPath)) {
+        return;
+    }
+
+    var stats = fs.lstatSync(targetPath);
+    if (!stats.isDirectory()) {
+        fs.unlinkSync(targetPath);
+        return;
+    }
+
+    fs.readdirSync(targetPath).forEach(function (entry) {
+        removePathRecursive(path.join(targetPath, entry));
+    });
+
+    fs.rmdirSync(targetPath);
 }

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/sourcecontrolwrapper.js
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/sourcecontrolwrapper.js
@@ -1,9 +1,8 @@
 "use strict";
 
-var tl = require('azure-pipelines-task-lib');
+var tl = require('azure-pipelines-task-lib/task');
 var events = require('events');
 var Q = require('q');
-var shell = require('shelljs');
 var path = require('path');
 
 var __extends = (this && this.__extends) || function (d, b) {
@@ -37,7 +36,7 @@ var SourceControlWrapper = (function (_super) {
         options.creds = true;
         return this.exec(['fetch'].concat(args), options);
     };
-    
+
     SourceControlWrapper.prototype.checkout = function (ref, options) {
         options = options || {};
         options.creds = true;
@@ -53,19 +52,18 @@ var SourceControlWrapper = (function (_super) {
         var _this = this;
         options = options || {};
         var defer = Q.defer();
-        
-        var toolPath = shell.which(this.toolType, false);
+
+        var toolPath = tl.which(this.toolType, false);
         if (!toolPath) {
             throw (new Error(this.toolType + ' not found.  ensure installed and in the path'));
         }
-        var tool = new tl.ToolRunner(toolPath.toString());
-        tool.silent = true;
+        var tool = tl.tool(toolPath.toString());
         var creds = this.username + ':' + this.password;
         var escapedCreds = encodeURIComponent(this.username) + ':' + encodeURIComponent(this.password);
         try {
             tl.setSecret(this.password);
             tl.setSecret(escapedCreds);
-        } catch {
+        } catch (err) {
             tl.warning('Failed to mask credentials for log redaction.');
         }
         tool.on('debug', function (message) {
@@ -81,7 +79,7 @@ var SourceControlWrapper = (function (_super) {
         tool.on('stderr', function (data) {
             _this.emit('stderr', data);
         });
-        
+
         args.map(function (arg) {
             tool.arg(arg, true); // raw arg
         });

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/_suite.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/_suite.ts
@@ -1,0 +1,567 @@
+import assert = require('assert');
+import fs = require('fs');
+import path = require('path');
+
+const mocktest = require('azure-pipelines-task-lib/mock-test');
+
+process.env['DISTRIBUTEDTASK_TASKS_NODE_SKIPDEBUGLOGSWHENDEBUGMODEOFF'] = 'true';
+
+const taskJsonPath = path.join(process.cwd(), 'Extensions', 'BitBucket', 'Src', 'Tasks', 'DownloadArtifactsBitbucket', 'task.json');
+const sourceControlWrapperModulePath = path.join(process.cwd(), 'Extensions', 'BitBucket', 'Src', 'Tasks', 'DownloadArtifactsBitbucket', 'sourcecontrolwrapper.js');
+const sourceControlWrapperTl = (function (): any {
+    try {
+        const resolvedPath = (require as any).resolve('azure-pipelines-task-lib/task', { paths: [path.dirname(sourceControlWrapperModulePath)] });
+        return require(resolvedPath);
+    } catch (err) {
+        return require('azure-pipelines-task-lib/task');
+    }
+})();
+
+function getDeclaredNodeVersions(): number[] {
+    const taskJson = JSON.parse(fs.readFileSync(taskJsonPath, 'utf-8'));
+    const versions = new Set<number>();
+    const exec = taskJson.execution || {};
+
+    for (const key of Object.keys(exec)) {
+        const match = /^Node(\d*)/i.exec(key);
+        if (!match) {
+            continue;
+        }
+
+        versions.add(parseInt(match[1], 10) || 6);
+    }
+
+    return Array.from(versions).sort((a, b) => a - b);
+}
+
+function newRunner(scenario: string): any {
+    return new mocktest.MockTestRunner(path.join(__dirname, scenario + '.js'), taskJsonPath);
+}
+
+async function runAndDump(runner: any, nodeVersion: number): Promise<void> {
+    try {
+        await runner.runAsync(nodeVersion);
+    } catch (err) {
+        console.log('--- runner threw ---');
+        console.log(err);
+        throw err;
+    }
+}
+
+function fail(runner: any, msg: string): never {
+    console.log('--- STDOUT ---');
+    console.log(runner.stdout);
+    console.log('--- STDERR ---');
+    console.log(runner.stderr);
+    throw new Error(msg);
+}
+
+const nodeVersions = getDeclaredNodeVersions();
+
+describe('DownloadArtifactsBitbucket Suite', function () {
+    this.timeout(120000);
+
+    nodeVersions.forEach(function (nodeVersion) {
+        describe('Node ' + nodeVersion, function () {
+
+            it('succeeds with token auth and performs clone + checkout sequence', async function () {
+                const runner = newRunner('successTokenAuth');
+                await runAndDump(runner, nodeVersion);
+                if (!runner.succeeded) fail(runner, 'expected task to succeed');
+
+                assert(runner.stdOutContained('[mock-https] request /2.0/repositories/workspace/repo authUser=token-user@example.com'), 'should call Bitbucket API with token username');
+                assert(runner.stdOutContained('[mock-scw] ctor tool=git'), 'should initialize source control wrapper with scm from API');
+                assert(runner.stdOutContained('[mock-scw] clone https://***@bitbucket.org/org/repo.git .'), 'should clone with authenticated URL');
+                assert(runner.stdOutContained('[mock-scw] auth user=x-bitbucket-api-token-auth passSet=true'), 'should set API token auth username/password on wrapper');
+                assert(runner.stdOutContained('[mock-scw] checkout refs/remotes/origin/main'), 'should checkout normalized branch ref');
+                assert(runner.stdOutContained('[mock-scw] checkout 1234567890abcdef1234567890abcdef12345678'), 'should checkout commit');
+                assert(runner.stdOutContained('##vso[task.setsecret]bb-token'), 'should register token as secret');
+            });
+
+            it('succeeds with username/password auth path', async function () {
+                const runner = newRunner('successUserPassAuth');
+                await runAndDump(runner, nodeVersion);
+                if (!runner.succeeded) fail(runner, 'expected task to succeed');
+
+                assert(runner.stdOutContained('[mock-https] request /2.0/repositories/workspace/repo authUser=bb-user'), 'should call Bitbucket API with username auth');
+                assert(runner.stdOutContained('[mock-scw] clone https://***@bitbucket.org/org/repo.git .'), 'should clone with authenticated URL');
+                assert(runner.stdOutContained('[mock-scw] auth user=bb-user passSet=true'), 'should set username/password on wrapper');
+                assert(runner.stdOutContained('[mock-scw] checkout develop'), 'should checkout raw branch when not refs/heads/*');
+                assert(runner.stdOutContained('##vso[task.setsecret]bb-pass'), 'should register password as secret');
+            });
+
+            it('succeeds when API reports hg scm and forwards tool type to wrapper', async function () {
+                const runner = newRunner('successHgScm');
+                await runAndDump(runner, nodeVersion);
+                if (!runner.succeeded) fail(runner, 'expected task to succeed for hg repository metadata');
+
+                assert(runner.stdOutContained('[mock-scw] ctor tool=hg'), 'should create wrapper with scm from API response');
+                assert(runner.stdOutContained('[mock-scw] clone https://***@bitbucket.org/org/repo.git .'), 'should still clone repository');
+            });
+
+            it('succeeds when token auth email parameter is omitted', async function () {
+                const runner = newRunner('successTokenAuthNoEmail');
+                await runAndDump(runner, nodeVersion);
+                if (!runner.succeeded) fail(runner, 'expected task to succeed when token email parameter is missing');
+                assert(runner.stdOutContained('[mock-https] request /2.0/repositories/workspace/repo authUser='), 'should call Bitbucket API with empty auth username when email is missing');
+                assert(runner.stdOutContained('[mock-scw] auth user=x-bitbucket-api-token-auth passSet=true'), 'should still use token auth username for clone credentials');
+            });
+
+            it('supports case-insensitive token auth parameter names', async function () {
+                const runner = newRunner('successAuthParamCaseInsensitiveToken');
+                await runAndDump(runner, nodeVersion);
+                if (!runner.succeeded) fail(runner, 'expected task to succeed with uppercase token auth parameter keys');
+
+                assert(runner.stdOutContained('[mock-https] request /2.0/repositories/workspace/repo authUser=token-user@example.com'), 'should read uppercase token parameters');
+            });
+
+            it('supports case-insensitive username/password parameter names', async function () {
+                const runner = newRunner('successAuthParamCaseInsensitiveUserPass');
+                await runAndDump(runner, nodeVersion);
+                if (!runner.succeeded) fail(runner, 'expected task to succeed with uppercase username/password keys');
+
+                assert(runner.stdOutContained('[mock-https] request /2.0/repositories/workspace/repo authUser=bb-user'), 'should read uppercase username/password parameters');
+            });
+
+            it('normalizes refs/heads/* to refs/remotes/origin/* for checkout', async function () {
+                const runner = newRunner('successBranchNormalization');
+                await runAndDump(runner, nodeVersion);
+                if (!runner.succeeded) fail(runner, 'expected task to succeed');
+
+                assert(runner.stdOutContained('[mock-scw] checkout refs/remotes/origin/release/v1'), 'should convert branch ref for checkout');
+            });
+
+            it('recursively removes existing download path before clone', async function () {
+                const runner = newRunner('successCleanupRecursive');
+                await runAndDump(runner, nodeVersion);
+                if (!runner.succeeded) fail(runner, 'expected task to succeed');
+
+                assert(runner.stdOutContained('[mock-fs] unlink a.txt'), 'should remove top-level files');
+                assert(runner.stdOutContained('[mock-fs] unlink sub/b.txt'), 'should remove nested files');
+                assert(runner.stdOutContained('[mock-fs] rmdir sub'), 'should remove nested directories');
+                assert(runner.stdOutContained('[mock-fs] rmdir .'), 'should remove target directory');
+            });
+
+            it('fails when required input connection is missing', async function () {
+                const runner = newRunner('failMissingConnection');
+                await runAndDump(runner, nodeVersion);
+                if (runner.succeeded) fail(runner, 'expected task to fail for missing connection');
+
+                assert(runner.stdOutContained('Input required: connection'), 'should fail on missing connection input');
+            });
+
+            it('fails when required input definition is missing', async function () {
+                const runner = newRunner('failMissingDefinition');
+                await runAndDump(runner, nodeVersion);
+                if (runner.succeeded) fail(runner, 'expected task to fail for missing definition');
+
+                assert(runner.stdOutContained('Input required: definition'), 'should fail on missing definition input');
+            });
+
+            it('fails when required input branch is missing', async function () {
+                const runner = newRunner('failMissingBranch');
+                await runAndDump(runner, nodeVersion);
+                if (runner.succeeded) fail(runner, 'expected task to fail for missing branch');
+
+                assert(runner.stdOutContained('Input required: branch'), 'should fail on missing branch input');
+            });
+
+            it('fails when required input version is missing', async function () {
+                const runner = newRunner('failMissingVersion');
+                await runAndDump(runner, nodeVersion);
+                if (runner.succeeded) fail(runner, 'expected task to fail for missing version');
+
+                assert(runner.stdOutContained('Input required: version'), 'should fail on missing version input');
+            });
+
+            it('fails when required input downloadPath is missing', async function () {
+                const runner = newRunner('failMissingDownloadPath');
+                await runAndDump(runner, nodeVersion);
+                if (runner.succeeded) fail(runner, 'expected task to fail for missing downloadPath');
+
+                assert(runner.stdOutContained('Input required: downloadPath'), 'should fail on missing downloadPath input');
+            });
+
+            it('fails for unsupported endpoint authorization scheme', async function () {
+                const runner = newRunner('failUnsupportedAuthScheme');
+                await runAndDump(runner, nodeVersion);
+                if (runner.succeeded) fail(runner, 'expected task to fail for unsupported auth scheme');
+
+                assert(runner.stdOutContained('is not supported for a bitbucket endpoint'), 'should reject unsupported auth scheme');
+            });
+
+            it('fails when endpoint authorization is missing', async function () {
+                const runner = newRunner('failNoEndpointAuthorization');
+                await runAndDump(runner, nodeVersion);
+                if (runner.succeeded) fail(runner, 'expected task to fail when endpoint authorization is missing');
+
+                const hasAuthError = runner.stdOutContained('scheme') || runner.stdOutContained('undefined') || runner.stdOutContained('Cannot read property');
+                assert(hasAuthError, 'should report a missing endpoint authorization failure');
+            });
+
+            it('continues when token auth parameter is missing', async function () {
+                const runner = newRunner('failMissingAuthParameter');
+                await runAndDump(runner, nodeVersion);
+                if (!runner.succeeded) fail(runner, 'expected task to continue when apitoken parameter is absent');
+
+                assert(runner.stdOutContained('[mock-https] request /2.0/repositories/workspace/repo authUser='), 'should call the API without an auth username when token is absent');
+                assert(runner.stdOutContained('[mock-scw] auth user=token-user@example.com passSet=false'), 'should forward missing token as an unset clone password');
+            });
+
+            it('continues when required username/password auth parameter is missing', async function () {
+                const runner = newRunner('failMissingPasswordParameter');
+                await runAndDump(runner, nodeVersion);
+                if (!runner.succeeded) fail(runner, 'expected task to continue when password parameter is absent');
+
+                assert(runner.stdOutContained('[mock-scw] auth user=bb-user passSet=false'), 'should forward the username with an unset password');
+            });
+
+            it('continues when required username parameter is missing', async function () {
+                const runner = newRunner('failMissingUsernameParameter');
+                await runAndDump(runner, nodeVersion);
+                if (!runner.succeeded) fail(runner, 'expected task to continue when username parameter is absent');
+
+                assert(runner.stdOutContained('[mock-scw] auth user=undefined passSet=true'), 'should forward an undefined username with the configured password');
+            });
+
+            it('fails when endpoint auth object is present but has no scheme', async function () {
+                const runner = newRunner('failAuthMissingScheme');
+                await runAndDump(runner, nodeVersion);
+                if (runner.succeeded) fail(runner, 'expected task to fail when endpoint auth scheme is missing');
+
+                const hasAuthError = runner.stdOutContained('scheme') || runner.stdOutContained('undefined') || runner.stdOutContained('Cannot read property');
+                assert(hasAuthError, 'should report a missing auth scheme failure');
+            });
+
+            it('fails when Bitbucket API returns malformed json', async function () {
+                const runner = newRunner('failMalformedApiResponse');
+                await runAndDump(runner, nodeVersion);
+                if (runner.succeeded) fail(runner, 'expected task to fail for malformed API response');
+
+                const hasJsonError = runner.stdOutContained('Unexpected token') || runner.stdOutContained('JSON');
+                assert(hasJsonError, 'should surface JSON parse failure');
+            });
+
+            it('fails when Bitbucket API payload misses links.clone', async function () {
+                const runner = newRunner('failApiMissingCloneLinks');
+                await runAndDump(runner, nodeVersion);
+                if (runner.succeeded) fail(runner, 'expected task to fail when links.clone is missing');
+
+                const hasShapeError = runner.stdOutContained('clone') || runner.stdOutContained('Cannot read') || runner.stdOutContained('undefined');
+                assert(hasShapeError, 'should surface payload shape error for missing clone links');
+            });
+
+            it('continues when Bitbucket API payload misses scm', async function () {
+                const runner = newRunner('failApiMissingScm');
+                await runAndDump(runner, nodeVersion);
+                if (!runner.succeeded) fail(runner, 'expected task to continue when scm is missing');
+
+                assert(runner.stdOutContained('[mock-scw] ctor tool=undefined'), 'should pass an undefined scm through to the wrapper');
+            });
+
+            it('fails when Bitbucket API clone entry has no href', async function () {
+                const runner = newRunner('failApiCloneHrefMissing');
+                await runAndDump(runner, nodeVersion);
+                if (runner.succeeded) fail(runner, 'expected task to fail when clone href is missing');
+
+                const hasShapeError = runner.stdOutContained('href') || runner.stdOutContained('undefined') || runner.stdOutContained('Cannot read');
+                assert(hasShapeError, 'should surface a payload shape error for missing clone href');
+            });
+
+            it('fails when Bitbucket API payload has empty clone links array', async function () {
+                const runner = newRunner('failApiEmptyCloneLinks');
+                await runAndDump(runner, nodeVersion);
+                if (runner.succeeded) fail(runner, 'expected task to fail for empty clone links array');
+
+                const hasShapeError = runner.stdOutContained('clone') || runner.stdOutContained('href') || runner.stdOutContained('Cannot read');
+                assert(hasShapeError, 'should surface payload shape error for empty clone links');
+            });
+
+            it('fails when recursive cleanup throws before any network operation', async function () {
+                const runner = newRunner('failCleanupThrows');
+                await runAndDump(runner, nodeVersion);
+                const hasErrorSignal = !runner.succeeded || runner.stdOutContained('##vso[task.issue type=error;source=TaskInternal;]');
+                if (!hasErrorSignal) fail(runner, 'expected cleanup error to emit a task error signal');
+
+                assert(runner.stdOutContained('Simulated cleanup failure'), 'should surface recursive cleanup error');
+                assert(!runner.stdOutContained('[mock-https] request'), 'should not call API when cleanup fails early');
+            });
+
+            it('fails when clone rejects', async function () {
+                const runner = newRunner('failCloneFails');
+                await runAndDump(runner, nodeVersion);
+                const hasErrorSignal = !runner.succeeded || runner.stdOutContained('##vso[task.issue type=error;source=TaskInternal;]');
+                if (!hasErrorSignal) fail(runner, 'expected task to emit an error signal when clone rejects');
+                assert(runner.stdOutContained('Simulated clone failure'), 'should surface clone failure reason');
+            });
+
+            it('fails when checkout rejects', async function () {
+                const runner = newRunner('failCheckoutFails');
+                await runAndDump(runner, nodeVersion);
+                const hasErrorSignal = !runner.succeeded || runner.stdOutContained('##vso[task.issue type=error;source=TaskInternal;]');
+                if (!hasErrorSignal) fail(runner, 'expected task to emit an error signal when checkout rejects');
+                assert(runner.stdOutContained('Simulated checkout failure'), 'should surface checkout failure reason');
+            });
+        });
+    });
+});
+
+describe('SourceControlWrapper Unit Suite', function () {
+    function newWrapper(): any {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const moduleRef = require(sourceControlWrapperModulePath);
+        return new moduleRef.SourceControlWrapper('git');
+    }
+
+    it('builds expected args for clone/fetch/checkout/reset', async function () {
+        const wrapper = newWrapper();
+        const observed: Array<{ args: string[]; opts: any }> = [];
+
+        wrapper.exec = function (args: string[], opts: any): Promise<number> {
+            observed.push({ args, opts });
+            return Promise.resolve(0);
+        };
+
+        await wrapper.clone('https://bitbucket.org/org/repo.git', true, 'repo', { debugOutput: true });
+        await wrapper.fetch(['origin', 'refs/heads/main'], {});
+        await wrapper.checkout('main', {});
+        await wrapper.reset(['--hard', 'HEAD'], {});
+
+        assert.strictEqual(JSON.stringify(observed[0].args), JSON.stringify(['clone', 'https://bitbucket.org/org/repo.git', '--progress', 'repo']));
+        assert.strictEqual(JSON.stringify(observed[1].args), JSON.stringify(['fetch', 'origin', 'refs/heads/main']));
+        assert.strictEqual(JSON.stringify(observed[2].args), JSON.stringify(['checkout', 'main']));
+        assert.strictEqual(JSON.stringify(observed[3].args), JSON.stringify(['reset', '--hard', 'HEAD']));
+        assert.strictEqual(observed[0].opts.creds, true, 'clone should force creds=true');
+        assert.strictEqual(observed[1].opts.creds, true, 'fetch should force creds=true');
+        assert.strictEqual(observed[2].opts.creds, true, 'checkout should force creds=true');
+        assert.strictEqual(observed[3].opts.creds, undefined, 'reset should not force creds=true');
+    });
+
+    it('exec wires tool events and masks credentials in debug output', async function () {
+        const originalWhich = sourceControlWrapperTl.which;
+        const originalTool = sourceControlWrapperTl.tool;
+        const originalSetSecret = sourceControlWrapperTl.setSecret;
+        const originalWarning = sourceControlWrapperTl.warning;
+
+        const seenArgs: string[] = [];
+        let seenExecOps: any = null;
+        const handlers: { [k: string]: Function } = {};
+        const masked: string[] = [];
+
+        sourceControlWrapperTl.which = function (): string {
+            return '/usr/bin/git';
+        };
+        sourceControlWrapperTl.setSecret = function (value: string): void {
+            masked.push(value);
+        };
+        sourceControlWrapperTl.warning = function (): void { return; };
+        sourceControlWrapperTl.tool = function (): any {
+            return {
+                on: function (name: string, cb: Function): void { handlers[name] = cb; },
+                arg: function (value: string): void { seenArgs.push(value); },
+                exec: function (ops: any): Promise<number> {
+                    seenExecOps = ops;
+                    handlers.debug('run https://u:p@bitbucket.org/org/repo.git and u%3Ap');
+                    handlers.stdout(new Buffer('stdout-line'));
+                    handlers.stderr(new Buffer('stderr-line'));
+                    return Promise.resolve(0);
+                }
+            };
+        };
+
+        try {
+            const wrapper = newWrapper();
+            wrapper.username = 'u';
+            wrapper.password = 'p';
+
+            const stdoutEvents: string[] = [];
+            const stderrEvents: string[] = [];
+            wrapper.on('stdout', function (data: any) { stdoutEvents.push(String(data)); });
+            wrapper.on('stderr', function (data: any) { stderrEvents.push(String(data)); });
+
+            const rc = await wrapper.exec(['clone', 'repo'], { debugOutput: true });
+
+            assert.strictEqual(rc, 0, 'exec should resolve with tool return code');
+            assert.strictEqual(JSON.stringify(seenArgs), JSON.stringify(['clone', 'repo']));
+            assert.ok(stdoutEvents.some(x => x.indexOf('[debug]') === 0), 'should emit debug output');
+            assert.ok(stdoutEvents.some(x => x.indexOf('...') >= 0), 'debug output should be masked');
+            assert.ok(stdoutEvents.some(x => x.indexOf('stdout-line') >= 0), 'should forward stdout events');
+            assert.ok(stderrEvents.some(x => x.indexOf('stderr-line') >= 0), 'should forward stderr events');
+            assert.ok(masked.indexOf('p') >= 0, 'should mask raw password');
+            assert.ok(masked.indexOf('u:p') >= 0 || masked.indexOf('u%3Ap') >= 0, 'should mask escaped credentials');
+            assert.ok(seenExecOps && seenExecOps.cwd, 'exec should pass options to tool');
+        } finally {
+            sourceControlWrapperTl.which = originalWhich;
+            sourceControlWrapperTl.tool = originalTool;
+            sourceControlWrapperTl.setSecret = originalSetSecret;
+            sourceControlWrapperTl.warning = originalWarning;
+        }
+    });
+
+    it('throws when source control binary is not found', function () {
+        const originalWhich = sourceControlWrapperTl.which;
+
+        sourceControlWrapperTl.which = function (): never {
+            throw new Error('not found');
+        };
+
+        try {
+            const wrapper = newWrapper();
+            assert.throws(function () {
+                wrapper.exec(['status'], {});
+            }, /not found/);
+        } finally {
+            sourceControlWrapperTl.which = originalWhich;
+        }
+    });
+
+    it('does not emit debug output when debugOutput is false', async function () {
+        const originalWhich = sourceControlWrapperTl.which;
+        const originalTool = sourceControlWrapperTl.tool;
+
+        const handlers: { [k: string]: Function } = {};
+
+        sourceControlWrapperTl.which = function (): string {
+            return '/usr/bin/git';
+        };
+        sourceControlWrapperTl.tool = function (): any {
+            return {
+                on: function (name: string, cb: Function): void { handlers[name] = cb; },
+                arg: function (): void { return; },
+                exec: function (): Promise<number> {
+                    handlers.debug('contains-userpass u:p and u%3Ap');
+                    return Promise.resolve(0);
+                }
+            };
+        };
+
+        try {
+            const wrapper = newWrapper();
+            wrapper.username = 'u';
+            wrapper.password = 'p';
+
+            const stdoutEvents: string[] = [];
+            wrapper.on('stdout', function (data: any) { stdoutEvents.push(String(data)); });
+
+            await wrapper.exec(['status'], { debugOutput: false });
+            assert.strictEqual(stdoutEvents.length, 0, 'no debug output should be emitted when debugOutput=false');
+        } finally {
+            sourceControlWrapperTl.which = originalWhich;
+            sourceControlWrapperTl.tool = originalTool;
+        }
+    });
+
+    it('passes custom exec options through to tool runner', async function () {
+        const originalWhich = sourceControlWrapperTl.which;
+        const originalTool = sourceControlWrapperTl.tool;
+
+        let capturedOps: any = null;
+
+        sourceControlWrapperTl.which = function (): string {
+            return '/usr/bin/git';
+        };
+        sourceControlWrapperTl.tool = function (): any {
+            return {
+                on: function (): void { return; },
+                arg: function (): void { return; },
+                exec: function (ops: any): Promise<number> {
+                    capturedOps = ops;
+                    return Promise.resolve(0);
+                }
+            };
+        };
+
+        try {
+            const wrapper = newWrapper();
+            const fakeOut = { write: function (): void { return; } } as any;
+            const fakeErr = { write: function (): void { return; } } as any;
+            const fakeEnv = { A: 'B' } as any;
+
+            await wrapper.exec(['status'], {
+                cwd: '/tmp/repo',
+                env: fakeEnv,
+                outStream: fakeOut,
+                errStream: fakeErr
+            });
+
+            assert.strictEqual(capturedOps.cwd, '/tmp/repo');
+            assert.strictEqual(capturedOps.env, fakeEnv);
+            assert.strictEqual(capturedOps.outStream, fakeOut);
+            assert.strictEqual(capturedOps.errStream, fakeErr);
+        } finally {
+            sourceControlWrapperTl.which = originalWhich;
+            sourceControlWrapperTl.tool = originalTool;
+        }
+    });
+
+    it('continues when setSecret throws and emits warning', async function () {
+        const originalWhich = sourceControlWrapperTl.which;
+        const originalTool = sourceControlWrapperTl.tool;
+        const originalSetSecret = sourceControlWrapperTl.setSecret;
+        const originalWarning = sourceControlWrapperTl.warning;
+
+        let warningCount = 0;
+
+        sourceControlWrapperTl.which = function (): string {
+            return '/usr/bin/git';
+        };
+        sourceControlWrapperTl.setSecret = function (): never {
+            throw new Error('secret store failure');
+        };
+        sourceControlWrapperTl.warning = function (message: string): void {
+            warningCount++;
+            assert(message.indexOf('Failed to mask credentials for log redaction') >= 0, 'should emit redaction warning');
+        };
+        sourceControlWrapperTl.tool = function (): any {
+            return {
+                on: function (): void { return; },
+                arg: function (): void { return; },
+                exec: function (): Promise<number> { return Promise.resolve(0); }
+            };
+        };
+
+        try {
+            const wrapper = newWrapper();
+            wrapper.username = 'u';
+            wrapper.password = 'p';
+            const rc = await wrapper.exec(['status'], {});
+            assert.strictEqual(rc, 0, 'exec should still succeed when secret masking fails');
+            assert.strictEqual(warningCount, 1, 'should emit one warning when setSecret throws');
+        } finally {
+            sourceControlWrapperTl.which = originalWhich;
+            sourceControlWrapperTl.tool = originalTool;
+            sourceControlWrapperTl.setSecret = originalSetSecret;
+            sourceControlWrapperTl.warning = originalWarning;
+        }
+    });
+
+    it('propagates tool execution rejection', async function () {
+        const originalWhich = sourceControlWrapperTl.which;
+        const originalTool = sourceControlWrapperTl.tool;
+
+        sourceControlWrapperTl.which = function (): string {
+            return '/usr/bin/git';
+        };
+        sourceControlWrapperTl.tool = function (): any {
+            return {
+                on: function (): void { return; },
+                arg: function (): void { return; },
+                exec: function (): Promise<number> {
+                    return Promise.reject(new Error('simulated exec failure'));
+                }
+            };
+        };
+
+        try {
+            const wrapper = newWrapper();
+            await wrapper.exec(['status'], {}).then(function () {
+                throw new Error('expected rejection from wrapper.exec');
+            }, function (err: Error) {
+                assert(err.message.indexOf('simulated exec failure') >= 0, 'should propagate underlying exec error');
+            });
+        } finally {
+            sourceControlWrapperTl.which = originalWhich;
+            sourceControlWrapperTl.tool = originalTool;
+        }
+    });
+});

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failApiCloneHrefMissing.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failApiCloneHrefMissing.ts
@@ -1,0 +1,22 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth({ scheme: 'Token' });
+registerAllMocks(tr, {
+    apiResponseText: JSON.stringify({
+        scm: 'git',
+        links: {
+            clone: [
+                { name: 'https' }
+            ]
+        }
+    })
+});
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failApiEmptyCloneLinks.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failApiEmptyCloneLinks.ts
@@ -1,0 +1,13 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth({ scheme: 'Token' });
+registerAllMocks(tr, { apiResponseText: JSON.stringify({ scm: 'git', links: { clone: [] } }) });
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failApiMissingCloneLinks.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failApiMissingCloneLinks.ts
@@ -1,0 +1,13 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth({ scheme: 'Token' });
+registerAllMocks(tr, { apiResponseText: JSON.stringify({ scm: 'git', links: {} }) });
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failApiMissingScm.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failApiMissingScm.ts
@@ -1,0 +1,21 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth({ scheme: 'Token' });
+registerAllMocks(tr, {
+    apiResponseText: JSON.stringify({
+        links: {
+            clone: [
+                { href: 'https://bitbucket.org/org/repo.git' }
+            ]
+        }
+    })
+});
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failAuthMissingScheme.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failAuthMissingScheme.ts
@@ -1,0 +1,13 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth({ authObjectRaw: JSON.stringify({ parameters: { apitoken: 'bb-token' } }) });
+registerAllMocks(tr);
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failCheckoutFails.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failCheckoutFails.ts
@@ -1,0 +1,13 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth({ scheme: 'Token' });
+registerAllMocks(tr, { checkoutFailsAt: 1 });
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failCleanupThrows.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failCleanupThrows.ts
@@ -1,0 +1,13 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth({ scheme: 'Token' });
+registerAllMocks(tr, { cleanupFixture: true, cleanupThrows: true });
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failCloneFails.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failCloneFails.ts
@@ -1,0 +1,13 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth({ scheme: 'Token' });
+registerAllMocks(tr, { cloneFails: true });
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failMalformedApiResponse.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failMalformedApiResponse.ts
@@ -1,0 +1,13 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth({ scheme: 'Token' });
+registerAllMocks(tr, { apiResponseText: 'not-json' });
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failMissingAuthParameter.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failMissingAuthParameter.ts
@@ -1,0 +1,18 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth({
+    scheme: 'Token',
+    authParameters: {
+        email: 'token-user@example.com'
+    }
+});
+registerAllMocks(tr);
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failMissingBranch.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failMissingBranch.ts
@@ -1,0 +1,13 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr, { branch: undefined });
+setEndpointAuth({ scheme: 'Token' });
+registerAllMocks(tr);
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failMissingConnection.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failMissingConnection.ts
@@ -1,0 +1,12 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr, { connection: undefined });
+registerAllMocks(tr);
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failMissingDefinition.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failMissingDefinition.ts
@@ -1,0 +1,13 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr, { definition: undefined });
+setEndpointAuth({ scheme: 'Token' });
+registerAllMocks(tr);
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failMissingDownloadPath.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failMissingDownloadPath.ts
@@ -1,0 +1,13 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr, { downloadPath: undefined });
+setEndpointAuth({ scheme: 'Token' });
+registerAllMocks(tr);
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failMissingPasswordParameter.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failMissingPasswordParameter.ts
@@ -1,0 +1,18 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth({
+    scheme: 'UsernamePassword',
+    authParameters: {
+        username: 'bb-user'
+    }
+});
+registerAllMocks(tr);
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failMissingUsernameParameter.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failMissingUsernameParameter.ts
@@ -1,0 +1,18 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth({
+    scheme: 'UsernamePassword',
+    authParameters: {
+        password: 'bb-pass'
+    }
+});
+registerAllMocks(tr);
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failMissingVersion.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failMissingVersion.ts
@@ -1,0 +1,13 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr, { version: undefined });
+setEndpointAuth({ scheme: 'Token' });
+registerAllMocks(tr);
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failNoEndpointAuthorization.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failNoEndpointAuthorization.ts
@@ -1,0 +1,13 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { clearEndpointAuth, registerAllMocks, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+clearEndpointAuth();
+registerAllMocks(tr);
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failUnsupportedAuthScheme.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/failUnsupportedAuthScheme.ts
@@ -1,0 +1,13 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth({ scheme: 'Unsupported' });
+registerAllMocks(tr);
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/mockHelpers.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/mockHelpers.ts
@@ -1,0 +1,249 @@
+import events = require('events');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+export const CONNECTION_ID = 'bitbucket-connection-id';
+export const REPOSITORY_ID = 'workspace/repo';
+export const BRANCH_MAIN = 'refs/heads/main';
+export const BRANCH_DEVELOP = 'develop';
+export const COMMIT_ID = '1234567890abcdef1234567890abcdef12345678';
+export const DOWNLOAD_PATH = '.';
+export const TOKEN_EMAIL = 'token-user@example.com';
+export const TOKEN_VALUE = 'bb-token';
+export const USERNAME = 'bb-user';
+export const PASSWORD = 'bb-pass';
+export const SOURCE_TASK_PATH = 'Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js';
+
+export interface ScenarioOptions {
+    scheme?: 'Token' | 'UsernamePassword' | 'Unsupported';
+    authParameters?: { [key: string]: string };
+    authObjectRaw?: string;
+    apiResponseText?: string;
+    cloneFails?: boolean;
+    checkoutFailsAt?: number;
+    cleanupFixture?: boolean;
+    cleanupThrows?: boolean;
+}
+
+export function setRequiredInputs(tr: tmrm.TaskMockRunner, overrides?: { [key: string]: string | undefined }): void {
+    const inputMap: { [key: string]: string | undefined } = {
+        connection: CONNECTION_ID,
+        definition: REPOSITORY_ID,
+        branch: BRANCH_MAIN,
+        version: COMMIT_ID,
+        downloadPath: DOWNLOAD_PATH
+    };
+
+    if (overrides) {
+        for (const key of Object.keys(overrides)) {
+            inputMap[key] = overrides[key];
+        }
+    }
+
+    Object.keys(inputMap).forEach(function (name) {
+        const value = inputMap[name];
+        if (value !== undefined) {
+            tr.setInput(name, value);
+        }
+    });
+}
+
+export function setEndpointAuth(options?: ScenarioOptions): void {
+    const scenario = options || {};
+    const scheme = scenario.scheme || 'Token';
+    const endpoint = CONNECTION_ID;
+    const parameters = scenario.authParameters;
+
+    if (scenario.authObjectRaw !== undefined) {
+        process.env['ENDPOINT_AUTH_' + endpoint] = scenario.authObjectRaw;
+        return;
+    }
+
+    if (scheme === 'Token') {
+        process.env['ENDPOINT_AUTH_' + endpoint] = JSON.stringify({
+            scheme: 'Token',
+            parameters: parameters || {
+                apitoken: TOKEN_VALUE,
+                email: TOKEN_EMAIL
+            }
+        });
+        process.env['ENDPOINT_AUTH_SCHEME_' + endpoint] = 'Token';
+        process.env['ENDPOINT_AUTH_PARAMETER_' + endpoint + '_APITOKEN'] = TOKEN_VALUE;
+        process.env['ENDPOINT_AUTH_PARAMETER_' + endpoint + '_EMAIL'] = TOKEN_EMAIL;
+        return;
+    }
+
+    if (scheme === 'UsernamePassword') {
+        process.env['ENDPOINT_AUTH_' + endpoint] = JSON.stringify({
+            scheme: 'UsernamePassword',
+            parameters: parameters || {
+                username: USERNAME,
+                password: PASSWORD
+            }
+        });
+        process.env['ENDPOINT_AUTH_SCHEME_' + endpoint] = 'UsernamePassword';
+        process.env['ENDPOINT_AUTH_PARAMETER_' + endpoint + '_USERNAME'] = USERNAME;
+        process.env['ENDPOINT_AUTH_PARAMETER_' + endpoint + '_PASSWORD'] = PASSWORD;
+        return;
+    }
+
+    process.env['ENDPOINT_AUTH_' + endpoint] = JSON.stringify({
+        scheme: 'Bearer',
+        parameters: {}
+    });
+    process.env['ENDPOINT_AUTH_SCHEME_' + endpoint] = 'Bearer';
+}
+
+export function registerAllMocks(tr: tmrm.TaskMockRunner, options?: ScenarioOptions): void {
+    const scenario = options || {};
+    registerFsMock(tr, scenario.cleanupFixture === true, scenario.cleanupThrows === true);
+    registerHttpsMock(tr, scenario.apiResponseText);
+    registerSourceControlWrapperMock(tr, scenario);
+}
+
+export function clearEndpointAuth(): void {
+    const endpoint = CONNECTION_ID;
+    delete process.env['ENDPOINT_AUTH_' + endpoint];
+    delete process.env['ENDPOINT_AUTH_SCHEME_' + endpoint];
+    delete process.env['ENDPOINT_AUTH_PARAMETER_' + endpoint + '_APITOKEN'];
+    delete process.env['ENDPOINT_AUTH_PARAMETER_' + endpoint + '_EMAIL'];
+    delete process.env['ENDPOINT_AUTH_PARAMETER_' + endpoint + '_USERNAME'];
+    delete process.env['ENDPOINT_AUTH_PARAMETER_' + endpoint + '_PASSWORD'];
+}
+
+function registerFsMock(tr: tmrm.TaskMockRunner, cleanupFixture: boolean, cleanupThrows: boolean): void {
+    const realFs = require('fs');
+    const mockFs: { [key: string]: unknown } = Object.assign({}, realFs);
+
+    function normalizePath(p: string): string {
+        return (p || '').replace(/\\/g, '/').replace(/^\.\//, '');
+    }
+
+    if (!cleanupFixture) {
+        mockFs['existsSync'] = function () { return false; };
+        tr.registerMock('fs', mockFs);
+        return;
+    }
+
+    if (cleanupThrows) {
+        mockFs['existsSync'] = function () { return true; };
+        mockFs['lstatSync'] = function () {
+            throw new Error('Simulated cleanup failure');
+        };
+        tr.registerMock('fs', mockFs);
+        return;
+    }
+
+    mockFs['existsSync'] = function (_targetPath: string) {
+        return true;
+    };
+
+    mockFs['lstatSync'] = function (targetPath: string) {
+        const p = normalizePath(targetPath);
+        const isDirectory = p === '' || p === '.' || p === 'sub';
+        return {
+            isDirectory: function () { return isDirectory; }
+        };
+    };
+
+    mockFs['readdirSync'] = function (targetPath: string) {
+        const p = normalizePath(targetPath);
+        if (p === '' || p === '.') {
+            return ['a.txt', 'sub'];
+        }
+        if (p === 'sub') {
+            return ['b.txt'];
+        }
+        return [];
+    };
+
+    mockFs['unlinkSync'] = function (targetPath: string) {
+        console.log('[mock-fs] unlink ' + normalizePath(targetPath));
+    };
+
+    mockFs['rmdirSync'] = function (targetPath: string) {
+        const p = normalizePath(targetPath);
+        console.log('[mock-fs] rmdir ' + (p || '.'));
+    };
+
+    tr.registerMock('fs', mockFs);
+}
+
+function registerHttpsMock(tr: tmrm.TaskMockRunner, apiResponseText?: string): void {
+    tr.registerMock('https', {
+        request: function (options: { [key: string]: string }, callback: Function) {
+            const auth = options.auth || '';
+            const authUser = auth.indexOf(':') >= 0 ? auth.split(':')[0] : auth;
+            console.log('[mock-https] request ' + options.path + ' authUser=' + authUser);
+
+            const response = new events.EventEmitter() as any;
+            response.statusCode = 200;
+            response.statusMessage = 'OK';
+            callback(response);
+
+            return {
+                on: function (): unknown {
+                    return this;
+                },
+                end: function () {
+                    const responseBody = apiResponseText !== undefined
+                        ? apiResponseText
+                        : JSON.stringify({
+                            scm: 'git',
+                            links: {
+                                clone: [
+                                    { href: 'https://bitbucket.org/org/repo.git' }
+                                ]
+                            }
+                        });
+
+                    process.nextTick(function () {
+                        response.emit('data', responseBody);
+                        response.emit('end');
+                    });
+                }
+            };
+        }
+    });
+}
+
+function registerSourceControlWrapperMock(tr: tmrm.TaskMockRunner, options: ScenarioOptions): void {
+    let checkoutCall = 0;
+
+    function sanitizeRepoUrl(repo: string): string {
+        return repo.replace(/:\/\/[^@]+@/, '://***@');
+    }
+
+    class MockSourceControlWrapper extends events.EventEmitter {
+        public username: string;
+        public password: string;
+
+        constructor(toolType: string) {
+            super();
+            this.username = '';
+            this.password = '';
+            console.log('[mock-scw] ctor tool=' + toolType);
+        }
+
+        public clone(repository: string, _progress: boolean, folder: string, _execOptions: unknown): Promise<number> {
+            console.log('[mock-scw] clone ' + sanitizeRepoUrl(repository) + ' ' + folder);
+            console.log('[mock-scw] auth user=' + this.username + ' passSet=' + (!!this.password));
+            if (options.cloneFails) {
+                return Promise.reject(new Error('Simulated clone failure'));
+            }
+            return Promise.resolve(0);
+        }
+
+        public checkout(ref: string, _execOptions?: unknown): Promise<number> {
+            checkoutCall++;
+            console.log('[mock-scw] checkout ' + ref);
+            if (options.checkoutFailsAt && checkoutCall === options.checkoutFailsAt) {
+                return Promise.reject(new Error('Simulated checkout failure'));
+            }
+            return Promise.resolve(0);
+        }
+    }
+
+    tr.registerMock('./sourcecontrolwrapper.js', {
+        SourceControlWrapper: MockSourceControlWrapper
+    });
+}

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/successAuthParamCaseInsensitiveToken.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/successAuthParamCaseInsensitiveToken.ts
@@ -1,0 +1,19 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth({
+    scheme: 'Token',
+    authParameters: {
+        APITOKEN: 'bb-token',
+        EMAIL: 'token-user@example.com'
+    }
+});
+registerAllMocks(tr);
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/successAuthParamCaseInsensitiveUserPass.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/successAuthParamCaseInsensitiveUserPass.ts
@@ -1,0 +1,19 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth({
+    scheme: 'UsernamePassword',
+    authParameters: {
+        USERNAME: 'bb-user',
+        PASSWORD: 'bb-pass'
+    }
+});
+registerAllMocks(tr);
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/successBranchNormalization.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/successBranchNormalization.ts
@@ -1,0 +1,13 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr, { branch: 'refs/heads/release/v1' });
+setEndpointAuth({ scheme: 'Token' });
+registerAllMocks(tr);
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/successCleanupRecursive.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/successCleanupRecursive.ts
@@ -1,0 +1,13 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth({ scheme: 'Token' });
+registerAllMocks(tr, { cleanupFixture: true });
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/successHgScm.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/successHgScm.ts
@@ -1,0 +1,22 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth({ scheme: 'Token' });
+registerAllMocks(tr, {
+    apiResponseText: JSON.stringify({
+        scm: 'hg',
+        links: {
+            clone: [
+                { href: 'https://bitbucket.org/org/repo.git' }
+            ]
+        }
+    })
+});
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/successTokenAuth.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/successTokenAuth.ts
@@ -1,0 +1,13 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr, { branch: 'refs/heads/main' });
+setEndpointAuth({ scheme: 'Token' });
+registerAllMocks(tr);
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/successTokenAuthNoEmail.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/successTokenAuthNoEmail.ts
@@ -1,0 +1,18 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth({
+    scheme: 'Token',
+    authParameters: {
+        apitoken: 'bb-token'
+    }
+});
+registerAllMocks(tr);
+
+tr.run();

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/successUserPassAuth.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/successUserPassAuth.ts
@@ -1,0 +1,13 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs, SOURCE_TASK_PATH } from './mockHelpers';
+
+const taskPath = path.join(process.cwd(), SOURCE_TASK_PATH);
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr, { branch: 'develop' });
+setEndpointAuth({ scheme: 'UsernamePassword' });
+registerAllMocks(tr);
+
+tr.run();


### PR DESCRIPTION
**Description**: Adds a comprehensive unit test suite for the Bitbucket Download Artifacts task, and refactors the task source so it can be unit tested:
- Removed the `shelljs` dependency from `downloadBitbucket.js` and `sourcecontrolwrapper.js`, replacing `shell.rm`/`shell.cd`/`shell.which` with native `fs`, `process.chdir`, and `tl.which`/`tl.tool`.
- Removed unused `vso-node-api` imports.
- Made `definition`, `branch`, `version`, `downloadPath`, and `connection` task inputs required.
- Replaced the deprecated `.fail()` promise handler with `.catch()`, and fixed empty `catch {}` blocks (`catch (err) {}`) for broader engine/lint compatibility.

- Implement tests for various failure scenarios including:
  - Missing clone href
  - Empty clone links
  - Missing clone links
  - Missing SCM
  - Missing authentication scheme
  - Checkout failures
  - Cleanup exceptions
  - Clone failures
  - Malformed API responses
  - Missing authentication parameters (username, password, email)
  - Missing required inputs (branch, connection, definition, download path, version)
  - Unsupported authentication scheme
  - No endpoint authorization

- Add success scenarios for:
  - Case insensitive authentication parameters
  - Branch normalization
  - Cleanup with recursive option
  - Successful token and username/password authentication
  - Support for Mercurial SCM

- Introduce mock helpers for setting up test scenarios and environment variables.

**Documentation changes required:** N

**Added unit tests:** Y

**Attached related issue:** N

**Checklist**:
- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.
- [ ] Checked that applied changes work as expected.
