### PR TITLE
Add unit tests for ServiceNow extension

### DIFF
--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.278.3",
+  "version": "4.278.4",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.278.4",
+  "version": "4.278.5",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.278.2",
+  "version": "4.278.3",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Tests/Tasks/CreateAndQueryChangeRequest/createTaskTests.ts
+++ b/Extensions/ServiceNow/Tests/Tasks/CreateAndQueryChangeRequest/createTaskTests.ts
@@ -1,0 +1,289 @@
+// Tests for CreateAndQueryChangeRequest task.json (all versions) and V2 advanced features.
+
+import assert = require('assert');
+import {
+    createTaskV0Path, createTaskV1Path, createTaskV2Path, loadJson
+} from '../../helpers';
+
+describe('CreateAndQueryChangeRequest Suite', function () {
+
+    const taskVersions = [
+        { label: 'V0', path: createTaskV0Path },
+        { label: 'V1', path: createTaskV1Path },
+        { label: 'V2', path: createTaskV2Path },
+    ];
+
+    taskVersions.forEach(({ label, path: taskPath }) => {
+        describe(label, function () {
+
+            let task: any;
+
+            before(function () {
+                task = loadJson(taskPath);
+            });
+
+            it('should be valid JSON', function () {
+                assert.ok(task, 'task.json should parse without errors');
+            });
+
+            it('should have a valid GUID as id', function () {
+                assert.ok(/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/.test(task.id),
+                    `task id "${task.id}" should be a valid GUID`);
+            });
+
+            it('should have consistent task id across versions', function () {
+                assert.strictEqual(task.id.toUpperCase(), '539E1E16-0680-4F8E-85D0-95B6FDE76E8C',
+                    'all versions should share the same task id');
+            });
+
+            it('should have name "CreateAndQueryChangeRequest"', function () {
+                assert.strictEqual(task.name, 'CreateAndQueryChangeRequest');
+            });
+
+            it('should run on ServerGate', function () {
+                assert.ok(task.runsOn.includes('ServerGate'), 'should include ServerGate in runsOn');
+            });
+
+            it('should have a valid version object', function () {
+                assert.ok(Number.isInteger(task.version.Major), 'Major should be an integer');
+                assert.ok(Number.isInteger(task.version.Minor), 'Minor should be an integer');
+                assert.ok(Number.isInteger(task.version.Patch), 'Patch should be an integer');
+            });
+
+            it('should require ServiceNowConnection input', function () {
+                const input = task.inputs.find((i: any) => i.name === 'ServiceNowConnection');
+                assert.ok(input, 'ServiceNowConnection input should exist');
+                assert.strictEqual(input.type, 'connectedService:ServiceNow');
+                assert.strictEqual(input.required, 'true');
+            });
+
+            if (label !== 'V0') {
+                it('should have changeRequestAction input with createNew and useExisting options', function () {
+                    const input = task.inputs.find((i: any) => i.name === 'changeRequestAction');
+                    assert.ok(input, 'changeRequestAction input should exist');
+                    assert.ok(input.options.createNew, 'should have createNew option');
+                    assert.ok(input.options.useExisting, 'should have useExisting option');
+                    assert.strictEqual(input.defaultValue, 'createNew');
+                });
+
+                it('should have changeType input with Normal, Standard, and Emergency options', function () {
+                    const input = task.inputs.find((i: any) => i.name === 'changeType');
+                    assert.ok(input, 'changeType input should exist');
+                    assert.ok(input.options.Normal, 'should have Normal option');
+                    assert.ok(input.options.Standard, 'should have Standard option');
+                    assert.ok(input.options.Emergency, 'should have Emergency option');
+                });
+
+                it('should have shortdescription as required input for createNew', function () {
+                    const input = task.inputs.find((i: any) => i.name === 'shortdescription');
+                    assert.ok(input, 'shortdescription input should exist');
+                    assert.strictEqual(input.required, 'true');
+                    assert.ok(input.visibleRule.includes('changeRequestAction = createNew'));
+                });
+            }
+
+            it('should use HttpRequestChain execution', function () {
+                assert.ok(task.execution.HttpRequestChain, 'should have HttpRequestChain execution');
+                assert.ok(task.execution.HttpRequestChain.Execute, 'should have Execute array');
+                assert.ok(task.execution.HttpRequestChain.Execute.length > 0, 'should have at least one request in chain');
+            });
+
+            it('should produce CHANGE_REQUEST_NUMBER and CHANGE_SYSTEM_ID output variables', function () {
+                const chain = task.execution.HttpRequestChain.Execute;
+                const allOutputVars = chain
+                    .filter((step: any) => step.ExecutionOptions && step.ExecutionOptions.OutputVariables)
+                    .map((step: any) => step.ExecutionOptions.OutputVariables)
+                    .join(' ');
+
+                assert.ok(allOutputVars.includes('CHANGE_REQUEST_NUMBER'), 'should output CHANGE_REQUEST_NUMBER');
+                assert.ok(allOutputVars.includes('CHANGE_SYSTEM_ID'), 'should output CHANGE_SYSTEM_ID');
+            });
+
+            it('should POST to import API for creating change requests', function () {
+                const chain = task.execution.HttpRequestChain.Execute;
+                const postSteps = chain.filter(
+                    (step: any) => step.RequestInputs.Method === 'POST'
+                );
+                assert.ok(postSteps.length > 0, 'should have POST steps');
+
+                const importStep = postSteps.find(
+                    (step: any) => step.RequestInputs.EndpointUrl.includes('/api/now/import/x_mioms_azpipeline_change_request_import')
+                );
+                assert.ok(importStep, 'should POST to the change_request_import endpoint');
+            });
+
+            it('should GET from table API for querying change requests', function () {
+                const chain = task.execution.HttpRequestChain.Execute;
+                const getSteps = chain.filter(
+                    (step: any) => step.RequestInputs.Method === 'GET'
+                );
+                assert.ok(getSteps.length > 0, 'should have GET steps');
+
+                const tableStep = getSteps.find(
+                    (step: any) => step.RequestInputs.EndpointUrl.includes('/api/now/table/change_request')
+                );
+                assert.ok(tableStep, 'should GET from the change_request table');
+            });
+
+            it('should set Content-Type and Accept headers to application/json', function () {
+                const chain = task.execution.HttpRequestChain.Execute;
+                chain.forEach((step: any, index: number) => {
+                    if (step.RequestInputs.Headers) {
+                        const headers = JSON.parse(step.RequestInputs.Headers);
+                        assert.strictEqual(headers['Content-Type'], 'application/json',
+                            `step ${index} should have Content-Type: application/json`);
+                        assert.strictEqual(headers['Accept'], 'application/json',
+                            `step ${index} should have Accept: application/json`);
+                    }
+                });
+            });
+
+            it('should have dataSourceBindings for picklist inputs', function () {
+                assert.ok(task.dataSourceBindings, 'dataSourceBindings should exist');
+                assert.ok(task.dataSourceBindings.length > 0, 'should have at least one data source binding');
+
+                const targets = task.dataSourceBindings.map((b: any) => b.target);
+                assert.ok(targets.includes('DesiredExitStatus'), 'should bind DesiredExitStatus');
+                assert.ok(targets.includes('priority'), 'should bind priority');
+                assert.ok(targets.includes('risk'), 'should bind risk');
+                assert.ok(targets.includes('impact'), 'should bind impact');
+            });
+        });
+    });
+
+    describe('V2 Advanced Features', function () {
+
+        let task: any;
+
+        before(function () {
+            task = loadJson(createTaskV2Path);
+        });
+
+        describe('Success criteria inputs', function () {
+
+            it('should have successCriteria input with desiredStatus and advanced options', function () {
+                const input = task.inputs.find((i: any) => i.name === 'successCriteria');
+                assert.ok(input, 'successCriteria input should exist');
+                assert.ok(input.options.desiredStatus, 'should have desiredStatus option');
+                assert.ok(input.options.advanced, 'should have advanced option');
+                assert.strictEqual(input.defaultValue, 'desiredStatus');
+            });
+
+            it('should have DesiredExitStatus input visible when successCriteria = desiredStatus', function () {
+                const input = task.inputs.find((i: any) => i.name === 'DesiredExitStatus');
+                assert.ok(input, 'DesiredExitStatus input should exist');
+                assert.ok(input.visibleRule.includes('successCriteria = desiredStatus'));
+            });
+
+            it('should have AdvancedSuccessCriteria input visible when successCriteria = advanced', function () {
+                const input = task.inputs.find((i: any) => i.name === 'AdvancedSuccessCriteria');
+                assert.ok(input, 'AdvancedSuccessCriteria input should exist');
+                assert.ok(input.visibleRule.includes('successCriteria = advanced'));
+            });
+        });
+
+        describe('useExisting flow inputs', function () {
+
+            it('should have changeQueryCriteria input with changeRequestNumber and queryString options', function () {
+                const input = task.inputs.find((i: any) => i.name === 'changeQueryCriteria');
+                assert.ok(input, 'changeQueryCriteria input should exist');
+                assert.ok(input.options.changeRequestNumber, 'should have changeRequestNumber option');
+                assert.ok(input.options.queryString, 'should have queryString option');
+                assert.ok(input.visibleRule.includes('changeRequestAction = useExisting'));
+            });
+
+            it('should have changeRequestNumber input visible for useExisting + changeRequestNumber', function () {
+                const input = task.inputs.find((i: any) => i.name === 'changeRequestNumber');
+                assert.ok(input, 'changeRequestNumber input should exist');
+                assert.ok(input.visibleRule.includes('changeRequestAction = useExisting'));
+                assert.ok(input.visibleRule.includes('changeQueryCriteria = changeRequestNumber'));
+            });
+
+            it('should have queryString input visible for useExisting + queryString', function () {
+                const input = task.inputs.find((i: any) => i.name === 'queryString');
+                assert.ok(input, 'queryString input should exist');
+                assert.ok(input.visibleRule.includes('changeRequestAction = useExisting'));
+                assert.ok(input.visibleRule.includes('changeQueryCriteria = queryString'));
+            });
+        });
+
+        describe('Checks vs Release dual execution paths', function () {
+
+            it('should have separate POST steps for checks and release hosttype', function () {
+                const chain = task.execution.HttpRequestChain.Execute;
+                const postSteps = chain.filter(
+                    (step: any) => step.RequestInputs.Method === 'POST'
+                );
+                assert.ok(postSteps.length >= 2, `should have at least 2 POST steps, found ${postSteps.length}`);
+            });
+
+            it('should have SkipSectionExpression referencing system.hosttype for checks path', function () {
+                const chain = task.execution.HttpRequestChain.Execute;
+                const checksSteps = chain.filter(
+                    (step: any) => step.ExecutionOptions &&
+                        step.ExecutionOptions.SkipSectionExpression &&
+                        step.ExecutionOptions.SkipSectionExpression.includes('system.hosttype')
+                );
+                assert.ok(checksSteps.length > 0, 'should have steps with system.hosttype SkipSectionExpression');
+            });
+
+            it('should reference checks-specific variables (stageId, buildId, stageAttempt)', function () {
+                const chain = task.execution.HttpRequestChain.Execute;
+                const allUrls = chain.map((step: any) => step.RequestInputs.EndpointUrl).join(' ');
+                const allBodies = chain
+                    .filter((step: any) => step.RequestInputs.Body)
+                    .map((step: any) => step.RequestInputs.Body)
+                    .join(' ');
+                const combined = allUrls + allBodies;
+
+                assert.ok(combined.includes('checks.stageId') || combined.includes('system.stageId'),
+                    'should reference stageId for checks context');
+                assert.ok(combined.includes('build.buildId'),
+                    'should reference build.buildId');
+            });
+
+            it('should have a WaitForCompletion gate step (polling step)', function () {
+                const chain = task.execution.HttpRequestChain.Execute;
+                const waitSteps = chain.filter(
+                    (step: any) => step.RequestInputs.WaitForCompletion === 'true'
+                );
+                assert.ok(waitSteps.length > 0, 'should have at least one step with WaitForCompletion=true');
+            });
+        });
+
+        describe('Output variables', function () {
+
+            it('should produce CHANGE_CORRELATION_ID output variable', function () {
+                const chain = task.execution.HttpRequestChain.Execute;
+                const allOutputVars = chain
+                    .filter((step: any) => step.ExecutionOptions && step.ExecutionOptions.OutputVariables)
+                    .map((step: any) => step.ExecutionOptions.OutputVariables)
+                    .join(' ');
+
+                assert.ok(allOutputVars.includes('CHANGE_CORRELATION_ID'), 'should output CHANGE_CORRELATION_ID');
+            });
+        });
+
+        describe('Additional inputs', function () {
+
+            it('should have otherParameters as multiLine input', function () {
+                const input = task.inputs.find((i: any) => i.name === 'otherParameters');
+                assert.ok(input, 'otherParameters input should exist');
+                assert.strictEqual(input.type, 'multiLine');
+            });
+
+            it('should have schedule group inputs (schedulestarttime, scheduleendtime)', function () {
+                const start = task.inputs.find((i: any) => i.name === 'schedulestarttime');
+                const end = task.inputs.find((i: any) => i.name === 'scheduleendtime');
+                assert.ok(start, 'schedulestarttime input should exist');
+                assert.ok(end, 'scheduleendtime input should exist');
+            });
+
+            it('should have standardChangeTemplate input visible for Standard change type', function () {
+                const input = task.inputs.find((i: any) => i.name === 'standardChangeTemplate');
+                assert.ok(input, 'standardChangeTemplate input should exist');
+                assert.ok(input.visibleRule.includes('changeType = Standard'));
+            });
+        });
+    });
+});

