### PR TITLE
refactor: update package dependencies and improve TypeScript support

### DIFF
--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
@@ -94,6 +94,11 @@ https.request(options, function (rs) {
             remoteUrl = result.links.clone[0].href;
         }
 
+        if (!remoteUrl) {
+            tl.setResult(tl.TaskResult.Failed, 'Failed to resolve the repository clone URL from the Bitbucket API response.');
+            process.exit(1);
+        }
+
         tl.debug('Remote Url:' + remoteUrl);
 
         // encodes projects and repo names with spaces

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
@@ -15,15 +15,19 @@ const scw = require('./sourcecontrolwrapper.js');
  */
 
 /**
+ * @typedef {Object} IBitbucketResponseLinksHref
+ * @property {string} href - The URL of the link.
+ */
+
+/**
  * @typedef {Object} IBitbucketResponseLinks
- * @property {Array<{ href: string }>} clone - An array of clone links for the repository.
+ * @property {IBitbucketResponseLinksHref[]} clone - An array of clone links for the repository.
  */
 
 /**
  * @typedef {Object} IBitbucketResponse
  * @property {string} scm - The source control management type (e.g., "git").
  * @property {IBitbucketResponseLinks} links - The links object containing repository links.
- * @property {Array<{ href: string }>} links.clone - An array of clone links for the repository.
  */
 
 const BITBUCKET_API_TOKEN_AUTH_USERNAME = 'x-bitbucket-api-token-auth';

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
@@ -37,7 +37,7 @@ const bitbucketEndpoint = getEndpointDetails('connection');
 try {
     removePathRecursive(downloadPath);
 } catch (error) {
-    tl.error(error);
+    tl.setResult(tl.TaskResult.Failed, error.message || error);
     process.exit(1);
 }
 
@@ -67,14 +67,14 @@ https.request(options, function (rs) {
     rs.on('end', function () {
         const statusCode = rs.statusCode || 0;
         if (statusCode < 200 || statusCode >= 300) {
-            tl.error('Failed to get repository details from Bitbucket. HTTP status: ' + statusCode + ' ' + rs.statusMessage + '. Response: ' + response);
+            tl.setResult(tl.TaskResult.Failed, 'Failed to get repository details from Bitbucket. HTTP status: ' + statusCode + ' ' + rs.statusMessage + '. Response: ' + response);
             process.exit(1);
         }
 
         try {
             result = JSON.parse(response);
         } catch (error) {
-            tl.error('Failed to parse Bitbucket API response as JSON. Response: ' + response);
+            tl.setResult(tl.TaskResult.Failed, 'Failed to parse Bitbucket API response as JSON. Response: ' + response);
             process.exit(1);
         }
 
@@ -141,7 +141,7 @@ https.request(options, function (rs) {
                 return sch.checkout(commitId);
             })
             .catch(function (error) {
-                tl.error(error);
+                tl.setResult(tl.TaskResult.Failed, error.message || error);
                 process.exit(1);
             });
     });

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
@@ -14,6 +14,18 @@ const scw = require('./sourcecontrolwrapper.js');
  * @property {string | null} [Token] - The token for the endpoint (if using token authentication).
  */
 
+/**
+ * @typedef {Object} IBitbucketResponseLinks
+ * @property {Array<{ href: string }>} clone - An array of clone links for the repository.
+ */
+
+/**
+ * @typedef {Object} IBitbucketResponse
+ * @property {string} scm - The source control management type (e.g., "git").
+ * @property {IBitbucketResponseLinks} links - The links object containing repository links.
+ * @property {Array<{ href: string }>} links.clone - An array of clone links for the repository.
+ */
+
 const BITBUCKET_API_TOKEN_AUTH_USERNAME = 'x-bitbucket-api-token-auth';
 
 const repositoryId = tl.getInputRequired('definition');
@@ -45,6 +57,7 @@ if (bitbucketEndpoint.Token) {
 
 https.request(options, function (rs) {
     tl.debug(`HTTP status: ${rs.statusCode} ${rs.statusMessage}`);
+    /** @type {IBitbucketResponse} */
     let result;
     let response = '';
     rs.on('data', function (data) {
@@ -52,7 +65,19 @@ https.request(options, function (rs) {
         response += data
     });
     rs.on('end', function () {
-        result = JSON.parse(response);
+        const statusCode = rs.statusCode || 0;
+        if (statusCode < 200 || statusCode >= 300) {
+            tl.error('Failed to get repository details from Bitbucket. HTTP status: ' + statusCode + ' ' + rs.statusMessage + '. Response: ' + response);
+            process.exit(1);
+        }
+
+        try {
+            result = JSON.parse(response);
+        } catch (error) {
+            tl.error('Failed to parse Bitbucket API response as JSON. Response: ' + response);
+            process.exit(1);
+        }
+
         tl.debug('result:' + JSON.stringify(result));
         const sch = new scw.SourceControlWrapper(result.scm);
 
@@ -63,7 +88,12 @@ https.request(options, function (rs) {
             console.log(data.toString());
         });
 
-        const remoteUrl = result.links.clone[0].href;
+        let remoteUrl = "";
+
+        if (result.links.clone[0]) {
+            remoteUrl = result.links.clone[0].href;
+        }
+
         tl.debug('Remote Url:' + remoteUrl);
 
         // encodes projects and repo names with spaces

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
@@ -235,8 +235,8 @@ function getEndpointDetails(inputFieldName) {
 
 /**
  * Gets the value of the specified authorization parameter from the given endpoint.
- * @param {*} endpoint - The endpoint from which to retrieve the authorization parameter.
- * @param {*} paramName - The name of the authorization parameter to retrieve.
+ * @param {string} endpoint - The endpoint from which to retrieve the authorization parameter.
+ * @param {string} paramName - The name of the authorization parameter to retrieve.
  * @returns {string|undefined} The value of the authorization parameter, or undefined if not found.
  */
 function getAuthParameter(endpoint, paramName) {

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
@@ -10,7 +10,7 @@ const scw = require('./sourcecontrolwrapper.js');
 /**
  * @typedef {Object} EndpointDetails
  * @property {string} [Username] - The username for the endpoint.
- * @property {string | null} [Password] - The password for the endpoint (if using username/password authentication).
+ * @property {string} [Password] - The password for the endpoint (if using username/password authentication).
  * @property {string | null} [Token] - The token for the endpoint (if using token authentication).
  */
 
@@ -157,14 +157,20 @@ function getEndpointDetails(inputFieldName) {
 
     if (scheme === 'token') {
         const token = getAuthParameter(bitbucketEndpoint, 'apitoken');
+
+        if (!token) {
+            throw new Error('The endpoint ' + bitbucketEndpoint + ' does not have an API token parameter.');
+        }
+
         const username = getAuthParameter(bitbucketEndpoint, 'email') || '';
         tl.debug('Using token authentication');
+
         try {
-            // @ts-ignore since setSecret applies nullability
             tl.setSecret(token);
         } catch (e) {
             tl.warning('Failed to mask API token for log redaction.');
         }
+
         return {
             'Token': token,
             'Username': username
@@ -172,13 +178,19 @@ function getEndpointDetails(inputFieldName) {
     } else {
         const hostUsername = getAuthParameter(bitbucketEndpoint, 'username');
         const hostPassword = getAuthParameter(bitbucketEndpoint, 'password');
+
+        if (hostUsername === undefined || hostPassword === undefined) {
+            throw new Error('The endpoint ' + bitbucketEndpoint + ' does not have the required username and password parameters.');
+        }
+
         try {
-            // @ts-ignore since setSecret applies nullability
             tl.setSecret(hostPassword);
         } catch (e) {
             tl.warning('Failed to mask password for log redaction.');
         }
+
         tl.debug('hostUsername: ' + hostUsername);
+
         return {
             'Username': hostUsername,
             'Password': hostPassword

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
@@ -1,25 +1,39 @@
-var tl = require('azure-pipelines-task-lib/task');
-var fs = require('fs');
-var path = require('path');
-var Q = require('q');
-var url = require('url');
-var scw = require('./sourcecontrolwrapper.js');
-var https = require("https");
+const fs = require('fs');
+const https = require('https');
+const url = require('url');
+const path = require('path');
 
-var BITBUCKET_API_TOKEN_AUTH_USERNAME = 'x-bitbucket-api-token-auth';
+const tl = require('azure-pipelines-task-lib/task');
 
-var repositoryId = tl.getInput("definition", true);
-var branch = tl.getInput("branch", true);
-var commitId = tl.getInput("version", true);
-var downloadPath = tl.getInput("downloadPath", true);
-var bitbucketEndpoint = getEndpointDetails("connection");
+const scw = require('./sourcecontrolwrapper.js');
 
-removePathRecursive(downloadPath);
+/**
+ * @typedef {Object} EndpointDetails
+ * @property {string} [Username] - The username for the endpoint.
+ * @property {string | null} [Password] - The password for the endpoint (if using username/password authentication).
+ * @property {string | null} [Token] - The token for the endpoint (if using token authentication).
+ */
 
-var options = {
-    host: "api.bitbucket.org",
-    method: "GET",
-    path: "/2.0/repositories/" + repositoryId
+const BITBUCKET_API_TOKEN_AUTH_USERNAME = 'x-bitbucket-api-token-auth';
+
+const repositoryId = tl.getInputRequired('definition');
+const branch = tl.getInputRequired('branch');
+const commitId = tl.getInputRequired('version');
+const downloadPath = tl.getInputRequired('downloadPath');
+const bitbucketEndpoint = getEndpointDetails('connection');
+
+try {
+    removePathRecursive(downloadPath);
+} catch (error) {
+    tl.error(error);
+    process.exit(1);
+}
+
+const options = {
+    host: 'api.bitbucket.org',
+    method: 'GET',
+    path: '/2.0/repositories/' + repositoryId,
+    auth: ''
 };
 
 // Set authentication based on the endpoint type
@@ -31,29 +45,29 @@ if (bitbucketEndpoint.Token) {
 
 https.request(options, function (rs) {
     tl.debug(`HTTP status: ${rs.statusCode} ${rs.statusMessage}`);
-    var result;
-    var response = '';
+    let result;
+    let response = '';
     rs.on('data', function (data) {
-        tl.debug("repository details:" + data)
+        tl.debug('repository details:' + data)
         response += data
     });
     rs.on('end', function () {
         result = JSON.parse(response);
-        tl.debug("result:" + JSON.stringify(result));
-        var sch = new scw.SourceControlWrapper(result.scm);
+        tl.debug('result:' + JSON.stringify(result));
+        const sch = new scw.SourceControlWrapper(result.scm);
 
-        sch.on('stdout', function (data) {
+        sch.on('stdout', function (/** @type {{ toString: () => any; }} */ data) {
             console.log(data.toString());
         });
-        sch.on('stderr', function (data) {
+        sch.on('stderr', function (/** @type {{ toString: () => any; }} */ data) {
             console.log(data.toString());
         });
 
-        var remoteUrl = result.links.clone[0].href;
-        tl.debug("Remote Url:" + remoteUrl);
+        const remoteUrl = result.links.clone[0].href;
+        tl.debug('Remote Url:' + remoteUrl);
 
         // encodes projects and repo names with spaces
-        var repoUrl = url.parse(remoteUrl);
+        const repoUrl = url.parse(remoteUrl);
         if (bitbucketEndpoint.Token) {
             // For token authentication, use the token as password with API token auth username
             repoUrl.auth = BITBUCKET_API_TOKEN_AUTH_USERNAME + ':' + bitbucketEndpoint.Token;
@@ -61,19 +75,21 @@ https.request(options, function (rs) {
             repoUrl.auth = bitbucketEndpoint.Username + ':' + bitbucketEndpoint.Password;
         }
 
-        // if branch, we want to clone remote branch name to avoid tracking etc.. ('/refs/remotes/...')
-        var ref;
-        var brPre = 'refs/heads/';
+        /**
+         * @type {string | undefined} - If branch, we want to clone remote branch name to avoid tracking etc.. ('/refs/remotes/...')
+         */
+        let ref;
+        const brPre = 'refs/heads/';
+
         if (branch.startsWith(brPre)) {
             ref = 'refs/remotes/origin/' + branch.substr(brPre.length, branch.length - brPre.length);
-        }
-        else {
+        } else {
             ref = branch;
         }
 
-        var options = {
+        const options = {
             creds: true,
-            debugOutput: this.debugOutput
+            debugOutput: false
         };
         if (bitbucketEndpoint.Token) {
             sch.username = BITBUCKET_API_TOKEN_AUTH_USERNAME;
@@ -83,92 +99,37 @@ https.request(options, function (rs) {
             sch.password = bitbucketEndpoint.Password;
         }
 
-        Q(0).then(function (code) {
-            return sch.clone(repoUrl.format(repoUrl), false, downloadPath, options)
-                .then(function (code) {
-                    process.chdir(downloadPath);
-                    return sch.checkout(ref, options);
-                })
-                .then(function (code) {
-                    return sch.checkout(commitId);
-                })
-                .catch(function (error) {
-                    tl.error(error);
-                    tl.exit(1);
-                });
-        });
+        Promise.resolve()
+            .then(function () {
+                return sch.clone(url.format(repoUrl), false, downloadPath, options);
+            })
+            .then(function () {
+                process.chdir(downloadPath);
+                return sch.checkout(ref || '', options);
+            })
+            .then(function () {
+                return sch.checkout(commitId);
+            })
+            .catch(function (error) {
+                tl.error(error);
+                process.exit(1);
+            });
     });
 }).end();
 
-function getEndpointDetails(inputFieldName) {
-    var bitbucketEndpoint = tl.getInput(inputFieldName, true);
-    var auth = tl.getEndpointAuthorization(bitbucketEndpoint, false);
-    var scheme = auth.scheme.toLowerCase().trim();
-
-    if (scheme === "token") {
-        var token = getAuthParameter(bitbucketEndpoint, 'apitoken');
-        var username = getAuthParameter(bitbucketEndpoint, 'email') || '';
-        tl.debug('Using token authentication');
-        try {
-            tl.setSecret(token);
-        } catch (err) {
-            tl.warning('Failed to mask API token for log redaction.');
-        }
-        return {
-            "Token": token,
-            "Username": username
-        };
-    } else {
-        var hostUsername = getAuthParameter(bitbucketEndpoint, 'username');
-        var hostPassword = getAuthParameter(bitbucketEndpoint, 'password');
-        try {
-            tl.setSecret(hostPassword);
-        } catch (err) {
-            tl.warning('Failed to mask password for log redaction.');
-        }
-        tl.debug('hostUsername: ' + hostUsername);
-        return {
-            "Username": hostUsername,
-            "Password": hostPassword
-        };
-    }
-}
-
-function getAuthParameter(endpoint, paramName) {
-    var paramValue = null;
-    var auth = tl.getEndpointAuthorization(endpoint, false);
-    var scheme = auth.scheme.toLowerCase().trim();
-
-    if (scheme !== "usernamepassword" && scheme !== "token") {
-        throw new Error("The authorization scheme " + auth.scheme + " is not supported for a bitbucket endpoint. Please use either 'usernamepassword' or 'token'.");
-    }
-
-    var keyName = getCaseInsensitiveKeyMatch(auth['parameters'], paramName);
-    paramValue = auth['parameters'][keyName];
-
-    return paramValue;
-}
-
-function getCaseInsensitiveKeyMatch(data, paramName) {
-    var keyName;
-    var parameters = Object.getOwnPropertyNames(data);
-    parameters.some(function (key) {
-        if (key.toLowerCase() === paramName.toLowerCase()) {
-            keyName = key;
-            return true;
-        }
-    });
-
-    return keyName;
-}
-
+/**
+ * @todo Replace this method to the native fs.rmSync() method when we drop support of Node@6.
+ * Removes a file or directory recursively.
+ * @param {string} targetPath - The path to the file or directory to remove.
+ * @returns {void}
+ */
 function removePathRecursive(targetPath) {
     if (!targetPath || !fs.existsSync(targetPath)) {
         return;
     }
 
-    var stats = fs.lstatSync(targetPath);
-    if (!stats.isDirectory()) {
+    const stat = fs.lstatSync(targetPath);
+    if (!stat.isDirectory()) {
         fs.unlinkSync(targetPath);
         return;
     }
@@ -178,4 +139,72 @@ function removePathRecursive(targetPath) {
     });
 
     fs.rmdirSync(targetPath);
+}
+
+/**
+ * Gets the endpoint details for the given input field name.
+ * @param {string} inputFieldName - The name of the input field to get the endpoint details for.
+ * @returns {EndpointDetails} An object containing the endpoint details, including the username and either the password or token.
+ */
+function getEndpointDetails(inputFieldName) {
+    const bitbucketEndpoint = tl.getInputRequired(inputFieldName);
+    const auth = tl.getEndpointAuthorization(bitbucketEndpoint, false);
+    if (!auth || !auth.scheme) {
+        throw new Error('Failed to get authorization details for service connection ' + bitbucketEndpoint + '.');
+    }
+
+    const scheme = auth.scheme.toLowerCase().trim();
+
+    if (scheme === 'token') {
+        const token = getAuthParameter(bitbucketEndpoint, 'apitoken');
+        const username = getAuthParameter(bitbucketEndpoint, 'email') || '';
+        tl.debug('Using token authentication');
+        try {
+            // @ts-ignore since setSecret applies nullability
+            tl.setSecret(token);
+        } catch (e) {
+            tl.warning('Failed to mask API token for log redaction.');
+        }
+        return {
+            'Token': token,
+            'Username': username
+        };
+    } else {
+        const hostUsername = getAuthParameter(bitbucketEndpoint, 'username');
+        const hostPassword = getAuthParameter(bitbucketEndpoint, 'password');
+        try {
+            // @ts-ignore since setSecret applies nullability
+            tl.setSecret(hostPassword);
+        } catch (e) {
+            tl.warning('Failed to mask password for log redaction.');
+        }
+        tl.debug('hostUsername: ' + hostUsername);
+        return {
+            'Username': hostUsername,
+            'Password': hostPassword
+        };
+    }
+}
+
+/**
+ * Gets the value of the specified authorization parameter from the given endpoint.
+ * @param {*} endpoint - The endpoint from which to retrieve the authorization parameter.
+ * @param {*} paramName - The name of the authorization parameter to retrieve.
+ * @returns {string|undefined} The value of the authorization parameter, or undefined if not found.
+ */
+function getAuthParameter(endpoint, paramName) {
+    const auth = tl.getEndpointAuthorization(endpoint, false);
+
+    if (!auth || !auth.parameters) {
+        throw new Error('The endpoint ' + endpoint + ' does not have any authorization parameters.');
+    }
+
+    const scheme = auth.scheme.toLowerCase().trim();
+
+    if (scheme !== 'usernamepassword' && scheme !== 'token') {
+        throw new Error('The authorization scheme ' + auth.scheme + ' is not supported for a bitbucket endpoint. Please use either "usernamepassword" or "token".');
+    }
+
+    const keyName = Object.getOwnPropertyNames(auth['parameters']).find(function (x) { return x.toLowerCase() === paramName.toLowerCase(); });
+    return keyName ? auth['parameters'][keyName] : undefined;
 }

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/downloadBitbucket.js
@@ -199,6 +199,10 @@ function getAuthParameter(endpoint, paramName) {
         throw new Error('The endpoint ' + endpoint + ' does not have any authorization parameters.');
     }
 
+    if (auth.scheme === undefined) {
+        throw new Error('The endpoint ' + endpoint + ' does not have an authorization scheme defined.');
+    }
+
     const scheme = auth.scheme.toLowerCase().trim();
 
     if (scheme !== 'usernamepassword' && scheme !== 'token') {

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package-lock.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "DownloadArtifactsBitbucket",
       "dependencies": {
-        "azure-pipelines-task-lib": "^5.2.8"
+        "azure-pipelines-task-lib": "5.2.8"
       },
       "devDependencies": {
         "@types/node": "^6.14.13"
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.277.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
-      "integrity": "sha1-IzR+ExQL+R24uw1eROr0Nv+olTQ=",
+      "version": "5.2.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
+      "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -86,7 +86,8 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0"
+        "shelljs": "^0.10.0",
+        "uuid": "^3.0.1"
       }
     },
     "node_modules/balanced-match": {
@@ -621,6 +622,16 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha1-+fY5ENFVNu4rLV3UZlOJcV6sXB4=",
       "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package-lock.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package-lock.json
@@ -1,13 +1,15 @@
 {
   "name": "DownloadArtifactsBitbucket",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "DownloadArtifactsBitbucket",
       "dependencies": {
-        "azure-pipelines-task-lib": "^5.2.8",
-        "vso-node-api": "6.0.1-preview"
+        "azure-pipelines-task-lib": "^5.2.8"
+      },
+      "devDependencies": {
+        "@types/node": "^6.14.13"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -44,6 +46,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@types/node": {
+      "version": "6.14.13",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-6.14.13.tgz",
+      "integrity": "sha1-tmSVePwLXayIxO9IpGyrM8UKbHI=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/adm-zip": {
       "version": "0.5.16",
@@ -608,21 +617,6 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
-    "node_modules/tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
-    "node_modules/underscore": {
-      "version": "1.13.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.8.tgz",
-      "integrity": "sha1-qTohGGwEnb8OhHSW26cre9jB6Ss=",
-      "license": "MIT"
-    },
     "node_modules/utf8-byte-length": {
       "version": "1.0.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
@@ -639,17 +633,6 @@
         "uuid": "bin/uuid"
       }
     },
-    "node_modules/vso-node-api": {
-      "version": "6.0.1-preview",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/vso-node-api/-/vso-node-api-6.0.1-preview.tgz",
-      "integrity": "sha1-RBprv5s8aNpiTbAeo1y6jwpMLKs=",
-      "license": "MIT",
-      "dependencies": {
-        "q": "^1.0.1",
-        "tunnel": "0.0.4",
-        "underscore": "^1.8.3"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/which/-/which-2.0.2.tgz",
@@ -663,416 +646,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    }
-  },
-  "dependencies": {
-    "@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
-      "requires": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      }
-    },
-    "@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos="
-    },
-    "@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
-      "requires": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      }
-    },
-    "adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk="
-    },
-    "agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
-      "requires": {
-        "debug": "4"
-      }
-    },
-    "azure-pipelines-task-lib": {
-      "version": "5.2.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
-      "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
-      "requires": {
-        "adm-zip": "^0.5.10",
-        "minimatch": "^3.1.5",
-        "nodejs-file-downloader": "^4.11.1",
-        "q": "^1.5.1",
-        "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
-      }
-    },
-    "balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
-    },
-    "brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "braces": {
-      "version": "3.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k=",
-      "requires": {
-        "fill-range": "^7.1.1"
-      }
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
-      "requires": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      }
-    },
-    "debug": {
-      "version": "4.4.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha1-5ai8bLxMbNPmQwiwaTo9T6VQGJs=",
-      "requires": {
-        "ms": "^2.1.3"
-      }
-    },
-    "execa": {
-      "version": "5.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
-      "requires": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      }
-    },
-    "fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha1-0G1YXOjbqQoWsFBcVDw8z7OuuBg=",
-      "requires": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      }
-    },
-    "fastq": {
-      "version": "1.19.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha1-1Q6rqAPIhGqIPBZJKCHrzSzaVfU=",
-      "requires": {
-        "reusify": "^1.0.4"
-      }
-    },
-    "fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI=",
-      "requires": {
-        "to-regex-range": "^5.0.1"
-      }
-    },
-    "follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha1-d31z1yqS+OxNLkEOtHNSpWuOg0A="
-    },
-    "get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c="
-    },
-    "glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
-      "requires": {
-        "is-glob": "^4.0.1"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
-      "requires": {
-        "agent-base": "6",
-        "debug": "4"
-      }
-    },
-    "human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA="
-    },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-    },
-    "is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
-    },
-    "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
-    },
-    "is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc="
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A="
-    },
-    "merge2": {
-      "version": "1.4.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4="
-    },
-    "micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha1-1m+hjzpHB2eJMgubGvMr2G2fogI=",
-      "requires": {
-        "braces": "^3.0.3",
-        "picomatch": "2.3.2"
-      }
-    },
-    "mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A="
-    },
-    "mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
-      "requires": {
-        "mime-db": "1.52.0"
-      }
-    },
-    "mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs="
-    },
-    "minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
-    "ms": {
-      "version": "2.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
-    },
-    "nodejs-file-downloader": {
-      "version": "4.13.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
-      "integrity": "sha1-2ofDAIHeX/TouGQGLJjN7APmatA=",
-      "requires": {
-        "follow-redirects": "^1.15.6",
-        "https-proxy-agent": "^5.0.0",
-        "mime-types": "^2.1.27",
-        "sanitize-filename": "^1.6.3"
-      }
-    },
-    "npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
-      "requires": {
-        "path-key": "^3.0.0"
-      }
-    },
-    "onetime": {
-      "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
-      "requires": {
-        "mimic-fn": "^2.1.0"
-      }
-    },
-    "path-key": {
-      "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U="
-    },
-    "picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE="
-    },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-    },
-    "queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM="
-    },
-    "reusify": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha1-D+E7lSLhRz9RtVjueW4I8R+bSJ8="
-    },
-    "run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
-      "requires": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
-    "sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha1-dV69dSBFkxl34wsgJdNA18kJA3g=",
-      "requires": {
-        "truncate-utf8-bytes": "^1.0.0"
-      }
-    },
-    "semver": {
-      "version": "5.7.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg="
-    },
-    "shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
-      "requires": {
-        "shebang-regex": "^3.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI="
-    },
-    "shelljs": {
-      "version": "0.10.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.10.0.tgz",
-      "integrity": "sha1-47uumbDz8MxdzgW0ajRvriCQ6IM=",
-      "requires": {
-        "execa": "^5.1.1",
-        "fast-glob": "^3.3.2"
-      }
-    },
-    "signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk="
-    },
-    "strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0="
-    },
-    "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
-      "requires": {
-        "is-number": "^7.0.0"
-      }
-    },
-    "truncate-utf8-bytes": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
-      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
-      "requires": {
-        "utf8-byte-length": "^1.0.1"
-      }
-    },
-    "tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
-    },
-    "underscore": {
-      "version": "1.13.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.8.tgz",
-      "integrity": "sha1-qTohGGwEnb8OhHSW26cre9jB6Ss="
-    },
-    "utf8-byte-length": {
-      "version": "1.0.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
-      "integrity": "sha1-+fY5ENFVNu4rLV3UZlOJcV6sXB4="
-    },
-    "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
-    },
-    "vso-node-api": {
-      "version": "6.0.1-preview",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/vso-node-api/-/vso-node-api-6.0.1-preview.tgz",
-      "integrity": "sha1-RBprv5s8aNpiTbAeo1y6jwpMLKs=",
-      "requires": {
-        "q": "^1.0.1",
-        "tunnel": "0.0.4",
-        "underscore": "1.13.8"
-      }
-    },
-    "which": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/which/-/which-2.0.2.tgz",
-      "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
-      "requires": {
-        "isexe": "^2.0.0"
       }
     }
   }

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package-lock.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package-lock.json
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
-      "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
+      "version": "5.277.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
+      "integrity": "sha1-IzR+ExQL+R24uw1eROr0Nv+olTQ=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -86,8 +86,7 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/balanced-match": {
@@ -97,9 +96,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
+      "version": "1.1.16",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -216,9 +215,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha1-d31z1yqS+OxNLkEOtHNSpWuOg0A=",
+      "version": "1.16.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha1-KEdKFZ07nRHvYgUKFO1g5N9tYbw=",
       "funding": [
         {
           "type": "individual",
@@ -622,16 +621,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha1-+fY5ENFVNu4rLV3UZlOJcV6sXB4=",
       "license": "(WTFPL OR MIT)"
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package.json
@@ -2,7 +2,7 @@
   "name": "DownloadArtifactsBitbucket",
   "main": "download.js",
   "dependencies": {
-    "azure-pipelines-task-lib": "^5.2.8"
+    "azure-pipelines-task-lib": "5.2.8"
   },
   "devDependencies": {
     "@types/node": "^6.14.13"

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package.json
@@ -2,11 +2,9 @@
   "name": "DownloadArtifactsBitbucket",
   "main": "download.js",
   "dependencies": {
-    "azure-pipelines-task-lib": "^5.2.8",
-    "vso-node-api": "6.0.1-preview"
+    "azure-pipelines-task-lib": "^5.2.8"
   },
-  "overrides": {
-    "underscore": "1.13.8",
-    "picomatch": "2.3.2"
+  "devDependencies": {
+    "@types/node": "^6.14.13"
   }
 }

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/sourcecontrolwrapper.js
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/sourcecontrolwrapper.js
@@ -1,27 +1,39 @@
-"use strict";
+const tl = require('azure-pipelines-task-lib/task');
+const events = require('events');
 
-var tl = require('azure-pipelines-task-lib/task');
-var events = require('events');
-var Q = require('q');
-var path = require('path');
+/**
+ * @typedef {Object} ExecOptions
+ * @property {boolean} [creds]
+ * @property {boolean} [debugOutput]
+ * @property {string} [cwd]
+ * @property {NodeJS.ProcessEnv} [env]
+ * @property {NodeJS.WritableStream} [outStream]
+ * @property {NodeJS.WritableStream} [errStream]
+ */
 
-var __extends = (this && this.__extends) || function (d, b) {
-    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
-    function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-};
-
-var SourceControlWrapper = (function (_super) {
-    __extends(SourceControlWrapper, _super);
-    function SourceControlWrapper(toolType) {
-        _super.call(this);
+class SourceControlWrapper extends events.EventEmitter {
+    /**
+     * @param {string} toolType
+     */
+    constructor(toolType) {
+        super();
         this.toolType = toolType;
+        /** @type {string | undefined} */
+        this.username = undefined;
+        /** @type {string | undefined} */
+        this.password = undefined;
     }
 
-    SourceControlWrapper.prototype.clone = function (repository, progress, folder, options) {
+    /**
+     * @param {string} repository
+     * @param {boolean} progress
+     * @param {string | undefined} folder
+     * @param {ExecOptions | undefined} options
+     */
+    clone(repository, progress, folder, options) {
         options = options || {};
         options.creds = true;
-        var args = ['clone', repository];
+        const args = ['clone', repository];
         if (progress) {
             args.push('--progress');
         }
@@ -29,74 +41,92 @@ var SourceControlWrapper = (function (_super) {
             args.push(folder);
         }
         return this.exec(args, options);
-    };
+    }
 
-    SourceControlWrapper.prototype.fetch = function (args, options) {
+    /**
+     * @param {string[]} args
+     * @param {ExecOptions | undefined} options
+     */
+    fetch(args, options) {
         options = options || {};
         options.creds = true;
         return this.exec(['fetch'].concat(args), options);
-    };
+    }
 
-    SourceControlWrapper.prototype.checkout = function (ref, options) {
+    /**
+     * @param {string} ref
+     * @param {ExecOptions} [options]
+     */
+    checkout(ref, options) {
         options = options || {};
         options.creds = true;
         return this.exec(['checkout', ref], options);
-    };
+    }
 
-    SourceControlWrapper.prototype.reset = function (args, options) {
+    /**
+     * @param {string[]} args
+     * @param {ExecOptions | undefined} options
+     */
+    reset(args, options) {
         options = options || {};
         return this.exec(['reset'].concat(args), options);
-    };
+    }
 
-    SourceControlWrapper.prototype.exec = function (args, options) {
-        var _this = this;
-        options = options || {};
-        var defer = Q.defer();
+    /**
+     * @param {string[]} args
+     * @param {ExecOptions | undefined} options
+     */
+    exec(args, options) {
+        const self = this;
+        const execOptions = options || {};
 
-        var toolPath = tl.which(this.toolType, false);
-        if (!toolPath) {
+        /** @type {string} */
+        let toolPath;
+        try {
+            toolPath = tl.which(this.toolType, true);
+        } catch (e) {
             throw (new Error(this.toolType + ' not found.  ensure installed and in the path'));
         }
-        var tool = tl.tool(toolPath.toString());
-        var creds = this.username + ':' + this.password;
-        var escapedCreds = encodeURIComponent(this.username) + ':' + encodeURIComponent(this.password);
+        const tool = tl.tool(toolPath.toString());
+        const username = this.username || '';
+        const password = this.password || '';
+        const creds = username + ':' + password;
+        const escapedCreds = encodeURIComponent(username) + ':' + encodeURIComponent(password);
         try {
-            tl.setSecret(this.password);
+            tl.setSecret(password);
             tl.setSecret(escapedCreds);
-        } catch (err) {
+        } catch (e) {
             tl.warning('Failed to mask credentials for log redaction.');
         }
-        tool.on('debug', function (message) {
-            if (options.debugOutput) {
-                var repl = message.replace(creds, '...');
-                repl = message.replace(escapedCreds, '...');
-                _this.emit('stdout', '[debug]' + repl);
+        tool.on('debug', function (/** @type {string} */ message) {
+            if (execOptions.debugOutput) {
+                let repl = message.replace(creds, '...').replace(escapedCreds, '...');
+                self.emit('stdout', '[debug]' + repl);
             }
         });
-        tool.on('stdout', function (data) {
-            _this.emit('stdout', data);
+        tool.on('stdout', function (/** @type {Buffer | string} */ data) {
+            self.emit('stdout', data);
         });
-        tool.on('stderr', function (data) {
-            _this.emit('stderr', data);
-        });
-
-        args.map(function (arg) {
-            tool.arg(arg, true); // raw arg
+        tool.on('stderr', function (/** @type {Buffer | string} */ data) {
+            self.emit('stderr', data);
         });
 
-        options = options || {};
-        var ops = {
-            cwd: options.cwd || process.cwd(),
-            env: options.env || process.env,
+        args.forEach(function (/** @type {string} */ arg) {
+            tool.arg(arg);
+        });
+
+        const ops = {
+            cwd: execOptions.cwd || process.cwd(),
+            env: execOptions.env || process.env,
             silent: true,
-            outStream: options.outStream || process.stdout,
-            errStream: options.errStream || process.stderr,
+            outStream: execOptions.outStream || process.stdout,
+            errStream: execOptions.errStream || process.stderr,
             failOnStdErr: false,
             ignoreReturnCode: false
         };
 
         return tool.exec(ops);
-    };
-    return SourceControlWrapper;
-}(events.EventEmitter));
+    }
+}
+
 exports.SourceControlWrapper = SourceControlWrapper;

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/sourcecontrolwrapper.js
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/sourcecontrolwrapper.js
@@ -125,7 +125,7 @@ class SourceControlWrapper extends events.EventEmitter {
             ignoreReturnCode: false
         };
 
-        return tool.exec(ops);
+        return tool.execAsync(ops);
     }
 }
 

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 15,
     "Minor": 277,
-    "Patch": 5
+    "Patch": 6
   },
   "minimumAgentVersion": "1.99.0",
   "instanceNameFormat": "Download Artifacts - Bitbucket",

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 15,
     "Minor": 277,
-    "Patch": 0
+    "Patch": 5
   },
   "minimumAgentVersion": "1.99.0",
   "instanceNameFormat": "Download Artifacts - Bitbucket",

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
@@ -13,7 +13,7 @@
   "demands": [],
   "version": {
     "Major": 15,
-    "Minor": 274,
+    "Minor": 277,
     "Patch": 0
   },
   "minimumAgentVersion": "1.99.0",

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/tsconfig.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "target": "ES6",
+        "module": "commonjs",
+        "esModuleInterop": true,
+        "types": ["node"],
+        "moduleResolution": "node",
+        "skipLibCheck": true,
+        "noEmit": true,
+        "checkJs": true,
+        "useUnknownInCatchVariables": false,
+        "strict": true,
+        "noUncheckedIndexedAccess": true,
+        "exactOptionalPropertyTypes": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noFallthroughCasesInSwitch": true
+    },
+    "include": [
+        "*.js"
+    ]
+}

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.277.0",
+  "version": "15.277.1",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.277.1",
+  "version": "15.277.5",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.277.5",
+  "version": "15.277.6",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/_suite.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/_suite.ts
@@ -359,7 +359,7 @@ describe('SourceControlWrapper Unit Suite', function () {
             return {
                 on: function (name: string, cb: Function): void { handlers[name] = cb; },
                 arg: function (value: string): void { seenArgs.push(value); },
-                exec: function (ops: any): Promise<number> {
+                execAsync: function (ops: any): Promise<number> {
                     seenExecOps = ops;
                     handlers.debug('run https://u:p@bitbucket.org/org/repo.git and u%3Ap');
                     handlers.stdout(new Buffer('stdout-line'));
@@ -428,7 +428,7 @@ describe('SourceControlWrapper Unit Suite', function () {
             return {
                 on: function (name: string, cb: Function): void { handlers[name] = cb; },
                 arg: function (): void { return; },
-                exec: function (): Promise<number> {
+                execAsync: function (): Promise<number> {
                     handlers.debug('contains-userpass u:p and u%3Ap');
                     return Promise.resolve(0);
                 }
@@ -464,7 +464,7 @@ describe('SourceControlWrapper Unit Suite', function () {
             return {
                 on: function (): void { return; },
                 arg: function (): void { return; },
-                exec: function (ops: any): Promise<number> {
+                execAsync: function (ops: any): Promise<number> {
                     capturedOps = ops;
                     return Promise.resolve(0);
                 }
@@ -516,7 +516,7 @@ describe('SourceControlWrapper Unit Suite', function () {
             return {
                 on: function (): void { return; },
                 arg: function (): void { return; },
-                exec: function (): Promise<number> { return Promise.resolve(0); }
+                execAsync: function (): Promise<number> { return Promise.resolve(0); }
             };
         };
 
@@ -546,7 +546,7 @@ describe('SourceControlWrapper Unit Suite', function () {
             return {
                 on: function (): void { return; },
                 arg: function (): void { return; },
-                exec: function (): Promise<number> {
+                execAsync: function (): Promise<number> {
                     return Promise.reject(new Error('simulated exec failure'));
                 }
             };

--- a/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/_suite.ts
+++ b/Extensions/BitBucket/Tests/Tasks/DownloadArtifactsBitbucket/_suite.ts
@@ -199,29 +199,31 @@ describe('DownloadArtifactsBitbucket Suite', function () {
                 assert(hasAuthError, 'should report a missing endpoint authorization failure');
             });
 
-            it('continues when token auth parameter is missing', async function () {
+            it('fails when token auth parameter is missing', async function () {
                 const runner = newRunner('failMissingAuthParameter');
                 await runAndDump(runner, nodeVersion);
-                if (!runner.succeeded) fail(runner, 'expected task to continue when apitoken parameter is absent');
+                if (runner.succeeded) fail(runner, 'expected task to fail when apitoken parameter is absent');
 
-                assert(runner.stdOutContained('[mock-https] request /2.0/repositories/workspace/repo authUser='), 'should call the API without an auth username when token is absent');
-                assert(runner.stdOutContained('[mock-scw] auth user=token-user@example.com passSet=false'), 'should forward missing token as an unset clone password');
+                assert(runner.stdOutContained('does not have an API token parameter'), 'should surface missing API token failure');
+                assert(!runner.stdOutContained('[mock-https] request'), 'should not call the API when token is missing');
             });
 
-            it('continues when required username/password auth parameter is missing', async function () {
+            it('fails when required password auth parameter is missing', async function () {
                 const runner = newRunner('failMissingPasswordParameter');
                 await runAndDump(runner, nodeVersion);
-                if (!runner.succeeded) fail(runner, 'expected task to continue when password parameter is absent');
+                if (runner.succeeded) fail(runner, 'expected task to fail when password parameter is absent');
 
-                assert(runner.stdOutContained('[mock-scw] auth user=bb-user passSet=false'), 'should forward the username with an unset password');
+                assert(runner.stdOutContained('does not have the required username and password parameters'), 'should surface missing username/password failure');
+                assert(!runner.stdOutContained('[mock-https] request'), 'should not call the API when password is missing');
             });
 
-            it('continues when required username parameter is missing', async function () {
+            it('fails when required username parameter is missing', async function () {
                 const runner = newRunner('failMissingUsernameParameter');
                 await runAndDump(runner, nodeVersion);
-                if (!runner.succeeded) fail(runner, 'expected task to continue when username parameter is absent');
+                if (runner.succeeded) fail(runner, 'expected task to fail when username parameter is absent');
 
-                assert(runner.stdOutContained('[mock-scw] auth user=undefined passSet=true'), 'should forward an undefined username with the configured password');
+                assert(runner.stdOutContained('does not have the required username and password parameters'), 'should surface missing username/password failure');
+                assert(!runner.stdOutContained('[mock-https] request'), 'should not call the API when username is missing');
             });
 
             it('fails when endpoint auth object is present but has no scheme', async function () {


### PR DESCRIPTION
- Refactors the Bitbucket Download Artifacts task (`downloadBitbucket.js`, `sourcecontrolwrapper.js`) to modernize the source: `var` → `const`/`let`, JSDoc type annotations, `tl.getInput(x, true)` → `tl.getInputRequired(x)`, and deprecated `repoUrl.format(repoUrl)` → `url.format(repoUrl)`.
- Hardens error handling throughout: `removePathRecursive` and the Bitbucket API response parsing are now wrapped in try/catch and fail the task via `tl.setResult(tl.TaskResult.Failed, ...)` instead of silently continuing; the task now validates the API HTTP status code, the presence of a repository clone URL, and the endpoint authorization scheme/parameters - failing fast instead of proceeding with `undefined` credentials.
- Converts `SourceControlWrapper` to a native ES6 `class ... extends events.EventEmitter` (removing the old TS-style `__extends` polyfill), drops the `Q` library in favor of native `Promise`s, and renames `exec` → `execAsync` for consistency with the underlying `azure-pipelines-task-lib` API. This also fixes a latent double-`.replace()` masking bug (now correctly chains `.replace(creds, '...').replace(escapedCreds, '...')`).
- Removes the unused `vso-node-api` dependency and the `underscore`/`picomatch` `overrides` pins from `package.json`/`package-lock.json` (bumping `lockfileVersion` 2→3), and adds `@types/node` as a devDependency.
- Adds a new `tsconfig.json` enabling strict `checkJs` type-checking over the plain `.js` files.
- Updates unit tests to match the new fail-fast auth validation behavior (missing token/username/password now fail the task instead of continuing) and to mock the renamed `execAsync`.
- Bumps task version to 15.277 and extension version to 15.277.1.

**Description**: Modernizes the Bitbucket Download Artifacts task source (ES6 classes, JSDoc/strict `checkJs`), hardens error handling so invalid or missing auth/API responses fail the task instead of continuing silently, and trims unused dependencies.

**Documentation changes required:** N

**Added unit tests:** Y — existing tests updated to cover the new fail-fast validation and the `execAsync` rename

**Attached related issue:** AB#2429504

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected. (CI green: CodeQL, Analyze, license/cla pass; ADO build still running with no failures.)