--- a/Extensions/ServiceNow/Tests/Tasks/UpdateChangeRequest/updateTaskTests.ts
+++ b/Extensions/ServiceNow/Tests/Tasks/UpdateChangeRequest/updateTaskTests.ts
@@ -1,0 +1,106 @@
+// Tests for UpdateServiceNowChangeRequest task.json (all versions).
+
+import assert = require('assert');
+import { updateTaskV0Path, updateTaskV1Path, updateTaskV2Path, loadJson } from '../../helpers';
+
+describe('UpdateServiceNowChangeRequest Suite', function () {
+
+    const taskVersions = [
+        { label: 'V0', path: updateTaskV0Path },
+        { label: 'V1', path: updateTaskV1Path },
+        { label: 'V2', path: updateTaskV2Path },
+    ];
+
+    taskVersions.forEach(({ label, path: taskPath }) => {
+        describe(label, function () {
+
+            let task: any;
+
+            before(function () {
+                task = loadJson(taskPath);
+            });
+
+            it('should be valid JSON', function () {
+                assert.ok(task, 'task.json should parse without errors');
+            });
+
+            it('should have a valid GUID as id', function () {
+                assert.ok(/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/.test(task.id),
+                    `task id "${task.id}" should be a valid GUID`);
+            });
+
+            it('should have consistent task id across versions', function () {
+                assert.strictEqual(task.id.toUpperCase(), '37AC13CA-AEAD-4E19-A5AC-E5366051FC1C',
+                    'all versions should share the same task id');
+            });
+
+            it('should have name "UpdateServiceNowChangeRequest"', function () {
+                assert.strictEqual(task.name, 'UpdateServiceNowChangeRequest');
+            });
+
+            it('should run on Server', function () {
+                assert.ok(task.runsOn.includes('Server'), 'should include Server in runsOn');
+            });
+
+            it('should have a valid version object', function () {
+                assert.ok(Number.isInteger(task.version.Major), 'Major should be an integer');
+                assert.ok(Number.isInteger(task.version.Minor), 'Minor should be an integer');
+                assert.ok(Number.isInteger(task.version.Patch), 'Patch should be an integer');
+            });
+
+            it('should require ServiceNowConnection input', function () {
+                const input = task.inputs.find((i: any) => i.name === 'ServiceNowConnection');
+                assert.ok(input, 'ServiceNowConnection input should exist');
+                assert.strictEqual(input.type, 'connectedService:ServiceNow');
+                assert.strictEqual(input.required, 'true');
+            });
+
+            it('should require ChangeRequestNumber input', function () {
+                const input = task.inputs.find((i: any) => i.name === 'ChangeRequestNumber');
+                assert.ok(input, 'ChangeRequestNumber input should exist');
+                assert.strictEqual(input.required, true);
+            });
+
+            if (label !== 'V0') {
+                it('should have UpdateStatus boolean input', function () {
+                    const input = task.inputs.find((i: any) => i.name === 'UpdateStatus');
+                    assert.ok(input, 'UpdateStatus input should exist');
+                    assert.strictEqual(input.type, 'boolean');
+                });
+
+                it('should have NewStatus input visible when UpdateStatus is true', function () {
+                    const input = task.inputs.find((i: any) => i.name === 'NewStatus');
+                    assert.ok(input, 'NewStatus input should exist');
+                    assert.ok(input.visibleRule.includes('UpdateStatus = true'));
+                });
+            }
+
+            it('should have CloseCode and CloseNotes inputs', function () {
+                const closeCode = task.inputs.find((i: any) => i.name === 'CloseCode');
+                const closeNotes = task.inputs.find((i: any) => i.name === 'CloseNotes');
+
+                assert.ok(closeCode, 'CloseCode input should exist');
+                assert.ok(closeNotes, 'CloseNotes input should exist');
+            });
+
+            it('should use HttpRequestChain execution', function () {
+                assert.ok(task.execution.HttpRequestChain, 'should have HttpRequestChain execution');
+                assert.ok(task.execution.HttpRequestChain.Execute, 'should have Execute array');
+                assert.ok(task.execution.HttpRequestChain.Execute.length > 0, 'should have at least one request');
+            });
+
+            it('should POST to import API for updates', function () {
+                const chain = task.execution.HttpRequestChain.Execute;
+                const postSteps = chain.filter(
+                    (step: any) => step.RequestInputs.Method === 'POST'
+                );
+                assert.ok(postSteps.length > 0, 'should have POST steps for updates');
+
+                const importStep = postSteps.find(
+                    (step: any) => step.RequestInputs.EndpointUrl.includes('/api/now/import/x_mioms_azpipeline_change_request_import')
+                );
+                assert.ok(importStep, 'should POST to the change_request_import endpoint');
+            });
+        });
+    });
+});

--- a/Extensions/ServiceNow/Tests/_suite.ts
+++ b/Extensions/ServiceNow/Tests/_suite.ts
@@ -1,0 +1,10 @@
+// ServiceNow Extension - Test Suite Aggregator
+//
+// This file imports all task-wise test modules.
+// Run with: npx mocha "_build/Extensions/ServiceNow/Tests/_suite.js" --timeout 10000
+
+import './Tasks/CreateAndQueryChangeRequest/createTaskTests';
+import './Tasks/UpdateChangeRequest/updateTaskTests';
+import './manifestTests';
+import './ciScriptsTests';
+import './validationTests';

--- a/Extensions/ServiceNow/Tests/ciScriptsTests.ts
+++ b/Extensions/ServiceNow/Tests/ciScriptsTests.ts
@@ -1,0 +1,163 @@
+// Tests for CI pipeline scripts (DetermineCiTestPipelineName.ps1 and TriggerCiTestsForExtensions.ps1).
+
+import assert = require('assert');
+import fs = require('fs');
+import { determineCiScriptPath, triggerCiScriptPath } from './helpers';
+
+describe('CI Scripts Suite', function () {
+
+    describe('DetermineCiTestPipelineName.ps1', function () {
+
+        let scriptContent: string;
+
+        before(function () {
+            scriptContent = fs.readFileSync(determineCiScriptPath, 'utf-8');
+        });
+
+        it('should exist and be non-empty', function () {
+            assert.ok(scriptContent.length > 0, 'script should be non-empty');
+        });
+
+        it('should contain a switch statement for extension mapping', function () {
+            assert.ok(scriptContent.includes('switch'), 'should contain a switch statement');
+        });
+
+        it('should map ServiceNow extension to a pipeline name', function () {
+            assert.ok(scriptContent.includes('ServiceNow'),
+                'should reference ServiceNow in mapping');
+        });
+
+        it('should map TeamCity extension to a pipeline name', function () {
+            assert.ok(scriptContent.includes('TeamCity'),
+                'should reference TeamCity in mapping');
+        });
+
+        it('should map all expected extensions', function () {
+            const expectedExtensions = ['Ansible', 'BitBucket', 'ExternalTfs', 'IISWebAppDeploy', 'ServiceNow', 'TeamCity'];
+            expectedExtensions.forEach(ext => {
+                assert.ok(scriptContent.includes(ext),
+                    `should reference ${ext} in mapping`);
+            });
+        });
+
+        it('should produce pipeline name output', function () {
+            assert.ok(
+                scriptContent.includes('pipelineName') || scriptContent.includes('PipelineName'),
+                'should reference pipelineName variable'
+            );
+        });
+    });
+
+    describe('TriggerCiTestsForExtensions.ps1', function () {
+
+        let scriptContent: string;
+        let pipelineMappingBlock: string;
+
+        function parseTriggerScript(): Map<string, string> {
+            // Extract only the $pipelineMapping = @{...} block
+            const mappingStart = scriptContent.indexOf('$pipelineMapping = @{');
+            if (mappingStart === -1) {
+                return new Map();
+            }
+            const blockStart = scriptContent.indexOf('{', mappingStart);
+            let braceCount = 0;
+            let blockEnd = blockStart;
+            for (let i = blockStart; i < scriptContent.length; i++) {
+                if (scriptContent[i] === '{') braceCount++;
+                if (scriptContent[i] === '}') braceCount--;
+                if (braceCount === 0) { blockEnd = i; break; }
+            }
+            pipelineMappingBlock = scriptContent.substring(blockStart, blockEnd + 1);
+
+            const mapping = new Map<string, string>();
+            const regex = /["'](\w+)["']\s*=\s*["']([^"']+)["']/g;
+            let match;
+            while ((match = regex.exec(pipelineMappingBlock)) !== null) {
+                mapping.set(match[1], match[2]);
+            }
+            return mapping;
+        }
+
+        before(function () {
+            scriptContent = fs.readFileSync(triggerCiScriptPath, 'utf-8');
+        });
+
+        it('should exist and be non-empty', function () {
+            assert.ok(scriptContent.length > 0, 'script should be non-empty');
+        });
+
+        it('should define a $pipelineMapping hashtable', function () {
+            assert.ok(scriptContent.includes('$pipelineMapping'),
+                'should define $pipelineMapping');
+        });
+
+        it('should map ServiceNow extension', function () {
+            const mapping = parseTriggerScript();
+            assert.ok(mapping.has('ServiceNow'),
+                'pipelineMapping should include ServiceNow');
+        });
+
+        it('should map TeamCity extension', function () {
+            const mapping = parseTriggerScript();
+            assert.ok(mapping.has('TeamCity'),
+                'pipelineMapping should include TeamCity');
+        });
+
+        it('should map all expected extensions', function () {
+            const mapping = parseTriggerScript();
+            const expectedExtensions = ['Ansible', 'BitBucket', 'ExternalTfs', 'IISWebAppDeploy', 'ServiceNow', 'TeamCity'];
+            expectedExtensions.forEach(ext => {
+                assert.ok(mapping.has(ext),
+                    `pipelineMapping should include ${ext}`);
+            });
+        });
+
+        it('should have non-empty pipeline names for all mappings', function () {
+            const mapping = parseTriggerScript();
+            mapping.forEach((value, key) => {
+                assert.ok(value.length > 0,
+                    `pipeline name for ${key} should be non-empty`);
+            });
+        });
+
+        it('should use OrgUrl parameter for Azure DevOps API calls', function () {
+            assert.ok(
+                scriptContent.includes('OrgUrl') || scriptContent.includes('orgUrl'),
+                'should reference OrgUrl parameter for API calls'
+            );
+        });
+    });
+
+    describe('Cross-script consistency', function () {
+
+        it('should have same extensions mapped in both scripts', function () {
+            const determineContent = fs.readFileSync(determineCiScriptPath, 'utf-8');
+            const triggerContent = fs.readFileSync(triggerCiScriptPath, 'utf-8');
+
+            // Extract extensions from trigger script's $pipelineMapping block
+            const mappingStart = triggerContent.indexOf('$pipelineMapping = @{');
+            const blockStart = triggerContent.indexOf('{', mappingStart);
+            let braceCount = 0;
+            let blockEnd = blockStart;
+            for (let i = blockStart; i < triggerContent.length; i++) {
+                if (triggerContent[i] === '{') braceCount++;
+                if (triggerContent[i] === '}') braceCount--;
+                if (braceCount === 0) { blockEnd = i; break; }
+            }
+            const mappingBlock = triggerContent.substring(blockStart, blockEnd + 1);
+
+            const triggerExtensions: string[] = [];
+            const regex = /["'](\w+)["']\s*=\s*["']/g;
+            let match;
+            while ((match = regex.exec(mappingBlock)) !== null) {
+                triggerExtensions.push(match[1]);
+            }
+
+            // Verify each trigger extension appears in determine script
+            triggerExtensions.forEach(ext => {
+                assert.ok(determineContent.includes(ext),
+                    `Extension "${ext}" mapped in TriggerCiTests should also appear in DetermineCiTestPipelineName`);
+            });
+        });
+    });
+});

--- a/Extensions/ServiceNow/Tests/ciScriptsTests.ts
+++ b/Extensions/ServiceNow/Tests/ciScriptsTests.ts
@@ -4,14 +4,55 @@ import assert = require('assert');
 import fs = require('fs');
 import { determineCiScriptPath, triggerCiScriptPath } from './helpers';
 
+// Parse the switch statement in DetermineCiTestPipelineName.ps1 to extract extension→pipeline mappings.
+function parseDetermineScript(content: string): Map<string, string> {
+    const mapping = new Map<string, string>();
+    // Match lines like:  "ExtensionName" { $pipelineName = "PipelineName" }
+    const regex = /["'](\w+)["']\s*\{\s*\$\w+\s*=\s*["']([^"']+)["']/g;
+    let match;
+    while ((match = regex.exec(content)) !== null) {
+        mapping.set(match[1], match[2]);
+    }
+    return mapping;
+}
+
+// Parse the $pipelineMapping hashtable in TriggerCiTestsForExtensions.ps1.
+function parseTriggerScript(content: string): Map<string, string> {
+    const mappingStart = content.indexOf('$pipelineMapping = @{');
+    if (mappingStart === -1) {
+        return new Map();
+    }
+    const blockStart = content.indexOf('{', mappingStart);
+    // Brace-counting to find the matching closing brace.
+    // Note: assumes no unescaped braces inside string values within this block.
+    let braceCount = 0;
+    let blockEnd = blockStart;
+    for (let i = blockStart; i < content.length; i++) {
+        if (content[i] === '{') braceCount++;
+        if (content[i] === '}') braceCount--;
+        if (braceCount === 0) { blockEnd = i; break; }
+    }
+    const pipelineMappingBlock = content.substring(blockStart, blockEnd + 1);
+
+    const mapping = new Map<string, string>();
+    const regex = /["'](\w+)["']\s*=\s*["']([^"']+)["']/g;
+    let match;
+    while ((match = regex.exec(pipelineMappingBlock)) !== null) {
+        mapping.set(match[1], match[2]);
+    }
+    return mapping;
+}
+
 describe('CI Scripts Suite', function () {
 
     describe('DetermineCiTestPipelineName.ps1', function () {
 
         let scriptContent: string;
+        let determineMapping: Map<string, string>;
 
         before(function () {
             scriptContent = fs.readFileSync(determineCiScriptPath, 'utf-8');
+            determineMapping = parseDetermineScript(scriptContent);
         });
 
         it('should exist and be non-empty', function () {
@@ -23,20 +64,27 @@ describe('CI Scripts Suite', function () {
         });
 
         it('should map ServiceNow extension to a pipeline name', function () {
-            assert.ok(scriptContent.includes('ServiceNow'),
-                'should reference ServiceNow in mapping');
+            assert.ok(determineMapping.has('ServiceNow'),
+                'parsed switch should include ServiceNow');
         });
 
         it('should map TeamCity extension to a pipeline name', function () {
-            assert.ok(scriptContent.includes('TeamCity'),
-                'should reference TeamCity in mapping');
+            assert.ok(determineMapping.has('TeamCity'),
+                'parsed switch should include TeamCity');
         });
 
         it('should map all expected extensions', function () {
             const expectedExtensions = ['Ansible', 'BitBucket', 'ExternalTfs', 'IISWebAppDeploy', 'ServiceNow', 'TeamCity'];
             expectedExtensions.forEach(ext => {
-                assert.ok(scriptContent.includes(ext),
-                    `should reference ${ext} in mapping`);
+                assert.ok(determineMapping.has(ext),
+                    `parsed switch should include ${ext}`);
+            });
+        });
+
+        it('should have non-empty pipeline names for all mappings', function () {
+            determineMapping.forEach((value, key) => {
+                assert.ok(value.length > 0,
+                    `pipeline name for ${key} should be non-empty`);
             });
         });
 
@@ -51,35 +99,11 @@ describe('CI Scripts Suite', function () {
     describe('TriggerCiTestsForExtensions.ps1', function () {
 
         let scriptContent: string;
-        let pipelineMappingBlock: string;
-
-        function parseTriggerScript(): Map<string, string> {
-            // Extract only the $pipelineMapping = @{...} block
-            const mappingStart = scriptContent.indexOf('$pipelineMapping = @{');
-            if (mappingStart === -1) {
-                return new Map();
-            }
-            const blockStart = scriptContent.indexOf('{', mappingStart);
-            let braceCount = 0;
-            let blockEnd = blockStart;
-            for (let i = blockStart; i < scriptContent.length; i++) {
-                if (scriptContent[i] === '{') braceCount++;
-                if (scriptContent[i] === '}') braceCount--;
-                if (braceCount === 0) { blockEnd = i; break; }
-            }
-            pipelineMappingBlock = scriptContent.substring(blockStart, blockEnd + 1);
-
-            const mapping = new Map<string, string>();
-            const regex = /["'](\w+)["']\s*=\s*["']([^"']+)["']/g;
-            let match;
-            while ((match = regex.exec(pipelineMappingBlock)) !== null) {
-                mapping.set(match[1], match[2]);
-            }
-            return mapping;
-        }
+        let triggerMapping: Map<string, string>;
 
         before(function () {
             scriptContent = fs.readFileSync(triggerCiScriptPath, 'utf-8');
+            triggerMapping = parseTriggerScript(scriptContent);
         });
 
         it('should exist and be non-empty', function () {
@@ -92,29 +116,25 @@ describe('CI Scripts Suite', function () {
         });
 
         it('should map ServiceNow extension', function () {
-            const mapping = parseTriggerScript();
-            assert.ok(mapping.has('ServiceNow'),
+            assert.ok(triggerMapping.has('ServiceNow'),
                 'pipelineMapping should include ServiceNow');
         });
 
         it('should map TeamCity extension', function () {
-            const mapping = parseTriggerScript();
-            assert.ok(mapping.has('TeamCity'),
+            assert.ok(triggerMapping.has('TeamCity'),
                 'pipelineMapping should include TeamCity');
         });
 
         it('should map all expected extensions', function () {
-            const mapping = parseTriggerScript();
             const expectedExtensions = ['Ansible', 'BitBucket', 'ExternalTfs', 'IISWebAppDeploy', 'ServiceNow', 'TeamCity'];
             expectedExtensions.forEach(ext => {
-                assert.ok(mapping.has(ext),
+                assert.ok(triggerMapping.has(ext),
                     `pipelineMapping should include ${ext}`);
             });
         });
 
         it('should have non-empty pipeline names for all mappings', function () {
-            const mapping = parseTriggerScript();
-            mapping.forEach((value, key) => {
+            triggerMapping.forEach((value, key) => {
                 assert.ok(value.length > 0,
                     `pipeline name for ${key} should be non-empty`);
             });
@@ -130,34 +150,35 @@ describe('CI Scripts Suite', function () {
 
     describe('Cross-script consistency', function () {
 
-        it('should have same extensions mapped in both scripts', function () {
+        let determineMapping: Map<string, string>;
+        let triggerMapping: Map<string, string>;
+
+        before(function () {
             const determineContent = fs.readFileSync(determineCiScriptPath, 'utf-8');
             const triggerContent = fs.readFileSync(triggerCiScriptPath, 'utf-8');
+            determineMapping = parseDetermineScript(determineContent);
+            triggerMapping = parseTriggerScript(triggerContent);
+        });
 
-            // Extract extensions from trigger script's $pipelineMapping block
-            const mappingStart = triggerContent.indexOf('$pipelineMapping = @{');
-            const blockStart = triggerContent.indexOf('{', mappingStart);
-            let braceCount = 0;
-            let blockEnd = blockStart;
-            for (let i = blockStart; i < triggerContent.length; i++) {
-                if (triggerContent[i] === '{') braceCount++;
-                if (triggerContent[i] === '}') braceCount--;
-                if (braceCount === 0) { blockEnd = i; break; }
-            }
-            const mappingBlock = triggerContent.substring(blockStart, blockEnd + 1);
-
-            const triggerExtensions: string[] = [];
-            const regex = /["'](\w+)["']\s*=\s*["']/g;
-            let match;
-            while ((match = regex.exec(mappingBlock)) !== null) {
-                triggerExtensions.push(match[1]);
-            }
-
-            // Verify each trigger extension appears in determine script
-            triggerExtensions.forEach(ext => {
-                assert.ok(determineContent.includes(ext),
+        it('every trigger-script extension should appear in the determine script', function () {
+            triggerMapping.forEach((_value, ext) => {
+                assert.ok(determineMapping.has(ext),
                     `Extension "${ext}" mapped in TriggerCiTests should also appear in DetermineCiTestPipelineName`);
             });
+        });
+
+        it('every determine-script extension should appear in the trigger script', function () {
+            determineMapping.forEach((_value, ext) => {
+                assert.ok(triggerMapping.has(ext),
+                    `Extension "${ext}" mapped in DetermineCiTestPipelineName should also appear in TriggerCiTests`);
+            });
+        });
+
+        it('both scripts should map the exact same set of extensions', function () {
+            const determineKeys = Array.from(determineMapping.keys()).sort();
+            const triggerKeys = Array.from(triggerMapping.keys()).sort();
+            assert.deepStrictEqual(determineKeys, triggerKeys,
+                'both scripts should map identical extension sets');
         });
     });
 });

--- a/Extensions/ServiceNow/Tests/helpers.ts
+++ b/Extensions/ServiceNow/Tests/helpers.ts
@@ -1,0 +1,25 @@
+// Shared helpers and path constants for ServiceNow extension tests.
+
+import path = require('path');
+import fs = require('fs');
+
+export const repoRoot = path.join(__dirname, '..', '..', '..', '..');
+export const srcRoot = path.join(repoRoot, 'Extensions', 'ServiceNow', 'Src');
+export const extensionManifestPath = path.join(srcRoot, 'vss-extension.json');
+
+export const createTaskV0Path = path.join(srcRoot, 'Tasks', 'CreateAndQueryChangeRequest', 'CreateAndQueryChangeRequestV0', 'task.json');
+export const createTaskV1Path = path.join(srcRoot, 'Tasks', 'CreateAndQueryChangeRequest', 'CreateAndQueryChangeRequestV1', 'task.json');
+export const createTaskV2Path = path.join(srcRoot, 'Tasks', 'CreateAndQueryChangeRequest', 'CreateAndQueryChangeRequestV2', 'task.json');
+
+export const updateTaskV0Path = path.join(srcRoot, 'Tasks', 'UpdateChangeRequest', 'UpdateChangeRequestV0', 'task.json');
+export const updateTaskV1Path = path.join(srcRoot, 'Tasks', 'UpdateChangeRequest', 'UpdateChangeRequestV1', 'task.json');
+export const updateTaskV2Path = path.join(srcRoot, 'Tasks', 'UpdateChangeRequest', 'UpdateChangeRequestV2', 'task.json');
+
+export const scriptsRoot = path.join(repoRoot, 'scripts');
+export const determineCiScriptPath = path.join(scriptsRoot, 'DetermineCiTestPipelineName.ps1');
+export const triggerCiScriptPath = path.join(scriptsRoot, 'TriggerCiTestsForExtensions.ps1');
+
+export function loadJson(filePath: string): any {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    return JSON.parse(content);
+}

--- a/Extensions/ServiceNow/Tests/helpers.ts
+++ b/Extensions/ServiceNow/Tests/helpers.ts
@@ -3,7 +3,20 @@
 import path = require('path');
 import fs = require('fs');
 
-export const repoRoot = path.join(__dirname, '..', '..', '..', '..');
+// Anchor repoRoot by walking up from __dirname until we find the 'Extensions' directory.
+// This avoids hard-coding depth relative to _build output layout.
+function findRepoRoot(startDir: string): string {
+    let dir = startDir;
+    while (dir !== path.dirname(dir)) {
+        if (fs.existsSync(path.join(dir, 'Extensions')) && fs.existsSync(path.join(dir, 'scripts'))) {
+            return dir;
+        }
+        dir = path.dirname(dir);
+    }
+    throw new Error(`Could not find repo root (containing Extensions/ and scripts/) from ${startDir}`);
+}
+
+export const repoRoot = findRepoRoot(__dirname);
 export const srcRoot = path.join(repoRoot, 'Extensions', 'ServiceNow', 'Src');
 export const extensionManifestPath = path.join(srcRoot, 'vss-extension.json');
 

--- a/Extensions/ServiceNow/Tests/manifestTests.ts
+++ b/Extensions/ServiceNow/Tests/manifestTests.ts
@@ -234,15 +234,12 @@ describe('Manifest Suite', function () {
                     });
                 });
 
-                it('should have non-empty Body in all request steps', function () {
+                it('should have non-empty Body fields when present', function () {
                     const chain = task.execution.HttpRequestChain.Execute;
                     chain.forEach((step: any, index: number) => {
-                        if (step.RequestInputs.Body) {
-                            // Body may contain template expressions (e.g. {{...}}) so we
-                            // cannot parse as JSON; just verify it is non-empty.
-                            assert.ok(step.RequestInputs.Body.length > 0,
-                                `step ${index} Body should be non-empty`);
-                        }
+                        if (!step.RequestInputs.Body) return;
+                        assert.ok(step.RequestInputs.Body.length > 0,
+                            `step ${index} Body should be non-empty`);
                     });
                 });
             });

--- a/Extensions/ServiceNow/Tests/manifestTests.ts
+++ b/Extensions/ServiceNow/Tests/manifestTests.ts
@@ -234,15 +234,14 @@ describe('Manifest Suite', function () {
                     });
                 });
 
-                it('should have valid JSON in all Body fields', function () {
+                it('should have non-empty Body in all request steps', function () {
                     const chain = task.execution.HttpRequestChain.Execute;
                     chain.forEach((step: any, index: number) => {
                         if (step.RequestInputs.Body) {
-                            assert.doesNotThrow(() => {
-                                // Body may contain template expressions, just check it's non-empty
-                                assert.ok(step.RequestInputs.Body.length > 0,
-                                    `step ${index} Body should be non-empty`);
-                            }, `step ${index} Body should be valid`);
+                            // Body may contain template expressions (e.g. {{...}}) so we
+                            // cannot parse as JSON; just verify it is non-empty.
+                            assert.ok(step.RequestInputs.Body.length > 0,
+                                `step ${index} Body should be non-empty`);
                         }
                     });
                 });

--- a/Extensions/ServiceNow/Tests/manifestTests.ts
+++ b/Extensions/ServiceNow/Tests/manifestTests.ts
@@ -1,0 +1,321 @@
+// Tests for vss-extension.json manifest, OAuth2 auth scheme, and structural consistency.
+
+import assert = require('assert');
+import path = require('path');
+import fs = require('fs');
+import {
+    extensionManifestPath, srcRoot,
+    createTaskV0Path, createTaskV1Path, createTaskV2Path,
+    updateTaskV0Path, updateTaskV1Path, updateTaskV2Path,
+    loadJson
+} from './helpers';
+
+describe('Manifest Suite', function () {
+
+    let manifest: any;
+
+    before(function () {
+        manifest = loadJson(extensionManifestPath);
+    });
+
+    describe('Extension manifest (vss-extension.json)', function () {
+
+        it('should be valid JSON', function () {
+            assert.ok(manifest, 'manifest should parse without errors');
+        });
+
+        it('should have a non-empty id', function () {
+            assert.ok(manifest.id && manifest.id.length > 0, 'id should be non-empty');
+        });
+
+        it('should have publisher set', function () {
+            assert.ok(manifest.publisher, 'publisher should be set');
+        });
+
+        it('should specify targets including Microsoft.VisualStudio.Services.Cloud', function () {
+            const targets = manifest.targets.map((t: any) => t.id);
+            assert.ok(targets.includes('Microsoft.VisualStudio.Services.Cloud'),
+                'should target Microsoft.VisualStudio.Services.Cloud');
+        });
+
+        it('should have categories that include Azure Pipelines', function () {
+            assert.ok(manifest.categories.includes('Azure Pipelines'),
+                'categories should include Azure Pipelines');
+        });
+    });
+
+    describe('Service endpoint contribution', function () {
+
+        let endpoint: any;
+
+        before(function () {
+            const contributions = manifest.contributions || [];
+            endpoint = contributions.find(
+                (c: any) => c.type === 'ms.vss-endpoint.service-endpoint-type'
+            );
+        });
+
+        it('should define a ServiceNow service endpoint type', function () {
+            assert.ok(endpoint, 'should have a service endpoint type contribution');
+            assert.strictEqual(endpoint.properties.name, 'ServiceNow');
+        });
+
+        it('should have OAuth2 as an authentication scheme', function () {
+            const authSchemes = endpoint.properties.authenticationSchemes;
+            const oauth2 = authSchemes.find((s: any) => s.type === 'ms.vss-endpoint.endpoint-auth-scheme-oauth2');
+            assert.ok(oauth2, 'should have an OAuth2 auth scheme');
+        });
+
+        it('should have exactly two authentication schemes (Basic and OAuth2)', function () {
+            const authSchemes = endpoint.properties.authenticationSchemes;
+            assert.strictEqual(authSchemes.length, 2, 'should have exactly 2 auth schemes');
+        });
+
+        it('should have Basic as an authentication scheme', function () {
+            const authSchemes = endpoint.properties.authenticationSchemes;
+            const basic = authSchemes.find((s: any) => s.type === 'ms.vss-endpoint.endpoint-auth-scheme-basic');
+            assert.ok(basic, 'should have a Basic auth scheme');
+        });
+    });
+
+    describe('OAuth2 auth scheme details', function () {
+
+        let oauth2: any;
+
+        before(function () {
+            const contributions = manifest.contributions || [];
+            const endpoint = contributions.find(
+                (c: any) => c.type === 'ms.vss-endpoint.service-endpoint-type'
+            );
+            const authSchemes = endpoint.properties.authenticationSchemes;
+            oauth2 = authSchemes.find((s: any) => s.type === 'ms.vss-endpoint.endpoint-auth-scheme-oauth2');
+        });
+
+        it('should define authorizationUrl with /oauth_auth.do path', function () {
+            assert.ok(oauth2.authorizationUrl, 'authorizationUrl should exist');
+            assert.ok(oauth2.authorizationUrl.includes('/oauth_auth.do'),
+                'authorizationUrl should include /oauth_auth.do');
+        });
+
+        it('should define dataSourceBindings with a token endpoint', function () {
+            assert.ok(oauth2.dataSourceBindings, 'dataSourceBindings should exist for OAuth2');
+            assert.ok(oauth2.dataSourceBindings.length > 0, 'should have at least one data source binding');
+
+            const tokenBinding = oauth2.dataSourceBindings.find(
+                (b: any) => b.dataSourceName && b.dataSourceName.toLowerCase().includes('token')
+            );
+            assert.ok(tokenBinding, 'should have a token-related data source binding');
+        });
+
+        it('should support authorization_code grant type in endpoint dataSources', function () {
+            const contributions = manifest.contributions || [];
+            const ep = contributions.find(
+                (c: any) => c.type === 'ms.vss-endpoint.service-endpoint-type'
+            );
+            const dataSources = ep.properties.dataSources || [];
+            const allDataSources = JSON.stringify(dataSources);
+            assert.ok(allDataSources.includes('authorization_code'),
+                'should reference authorization_code grant type in dataSources');
+        });
+
+        it('should include client_id and client_secret in token request dataSources', function () {
+            const contributions = manifest.contributions || [];
+            const ep = contributions.find(
+                (c: any) => c.type === 'ms.vss-endpoint.service-endpoint-type'
+            );
+            const dataSources = ep.properties.dataSources || [];
+            const allDataSources = JSON.stringify(dataSources);
+            assert.ok(allDataSources.includes('client_id'), 'should reference client_id');
+            assert.ok(allDataSources.includes('client_secret'), 'should reference client_secret');
+        });
+
+        it('should use /oauth_token.do for token endpoint in dataSources', function () {
+            const contributions = manifest.contributions || [];
+            const ep = contributions.find(
+                (c: any) => c.type === 'ms.vss-endpoint.service-endpoint-type'
+            );
+            const dataSources = ep.properties.dataSources || [];
+            const allDataSources = JSON.stringify(dataSources);
+            assert.ok(allDataSources.includes('/oauth_token.do'),
+                'should reference /oauth_token.do token endpoint in dataSources');
+        });
+    });
+
+    describe('Data sources', function () {
+
+        let dataSources: any[];
+
+        before(function () {
+            const contributions = manifest.contributions || [];
+            const endpoint = contributions.find(
+                (c: any) => c.type === 'ms.vss-endpoint.service-endpoint-type'
+            );
+            dataSources = endpoint.properties.dataSources || [];
+        });
+
+        it('should define at least one data source', function () {
+            assert.ok(dataSources.length > 0, 'should have at least one data source');
+        });
+
+        it('should have unique data source names', function () {
+            const names = dataSources.map((ds: any) => ds.name);
+            const uniqueNames = new Set(names);
+            assert.strictEqual(names.length, uniqueNames.size,
+                `data source names should be unique, found duplicates: ${names.filter((n: string, i: number) => names.indexOf(n) !== i)}`);
+        });
+
+        it('should have resultSelector using jsonpath syntax for applicable sources', function () {
+            const withSelectors = dataSources.filter((ds: any) => ds.resultSelector);
+            withSelectors.forEach((ds: any) => {
+                assert.ok(ds.resultSelector.startsWith('jsonpath:'),
+                    `data source "${ds.name}" resultSelector should start with jsonpath:`);
+            });
+        });
+    });
+
+    describe('Task contributions', function () {
+
+        it('should declare CreateAndQueryChangeRequest task contributions', function () {
+            const contributions = manifest.contributions || [];
+            const taskContributions = contributions.filter(
+                (c: any) => c.type === 'ms.vss-distributed-task.task'
+            );
+            const createTasks = taskContributions.filter(
+                (c: any) => c.properties && c.properties.name &&
+                    c.properties.name.includes('CreateAndQueryChangeRequest')
+            );
+            assert.ok(createTasks.length > 0, 'should have CreateAndQueryChangeRequest task contributions');
+        });
+
+        it('should declare UpdateServiceNowChangeRequest task contributions', function () {
+            const contributions = manifest.contributions || [];
+            const taskContributions = contributions.filter(
+                (c: any) => c.type === 'ms.vss-distributed-task.task'
+            );
+            const updateTasks = taskContributions.filter(
+                (c: any) => c.properties && c.properties.name &&
+                    c.properties.name.includes('UpdateChangeRequest')
+            );
+            assert.ok(updateTasks.length > 0, 'should have UpdateChangeRequest task contributions');
+        });
+    });
+
+    describe('Structural consistency', function () {
+
+        const allTaskPaths = [
+            { label: 'CreateV0', path: createTaskV0Path },
+            { label: 'CreateV1', path: createTaskV1Path },
+            { label: 'CreateV2', path: createTaskV2Path },
+            { label: 'UpdateV0', path: updateTaskV0Path },
+            { label: 'UpdateV1', path: updateTaskV1Path },
+            { label: 'UpdateV2', path: updateTaskV2Path },
+        ];
+
+        allTaskPaths.forEach(({ label, path: taskPath }) => {
+            describe(`${label} structural integrity`, function () {
+
+                let task: any;
+
+                before(function () {
+                    task = loadJson(taskPath);
+                });
+
+                it('should have no duplicate input names', function () {
+                    const names = task.inputs.map((i: any) => i.name);
+                    const uniqueNames = new Set(names);
+                    assert.strictEqual(names.length, uniqueNames.size,
+                        `should have unique input names, found duplicates: ${names.filter((n: string, i: number) => names.indexOf(n) !== i)}`);
+                });
+
+                it('should have all dataSourceBindings reference valid endpointId', function () {
+                    (task.dataSourceBindings || []).forEach((binding: any) => {
+                        assert.strictEqual(binding.endpointId, '$(ServiceNowConnection)',
+                            `dataSourceBinding target "${binding.target}" should reference ServiceNowConnection`);
+                    });
+                });
+
+                it('should have valid JSON in all Body fields', function () {
+                    const chain = task.execution.HttpRequestChain.Execute;
+                    chain.forEach((step: any, index: number) => {
+                        if (step.RequestInputs.Body) {
+                            assert.doesNotThrow(() => {
+                                // Body may contain template expressions, just check it's non-empty
+                                assert.ok(step.RequestInputs.Body.length > 0,
+                                    `step ${index} Body should be non-empty`);
+                            }, `step ${index} Body should be valid`);
+                        }
+                    });
+                });
+            });
+        });
+
+        describe('Manifest file references', function () {
+
+            it('should reference existing task folders in contributions', function () {
+                const contributions = manifest.contributions || [];
+                const taskContributions = contributions.filter(
+                    (c: any) => c.type === 'ms.vss-distributed-task.task'
+                );
+                taskContributions.forEach((tc: any) => {
+                    const taskFolder = path.join(srcRoot, tc.properties.name);
+                    assert.ok(fs.existsSync(taskFolder),
+                        `task contribution references folder "${tc.properties.name}" which should exist at ${taskFolder}`);
+                });
+            });
+
+            it('should reference existing icon files', function () {
+                if (manifest.icons) {
+                    Object.entries(manifest.icons).forEach(([key, relativePath]: [string, any]) => {
+                        const iconPath = path.join(srcRoot, relativePath);
+                        assert.ok(fs.existsSync(iconPath),
+                            `icon "${key}" references "${relativePath}" which should exist at ${iconPath}`);
+                    });
+                }
+            });
+
+            it('should have matching file entries for static files', function () {
+                const files = manifest.files || [];
+                files.forEach((f: any) => {
+                    const filePath = path.join(srcRoot, f.path);
+                    assert.ok(fs.existsSync(filePath),
+                        `manifest file entry "${f.path}" should exist at ${filePath}`);
+                });
+            });
+        });
+
+        describe('Cross-version consistency', function () {
+
+            it('should have same task id for all CreateAndQueryChangeRequest versions', function () {
+                const v0 = loadJson(createTaskV0Path);
+                const v1 = loadJson(createTaskV1Path);
+                const v2 = loadJson(createTaskV2Path);
+                assert.strictEqual(v0.id, v1.id, 'V0 and V1 should share task id');
+                assert.strictEqual(v1.id, v2.id, 'V1 and V2 should share task id');
+            });
+
+            it('should have same task id for all UpdateChangeRequest versions', function () {
+                const v0 = loadJson(updateTaskV0Path);
+                const v1 = loadJson(updateTaskV1Path);
+                const v2 = loadJson(updateTaskV2Path);
+                assert.strictEqual(v0.id, v1.id, 'V0 and V1 should share task id');
+                assert.strictEqual(v1.id, v2.id, 'V1 and V2 should share task id');
+            });
+
+            it('should have ascending Major versions', function () {
+                const cv0 = loadJson(createTaskV0Path);
+                const cv1 = loadJson(createTaskV1Path);
+                const cv2 = loadJson(createTaskV2Path);
+                assert.ok(cv0.version.Major < cv1.version.Major, 'Create V0 < V1');
+                assert.ok(cv1.version.Major < cv2.version.Major, 'Create V1 < V2');
+            });
+
+            it('should have same task name across all versions', function () {
+                const cv0 = loadJson(createTaskV0Path);
+                const cv1 = loadJson(createTaskV1Path);
+                const cv2 = loadJson(createTaskV2Path);
+                assert.strictEqual(cv0.name, cv1.name);
+                assert.strictEqual(cv1.name, cv2.name);
+            });
+        });
+    });
+});

--- a/Extensions/ServiceNow/Tests/validationTests.ts
+++ b/Extensions/ServiceNow/Tests/validationTests.ts
@@ -1,0 +1,368 @@
+// High-priority validation tests: visibleRules, pickList bindings, expressions, data sources, and cross-version checks.
+
+import assert = require('assert');
+import {
+    extensionManifestPath, srcRoot,
+    createTaskV0Path, createTaskV1Path, createTaskV2Path,
+    updateTaskV0Path, updateTaskV1Path, updateTaskV2Path,
+    loadJson
+} from './helpers';
+
+describe('Validation Suite', function () {
+
+    const allTaskPaths = [
+        { label: 'CreateV0', path: createTaskV0Path },
+        { label: 'CreateV1', path: createTaskV1Path },
+        { label: 'CreateV2', path: createTaskV2Path },
+        { label: 'UpdateV0', path: updateTaskV0Path },
+        { label: 'UpdateV1', path: updateTaskV1Path },
+        { label: 'UpdateV2', path: updateTaskV2Path },
+    ];
+
+    describe('VisibleRule input reference validation', function () {
+
+        allTaskPaths.forEach(({ label, path: taskPath }) => {
+            it(`${label}: all visibleRule references should point to existing inputs`, function () {
+                const task = loadJson(taskPath);
+                const inputNames = new Set(task.inputs.map((i: any) => i.name));
+
+                task.inputs.forEach((input: any) => {
+                    if (!input.visibleRule) return;
+
+                    // Extract input names from visibleRule (format: "inputName = value")
+                    const references = input.visibleRule.match(/(\w+)\s*=/g) || [];
+                    references.forEach((ref: string) => {
+                        const refName = ref.replace(/\s*=\s*$/, '').trim();
+                        // Skip known non-input references
+                        if (['true', 'false'].includes(refName.toLowerCase())) return;
+                        assert.ok(inputNames.has(refName),
+                            `Input "${input.name}" visibleRule references "${refName}" which does not exist in ${label} inputs`);
+                    });
+                });
+            });
+        });
+
+        allTaskPaths.forEach(({ label, path: taskPath }) => {
+            it(`${label}: all group visibleRules should reference existing inputs`, function () {
+                const task = loadJson(taskPath);
+                const inputNames = new Set(task.inputs.map((i: any) => i.name));
+                const groups = task.groups || [];
+
+                groups.forEach((group: any) => {
+                    if (!group.visibleRule) return;
+
+                    const references = group.visibleRule.match(/(\w+)\s*=/g) || [];
+                    references.forEach((ref: string) => {
+                        const refName = ref.replace(/\s*=\s*$/, '').trim();
+                        if (['true', 'false'].includes(refName.toLowerCase())) return;
+                        assert.ok(inputNames.has(refName),
+                            `Group "${group.name}" visibleRule references "${refName}" which does not exist in ${label} inputs`);
+                    });
+                });
+            });
+        });
+    });
+
+    describe('PickList binding completeness', function () {
+
+        allTaskPaths.forEach(({ label, path: taskPath }) => {
+            it(`${label}: every pickList input should have options or a dataSourceBinding`, function () {
+                const task = loadJson(taskPath);
+                const boundTargets = new Set(
+                    (task.dataSourceBindings || []).map((b: any) => b.target)
+                );
+
+                const pickListInputs = task.inputs.filter((i: any) => i.type === 'pickList');
+
+                pickListInputs.forEach((input: any) => {
+                    const hasOptions = input.options && Object.keys(input.options).length > 0;
+                    const hasDsBinding = boundTargets.has(input.name);
+                    assert.ok(hasOptions || hasDsBinding,
+                        `pickList input "${input.name}" in ${label} has neither inline options nor a dataSourceBinding`);
+                });
+            });
+        });
+    });
+
+    describe('GroupName references valid groups', function () {
+
+        allTaskPaths.forEach(({ label, path: taskPath }) => {
+            it(`${label}: all input groupNames should reference existing groups`, function () {
+                const task = loadJson(taskPath);
+                const groupNames = new Set((task.groups || []).map((g: any) => g.name));
+
+                task.inputs.forEach((input: any) => {
+                    if (!input.groupName) return;
+                    assert.ok(groupNames.has(input.groupName),
+                        `Input "${input.name}" references group "${input.groupName}" which does not exist in ${label}`);
+                });
+            });
+        });
+    });
+
+    describe('Expression balanced parentheses', function () {
+
+        function hasBalancedParentheses(expr: string): boolean {
+            let depth = 0;
+            for (const ch of expr) {
+                if (ch === '(') depth++;
+                if (ch === ')') depth--;
+                if (depth < 0) return false;
+            }
+            return depth === 0;
+        }
+
+        allTaskPaths.forEach(({ label, path: taskPath }) => {
+            it(`${label}: all SkipSectionExpression values should have balanced parentheses`, function () {
+                const task = loadJson(taskPath);
+                const chain = task.execution.HttpRequestChain.Execute;
+
+                chain.forEach((step: any, index: number) => {
+                    if (step.ExecutionOptions && step.ExecutionOptions.SkipSectionExpression) {
+                        const expr = step.ExecutionOptions.SkipSectionExpression;
+                        assert.ok(hasBalancedParentheses(expr),
+                            `Step ${index} SkipSectionExpression has unbalanced parentheses in ${label}: "${expr.substring(0, 80)}..."`);
+                    }
+                });
+            });
+        });
+    });
+
+    describe('Update V2 checks execution path', function () {
+
+        let task: any;
+
+        before(function () {
+            task = loadJson(updateTaskV2Path);
+        });
+
+        it('should include "Build" in visibility', function () {
+            assert.ok(task.visibility.includes('Build'),
+                'Update V2 should have Build in visibility');
+            assert.ok(task.visibility.includes('Release'),
+                'Update V2 should still have Release in visibility');
+        });
+
+        it('should have 3 execution steps', function () {
+            const chain = task.execution.HttpRequestChain.Execute;
+            assert.strictEqual(chain.length, 3,
+                `Update V2 should have 3 execution steps, found ${chain.length}`);
+        });
+
+        it('should have a GET step referencing stageId/buildId/stageAttempt for checks context', function () {
+            const chain = task.execution.HttpRequestChain.Execute;
+            const checksStep = chain.find(
+                (step: any) => step.RequestInputs.EndpointUrl.includes('system.stageId')
+            );
+            assert.ok(checksStep, 'should have a step with system.stageId');
+            assert.ok(checksStep.RequestInputs.EndpointUrl.includes('build.buildId'),
+                'checks step should reference build.buildId');
+            assert.ok(checksStep.RequestInputs.EndpointUrl.includes('system.stageAttempt'),
+                'checks step should reference system.stageAttempt');
+        });
+
+        it('should use SkipSectionExpression to distinguish ChangeRequestNumber present vs absent', function () {
+            const chain = task.execution.HttpRequestChain.Execute;
+            const step1Skip = chain[0].ExecutionOptions?.SkipSectionExpression || '';
+            const step2Skip = chain[1].ExecutionOptions?.SkipSectionExpression || '';
+
+            assert.ok(step1Skip.includes("taskInputs['ChangeRequestNumber']"),
+                'step 1 should reference ChangeRequestNumber input');
+            assert.ok(step2Skip.includes("taskInputs['ChangeRequestNumber']"),
+                'step 2 should reference ChangeRequestNumber input');
+
+            // One skips when empty, other skips when not empty
+            assert.ok(step1Skip.includes('true') && step2Skip.includes('false'),
+                'steps should have complementary skip conditions');
+        });
+
+        it('should query by correlation fields when ChangeRequestNumber is absent', function () {
+            const chain = task.execution.HttpRequestChain.Execute;
+            const correlationStep = chain.find(
+                (step: any) => step.RequestInputs.EndpointUrl.includes('x_mioms_azpipeline_stage_id')
+            );
+            assert.ok(correlationStep, 'should have a correlation-based query step');
+            assert.ok(correlationStep.RequestInputs.EndpointUrl.includes('x_mioms_azpipeline_build_id'),
+                'should query by build_id');
+            assert.ok(correlationStep.RequestInputs.EndpointUrl.includes('x_mioms_azpipeline_stage_attempt'),
+                'should query by stage_attempt');
+        });
+    });
+
+    describe('Update V2 visibility change', function () {
+
+        it('should have V0 and V1 with only "Release" visibility', function () {
+            const v0 = loadJson(updateTaskV0Path);
+            const v1 = loadJson(updateTaskV1Path);
+            assert.deepStrictEqual(v0.visibility, ['Release'],
+                'V0 should only have Release visibility');
+            assert.deepStrictEqual(v1.visibility, ['Release'],
+                'V1 should only have Release visibility');
+        });
+
+        it('should have V2 with both "Build" and "Release" visibility', function () {
+            const v2 = loadJson(updateTaskV2Path);
+            assert.ok(v2.visibility.includes('Build'), 'V2 should include Build');
+            assert.ok(v2.visibility.includes('Release'), 'V2 should include Release');
+        });
+    });
+
+    describe('DataSource name evolution between versions', function () {
+
+        it('Update V0/V1 should use "StateLabel"/"CloseCodeLabel" data sources', function () {
+            const v0 = loadJson(updateTaskV0Path);
+            const v1 = loadJson(updateTaskV1Path);
+
+            [v0, v1].forEach((task) => {
+                const bindings = task.dataSourceBindings || [];
+                const stateBinding = bindings.find((b: any) => b.target === 'NewStatus');
+                const closeBinding = bindings.find((b: any) => b.target === 'CloseCode');
+
+                if (stateBinding) {
+                    assert.strictEqual(stateBinding.dataSourceName, 'StateLabel',
+                        'V0/V1 NewStatus should use StateLabel data source');
+                }
+                if (closeBinding) {
+                    assert.strictEqual(closeBinding.dataSourceName, 'CloseCodeLabel',
+                        'V0/V1 CloseCode should use CloseCodeLabel data source');
+                }
+            });
+        });
+
+        it('Update V2 should use "State"/"Close code" data sources (with value+label)', function () {
+            const v2 = loadJson(updateTaskV2Path);
+            const bindings = v2.dataSourceBindings || [];
+
+            const stateBinding = bindings.find((b: any) => b.target === 'NewStatus');
+            const closeBinding = bindings.find((b: any) => b.target === 'CloseCode');
+
+            assert.ok(stateBinding, 'V2 should have NewStatus dataSourceBinding');
+            assert.strictEqual(stateBinding.dataSourceName, 'State',
+                'V2 NewStatus should use "State" data source (not StateLabel)');
+
+            assert.ok(closeBinding, 'V2 should have CloseCode dataSourceBinding');
+            assert.strictEqual(closeBinding.dataSourceName, 'Close code',
+                'V2 CloseCode should use "Close code" data source (not CloseCodeLabel)');
+        });
+    });
+
+    describe('Data source endpointUrl validation', function () {
+
+        let dataSources: any[];
+
+        before(function () {
+            const manifest = loadJson(extensionManifestPath);
+            const contributions = manifest.contributions || [];
+            const endpoint = contributions.find(
+                (c: any) => c.type === 'ms.vss-endpoint.service-endpoint-type'
+            );
+            dataSources = endpoint.properties.dataSources || [];
+        });
+
+        it('should have at least 17 data sources', function () {
+            assert.ok(dataSources.length >= 17,
+                `expected at least 17 data sources, found ${dataSources.length}`);
+        });
+
+        it('all endpointUrls should start with {{endpoint.url}} or {{{configuration.Url}}}', function () {
+            dataSources.forEach((ds: any) => {
+                const url = ds.endpointUrl;
+                const validPrefix = url.startsWith('{{endpoint.url}}') ||
+                    url.startsWith('{{{configuration.Url}}}');
+                assert.ok(validPrefix,
+                    `data source "${ds.name}" endpointUrl should start with a valid template prefix, got: "${url.substring(0, 40)}"`);
+            });
+        });
+
+        it('TestConnection should include app_major_version=4', function () {
+            const testConn = dataSources.find((ds: any) => ds.name === 'TestConnection');
+            assert.ok(testConn, 'TestConnection data source should exist');
+            assert.ok(testConn.endpointUrl.includes('app_major_version=4'),
+                'TestConnection should reference app_major_version=4');
+        });
+
+        it('TestConnection should point to the azpipeline app_version API', function () {
+            const testConn = dataSources.find((ds: any) => ds.name === 'TestConnection');
+            assert.ok(testConn.endpointUrl.includes('/api/x_mioms_azpipeline/app_version'),
+                'TestConnection should use the app_version API');
+        });
+
+        it('paginated data sources (Configuration Item, Assignment Group) should include sysparm_offset', function () {
+            const paginatedSources = ['Configuration Item', 'Assignment Group'];
+            paginatedSources.forEach((name) => {
+                const ds = dataSources.find((d: any) => d.name === name);
+                assert.ok(ds, `${name} data source should exist`);
+                assert.ok(ds.endpointUrl.includes('sysparm_offset'),
+                    `${name} should include sysparm_offset for pagination`);
+                assert.ok(ds.endpointUrl.includes('sysparm_limit'),
+                    `${name} should include sysparm_limit for pagination`);
+            });
+        });
+
+        it('all data sources that query sys_choice should include sysparm_fields', function () {
+            const choiceSources = dataSources.filter(
+                (ds: any) => ds.endpointUrl.includes('/sys_choice')
+            );
+            choiceSources.forEach((ds: any) => {
+                assert.ok(ds.endpointUrl.includes('sysparm_fields'),
+                    `data source "${ds.name}" queries sys_choice but missing sysparm_fields`);
+            });
+        });
+    });
+
+    describe('Update V2 CloseCode visibleRule uses numeric state value', function () {
+
+        it('V0 CloseCode should use "NewStatus = Closed"', function () {
+            const v0 = loadJson(updateTaskV0Path);
+            const closeCode = v0.inputs.find((i: any) => i.name === 'CloseCode');
+            assert.ok(closeCode, 'CloseCode should exist in V0');
+            assert.ok(closeCode.visibleRule.includes('Closed'),
+                'V0 CloseCode visibleRule should reference "Closed" (label)');
+        });
+
+        it('V1 CloseCode should use "UpdateStatus = true && NewStatus = Closed"', function () {
+            const v1 = loadJson(updateTaskV1Path);
+            const closeCode = v1.inputs.find((i: any) => i.name === 'CloseCode');
+            assert.ok(closeCode, 'CloseCode should exist in V1');
+            assert.ok(closeCode.visibleRule.includes('UpdateStatus = true'),
+                'V1 CloseCode should require UpdateStatus = true');
+            assert.ok(closeCode.visibleRule.includes('Closed'),
+                'V1 CloseCode should reference "Closed" (label)');
+        });
+
+        it('V2 CloseCode should use "UpdateStatus = true && NewStatus = 3"', function () {
+            const v2 = loadJson(updateTaskV2Path);
+            const closeCode = v2.inputs.find((i: any) => i.name === 'CloseCode');
+            assert.ok(closeCode, 'CloseCode should exist in V2');
+            assert.ok(closeCode.visibleRule.includes('UpdateStatus = true'),
+                'V2 CloseCode should require UpdateStatus = true');
+            assert.ok(closeCode.visibleRule.includes('NewStatus = 3'),
+                'V2 CloseCode should use numeric value "3" (not label "Closed")');
+        });
+    });
+
+    describe('HelpMarkDown validation', function () {
+
+        allTaskPaths.forEach(({ label, path: taskPath }) => {
+            it(`${label}: all inputs should have non-empty helpMarkDown`, function () {
+                const task = loadJson(taskPath);
+                task.inputs.forEach((input: any) => {
+                    assert.ok(input.helpMarkDown !== undefined && input.helpMarkDown !== null,
+                        `Input "${input.name}" in ${label} should have helpMarkDown defined`);
+                    // Allow empty string for some inputs but not undefined/null
+                });
+            });
+        });
+    });
+
+    describe('InstanceNameFormat validation', function () {
+
+        allTaskPaths.forEach(({ label, path: taskPath }) => {
+            it(`${label}: should have non-empty instanceNameFormat`, function () {
+                const task = loadJson(taskPath);
+                assert.ok(task.instanceNameFormat && task.instanceNameFormat.length > 0,
+                    `${label} should have a non-empty instanceNameFormat`);
+            });
+        });
+    });
+});

--- a/Extensions/ServiceNow/Tests/validationTests.ts
+++ b/Extensions/ServiceNow/Tests/validationTests.ts
@@ -357,12 +357,12 @@ describe('Validation Suite', function () {
     describe('HelpMarkDown validation', function () {
 
         allTaskPaths.forEach(({ label, path: taskPath }) => {
-            it(`${label}: all inputs should have non-empty helpMarkDown`, function () {
+            it(`${label}: all inputs should have helpMarkDown defined`, function () {
                 const task = loadJson(taskPath);
                 task.inputs.forEach((input: any) => {
                     assert.ok(input.helpMarkDown !== undefined && input.helpMarkDown !== null,
                         `Input "${input.name}" in ${label} should have helpMarkDown defined`);
-                    // Allow empty string for some inputs but not undefined/null
+                    // Allow empty string — only undefined/null is invalid
                 });
             });
         });

--- a/Extensions/ServiceNow/Tests/validationTests.ts
+++ b/Extensions/ServiceNow/Tests/validationTests.ts
@@ -21,6 +21,25 @@ describe('Validation Suite', function () {
 
     describe('VisibleRule input reference validation', function () {
 
+        // Tokenize a visibleRule into the LHS input names it references.
+        // Rules have the form: "inputA = valueA && inputB = valueB"
+        function extractVisibleRuleInputRefs(rule: string): string[] {
+            // Split on && and || (with optional whitespace), then extract LHS of each clause
+            const clauses = rule.split(/\s*(?:&&|\|\|)\s*/);
+            const refs: string[] = [];
+            for (const clause of clauses) {
+                const match = clause.trim().match(/^(\w+)\s*=/);
+                if (match) {
+                    const name = match[1];
+                    // Skip boolean literals that aren't input names
+                    if (!['true', 'false'].includes(name.toLowerCase())) {
+                        refs.push(name);
+                    }
+                }
+            }
+            return refs;
+        }
+
         allTaskPaths.forEach(({ label, path: taskPath }) => {
             it(`${label}: all visibleRule references should point to existing inputs`, function () {
                 const task = loadJson(taskPath);
@@ -29,12 +48,8 @@ describe('Validation Suite', function () {
                 task.inputs.forEach((input: any) => {
                     if (!input.visibleRule) return;
 
-                    // Extract input names from visibleRule (format: "inputName = value")
-                    const references = input.visibleRule.match(/(\w+)\s*=/g) || [];
-                    references.forEach((ref: string) => {
-                        const refName = ref.replace(/\s*=\s*$/, '').trim();
-                        // Skip known non-input references
-                        if (['true', 'false'].includes(refName.toLowerCase())) return;
+                    const refs = extractVisibleRuleInputRefs(input.visibleRule);
+                    refs.forEach((refName) => {
                         assert.ok(inputNames.has(refName),
                             `Input "${input.name}" visibleRule references "${refName}" which does not exist in ${label} inputs`);
                     });
@@ -51,10 +66,8 @@ describe('Validation Suite', function () {
                 groups.forEach((group: any) => {
                     if (!group.visibleRule) return;
 
-                    const references = group.visibleRule.match(/(\w+)\s*=/g) || [];
-                    references.forEach((ref: string) => {
-                        const refName = ref.replace(/\s*=\s*$/, '').trim();
-                        if (['true', 'false'].includes(refName.toLowerCase())) return;
+                    const refs = extractVisibleRuleInputRefs(group.visibleRule);
+                    refs.forEach((refName) => {
                         assert.ok(inputNames.has(refName),
                             `Group "${group.name}" visibleRule references "${refName}" which does not exist in ${label} inputs`);
                     });


### PR DESCRIPTION

**Description:**

Adds **217 automated tests** that check the ServiceNow extension's JSON configuration files are correct and consistent. These tests catch mistakes like:
- A dropdown input that has no data source connected (empty dropdown for users)
- A visibility rule referencing an input that doesn't exist (hidden fields)
- A task version missing required fields
- CI scripts getting out of sync with each other

No ServiceNow instance needed — tests just read the local JSON/PS1 files and verify their structure.

## What's tested

| Area | What it checks |
|------|----------------|
| **Create task** (V0/V1/V2) | Required inputs exist, execution chain is valid, output variables are produced, API endpoints are correct |
| **Update task** (V0/V1/V2) | Same as above, plus V2's new "Build" visibility and checks-aware execution path |
| **Manifest** | Auth schemes, data sources, file references all point to real things that exist |
| **CI scripts** | Both pipeline scripts map the same extensions, no drift between them |
| **Cross-cutting** | Every dropdown has a data source, every visibility rule references real inputs, all expressions have balanced parentheses |

## File layout

```
Extensions/ServiceNow/Tests/
├── _suite.ts              ← Entry point (imports everything)
├── helpers.ts             ← Shared utilities
├── manifestTests.ts       ← Manifest + OAuth2 + data sources
├── ciScriptsTests.ts      ← CI pipeline script checks
├── validationTests.ts     ← Structural validation rules
└── Tasks/
    ├── CreateAndQueryChangeRequest/
    │   └── createTaskTests.ts
    └── UpdateChangeRequest/
        └── updateTaskTests.ts
```
