### PR TITLE
Use internal feed to install tfx and gulp

### DIFF
--- a/.pipelines/1es-migration/azure-pipelines-integration.yml
+++ b/.pipelines/1es-migration/azure-pipelines-integration.yml
@@ -91,12 +91,6 @@ extends:
         - script: echo "##vso[task.prependpath]$(Build.SourcesDirectory)/node_modules/.bin"
           displayName: 'Add node_modules/.bin to PATH'
 
-        - task: Npm@1
-          displayName: 'Install Gulp CLI'
-          inputs:
-            command: custom
-            customCommand: 'install -g gulp-cli --registry https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/'
-
         - script: gulp detectChangedExtensions
           name: DetectExtensions
           displayName: 'Auto-detect changed extensions'

--- a/.pipelines/1es-migration/azure-pipelines-integration.yml
+++ b/.pipelines/1es-migration/azure-pipelines-integration.yml
@@ -88,11 +88,8 @@ extends:
             command: install
             verbose: false
 
-        - task: Npm@1
-          displayName: 'Install TFX CLI'
-          inputs:
-            command: custom
-            customCommand: 'install -g tfx-cli --registry https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/'
+        - script: echo "##vso[task.prependpath]$(Build.SourcesDirectory)/node_modules/.bin"
+          displayName: 'Add node_modules/.bin to PATH'
 
         - task: Npm@1
           displayName: 'Install Gulp CLI'
@@ -201,10 +198,12 @@ extends:
             workingFile: '$(Build.SourcesDirectory)/.npmrc'
 
         - task: Npm@1
-          displayName: 'Install TFX CLI'
+          displayName: 'Install dependencies'
           inputs:
-            command: custom
-            customCommand: 'install -g tfx-cli --registry https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/'
+            command: 'ci'
+
+        - script: echo "##vso[task.prependpath]$(Build.SourcesDirectory)/node_modules/.bin"
+          displayName: 'Add node_modules/.bin to PATH'
 
         - task: AzureCLI@2
           displayName: 'Publish all test extensions (unsigned)'

--- a/.pipelines/1es-migration/azure-pipelines-integration.yml
+++ b/.pipelines/1es-migration/azure-pipelines-integration.yml
@@ -88,7 +88,9 @@ extends:
             command: install
             verbose: false
 
-        - script: echo "##vso[task.prependpath]$(Build.SourcesDirectory)/node_modules/.bin"
+        - pwsh: |
+            $binPath = Join-Path "$(Build.SourcesDirectory)" "node_modules" ".bin"
+            Write-Host "##vso[task.prependpath]$binPath"
           displayName: 'Add node_modules/.bin to PATH'
 
         - script: gulp detectChangedExtensions
@@ -196,7 +198,9 @@ extends:
           inputs:
             command: 'ci'
 
-        - script: echo "##vso[task.prependpath]$(Build.SourcesDirectory)/node_modules/.bin"
+        - pwsh: |
+            $binPath = Join-Path "$(Build.SourcesDirectory)" "node_modules" ".bin"
+            Write-Host "##vso[task.prependpath]$binPath"
           displayName: 'Add node_modules/.bin to PATH'
 
         - task: AzureCLI@2

--- a/.pipelines/1es-migration/azure-pipelines.yml
+++ b/.pipelines/1es-migration/azure-pipelines.yml
@@ -115,17 +115,10 @@ extends:
             command: install
             verbose: false
 
-        - task: Npm@1
-          displayName: 'Install TFX CLI (needed for publishing on Marketplace)'
-          inputs:
-            command: custom
-            customCommand: 'install -g tfx-cli --registry https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/'
-
-        - task: Npm@1
-          displayName: 'Install Gulp CLI'
-          inputs:
-            command: custom
-            customCommand: 'install -g gulp-cli --registry https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/'
+        - pwsh: |
+            $binPath = Join-Path "$(Build.SourcesDirectory)" "node_modules" ".bin"
+            Write-Host "##vso[task.prependpath]$binPath"
+          displayName: 'Add node_modules/.bin to PATH'
 
         - task: PowerShell@2
           displayName: 'Build PROD resources'
@@ -295,11 +288,26 @@ extends:
             inputs:
               versionSpec: '20.x'
 
-          - task: Npm@1
-            displayName: 'Install TFX CLI'
+          - checkout: self
+            displayName: 'Checkout repository'
+            clean: true
+            fetchTags: false
+
+          - task: NpmAuthenticate@0
+            displayName: 'Authenticate npm with internal CFS-upstream feed'
             inputs:
-              command: custom
-              customCommand: 'install -g tfx-cli --registry https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/'
+              workingFile: '$(Build.SourcesDirectory)/.npmrc'
+
+          - task: Npm@1
+            displayName: 'Install dependencies'
+            inputs:
+              command: install
+              verbose: false
+
+          - pwsh: |
+              $binPath = Join-Path "$(Build.SourcesDirectory)" "node_modules" ".bin"
+              Write-Host "##vso[task.prependpath]$binPath"
+            displayName: 'Add node_modules/.bin to PATH'
 
           - task: 1ES.PublishAzureDevOpsExtension@1
             name: PublishTestExtensionToMarketplace
@@ -409,11 +417,26 @@ extends:
           inputs:
             versionSpec: '20.x'
 
-        - task: Npm@1
-          displayName: 'Install TFX CLI'
+        - checkout: self
+          displayName: 'Checkout repository'
+          clean: true
+          fetchTags: false
+
+        - task: NpmAuthenticate@0
+          displayName: 'Authenticate npm with internal CFS-upstream feed'
           inputs:
-            command: custom
-            customCommand: 'install -g tfx-cli --registry https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/'
+            workingFile: '$(Build.SourcesDirectory)/.npmrc'
+
+        - task: Npm@1
+          displayName: 'Install dependencies'
+          inputs:
+            command: install
+            verbose: false
+
+        - pwsh: |
+            $binPath = Join-Path "$(Build.SourcesDirectory)" "node_modules" ".bin"
+            Write-Host "##vso[task.prependpath]$binPath"
+          displayName: 'Add node_modules/.bin to PATH'
 
         - task: 1ES.PublishAzureDevOpsExtension@1
           name: PublishProdExtensionToMarketplace

--- a/.pipelines/1es-migration/azure-pipelines.yml
+++ b/.pipelines/1es-migration/azure-pipelines.yml
@@ -295,10 +295,11 @@ extends:
             inputs:
               versionSpec: '20.x'
 
-          - task: TfxInstaller@5
-            displayName: 'Install TFX'
+          - task: Npm@1
+            displayName: 'Install TFX CLI'
             inputs:
-              version: 'v0.21.1'
+              command: custom
+              customCommand: 'install -g tfx-cli --registry https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/'
 
           - task: 1ES.PublishAzureDevOpsExtension@1
             name: PublishTestExtensionToMarketplace
@@ -408,10 +409,11 @@ extends:
           inputs:
             versionSpec: '20.x'
 
-        - task: TfxInstaller@5
-          displayName: 'Install TFX'
+        - task: Npm@1
+          displayName: 'Install TFX CLI'
           inputs:
-            version: 'v0.21.1'
+            command: custom
+            customCommand: 'install -g tfx-cli --registry https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/'
 
         - task: 1ES.PublishAzureDevOpsExtension@1
           name: PublishProdExtensionToMarketplace

--- a/.pipelines/1es-migration/azure-pipelines.yml
+++ b/.pipelines/1es-migration/azure-pipelines.yml
@@ -118,8 +118,7 @@ extends:
         - pwsh: |
             $binPath = Join-Path "$(Build.SourcesDirectory)" "node_modules" ".bin"
             Write-Host "##vso[task.prependpath]$binPath"
-            Write-Host "##vso[task.setvariable variable=__tfxpath]$binPath"
-          displayName: 'Add node_modules/.bin to PATH and set __tfxpath'
+          displayName: 'Add node_modules/.bin to PATH
 
         - task: PowerShell@2
           displayName: 'Build PROD resources'

--- a/.pipelines/1es-migration/azure-pipelines.yml
+++ b/.pipelines/1es-migration/azure-pipelines.yml
@@ -118,7 +118,8 @@ extends:
         - pwsh: |
             $binPath = Join-Path "$(Build.SourcesDirectory)" "node_modules" ".bin"
             Write-Host "##vso[task.prependpath]$binPath"
-          displayName: 'Add node_modules/.bin to PATH'
+            Write-Host "##vso[task.setvariable variable=__tfxpath]$binPath"
+          displayName: 'Add node_modules/.bin to PATH and set __tfxpath'
 
         - task: PowerShell@2
           displayName: 'Build PROD resources'

--- a/.pipelines/1es-migration/azure-pipelines.yml
+++ b/.pipelines/1es-migration/azure-pipelines.yml
@@ -307,7 +307,8 @@ extends:
           - pwsh: |
               $binPath = Join-Path "$(Build.SourcesDirectory)" "node_modules" ".bin"
               Write-Host "##vso[task.prependpath]$binPath"
-            displayName: 'Add node_modules/.bin to PATH'
+              Write-Host "##vso[task.setvariable variable=__tfxpath]$binPath"
+            displayName: 'Add node_modules/.bin to PATH and set __tfxpath'
 
           - task: 1ES.PublishAzureDevOpsExtension@1
             name: PublishTestExtensionToMarketplace
@@ -436,7 +437,8 @@ extends:
         - pwsh: |
             $binPath = Join-Path "$(Build.SourcesDirectory)" "node_modules" ".bin"
             Write-Host "##vso[task.prependpath]$binPath"
-          displayName: 'Add node_modules/.bin to PATH'
+            Write-Host "##vso[task.setvariable variable=__tfxpath]$binPath"
+          displayName: 'Add node_modules/.bin to PATH and set __tfxpath'
 
         - task: 1ES.PublishAzureDevOpsExtension@1
           name: PublishProdExtensionToMarketplace

--- a/.pipelines/1es-migration/azure-pipelines.yml
+++ b/.pipelines/1es-migration/azure-pipelines.yml
@@ -288,11 +288,6 @@ extends:
             inputs:
               versionSpec: '20.x'
 
-          - checkout: self
-            displayName: 'Checkout repository'
-            clean: true
-            fetchTags: false
-
           - task: NpmAuthenticate@0
             displayName: 'Authenticate npm with internal CFS-upstream feed'
             inputs:
@@ -417,11 +412,6 @@ extends:
           displayName: 'Use Node.js 20.x'
           inputs:
             versionSpec: '20.x'
-
-        - checkout: self
-          displayName: 'Checkout repository'
-          clean: true
-          fetchTags: false
 
         - task: NpmAuthenticate@0
           displayName: 'Authenticate npm with internal CFS-upstream feed'

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.278.6",
+  "version": "0.279.1",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.278.5",
+  "version": "0.278.6",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.1",
+  "version": "0.279.2",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.7",
+  "version": "0.279.8",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.6",
+  "version": "0.279.7",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.5",
+  "version": "0.279.7",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.3",
+  "version": "15.279.4",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.278.6",
+  "version": "15.279.3",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.278.5",
+  "version": "15.278.6",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.12",
+  "version": "15.279.13",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.11",
+  "version": "15.279.12",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.6",
+  "version": "15.279.11",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.13",
+  "version": "15.279.14",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.278.5",
+  "version": "16.278.6",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.278.6",
+  "version": "16.279.1",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.1",
+  "version": "16.279.3",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.7",
+  "version": "16.279.8",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.5",
+  "version": "16.279.7",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.1",
+  "version": "1.279.3",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.278.5",
+  "version": "1.278.6",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.278.6",
+  "version": "1.279.1",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.8",
+  "version": "1.279.9",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.5",
+  "version": "1.279.8",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.278.11",
+  "version": "4.278.12",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.279.1",
+  "version": "4.279.3",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.278.12",
+  "version": "4.279.1",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.279.8",
+  "version": "4.279.9",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.279.7",
+  "version": "4.279.8",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.2",
+  "version": "15.279.3",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.1",
+  "version": "15.279.2",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.278.5",
+  "version": "15.278.6",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.8",
+  "version": "15.279.11",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.7",
+  "version": "15.279.9",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,11 +20,13 @@
         "adm-zip": "0.4.11",
         "azure-pipelines-task-lib": "5.2.8",
         "gulp": "^5.0.1",
+        "gulp-cli": "^3.0.0",
         "gulp-mocha": "^10.0.1",
         "gulp-typescript": "^5.0.1",
         "minimatch": "3.1.5",
         "shelljs": "^0.10.0",
         "sync-request": "3.0.1",
+        "tfx-cli": "^0.21.1",
         "through2": "^2.0.1",
         "typescript": "^4.9.5",
         "validator": "^13.15.22",
@@ -33,6 +35,16 @@
       "engines": {
         "node": ">=20.0.0",
         "npm": ">=10.8.2"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha1-u1BFecHK6SPmV2pPXaQ9Jfl729k=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@gulpjs/messages": {
@@ -295,6 +307,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/app-root-path": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/app-root-path/-/app-root-path-1.0.0.tgz",
+      "integrity": "sha1-LHKZF0vGHLhv46SnmOAeSTt9U30=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/append-buffer": {
       "version": "1.0.2",
       "dev": true,
@@ -304,6 +323,102 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/archiver": {
+      "version": "2.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/archiver/-/archiver-2.0.3.tgz",
+      "integrity": "sha1-tDYLtYSvFDeZGUJxbyHXxSPR270=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^1.3.0",
+        "async": "^2.0.0",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.0.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0",
+        "tar-stream": "^1.5.0",
+        "walkdir": "^0.0.11",
+        "zip-stream": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "1.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/archiver-utils/-/archiver-utils-1.3.0.tgz",
+      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.0.0",
+        "graceful-fs": "^4.1.0",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.8.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/archiver/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/argparse": {
@@ -329,6 +444,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha1-OE0So3KVrsN2mrAirTI6GKUcz4s=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-each": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/array-each/-/array-each-1.0.1.tgz",
@@ -349,6 +481,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/array.prototype.reduce": {
+      "version": "1.0.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/array.prototype.reduce/-/array.prototype.reduce-1.0.8.tgz",
+      "integrity": "sha1-Qvl/UHja7cpofURj/TwFy/2D2lc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "is-string": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha1-nXYNhNvdBtDL+SyISWFaGnqzGDw=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/asap": {
       "version": "2.0.6",
       "dev": true,
@@ -360,6 +537,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/async/-/async-2.6.4.tgz",
+      "integrity": "sha1-cGt/9ghGZM1+rnE/b5ZUM7VQQiE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
       }
     },
     "node_modules/async-done": {
@@ -374,6 +561,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha1-UJyfymDq+FA0xoKYOBiOTkyP+ys=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/async-settle": {
@@ -402,6 +599,36 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha1-pcw3XWoDwu/IelU/PgsVIt7xSEY=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/azure-devops-node-api": {
+      "version": "14.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-14.1.0.tgz",
+      "integrity": "sha1-7FOT3p+hRjmd6qtpBOQdoD7c4YA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "2.1.0"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/azure-pipelines-task-lib": {
@@ -621,6 +848,34 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha1-iQ3ZDZI6hz4I4Q5f1RpX5bfM4Ow=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha1-vX3CauKXLQ7aJTvgYdupkjScGfA=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/buffer-equal": {
       "version": "1.0.1",
       "dev": true,
@@ -631,6 +886,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -717,6 +979,24 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/clipboardy": {
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/clipboardy/-/clipboardy-4.0.0.tgz",
+      "integrity": "sha1-5zztk6dtGd03nr8fKXVlQm3/3KE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^8.0.1",
+        "is-wsl": "^3.1.0",
+        "is64bit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/clone": {
       "version": "2.1.2",
       "dev": true,
@@ -746,6 +1026,45 @@
         "inherits": "^2.0.1",
         "process-nextick-args": "^2.0.0",
         "readable-stream": "^2.3.5"
+      }
+    },
+    "node_modules/colors": {
+      "version": "1.3.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha1-OeAF1Uav4B4B+cTKj6UPaGoBIF0=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "1.2.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/compress-commons/-/compress-commons-1.2.2.tgz",
+      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.1",
+        "crc32-stream": "^2.0.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/compress-commons/node_modules/normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/concat-map": {
@@ -791,6 +1110,55 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/crc": {
+      "version": "3.8.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha1-rWAmnCyFb4wpnixMwN5FVpFAVsY=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.1.0"
+      }
+    },
+    "node_modules/crc/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha1-umLnwTEzBTWCGXFghRqPZI6Z7tA=",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc": "^3.4.4",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "dev": true,
@@ -804,6 +1172,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cycle": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dargs": {
       "version": "8.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/dargs/-/dargs-8.1.0.tgz",
@@ -815,6 +1192,76 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha1-IRoDupXsr3eYqMcZjXlTYhH4hXA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha1-noD3ylJFPOPpPSWjUxh2fqdwRzU=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha1-BoMH+bcat2274QKROJ4CCFZgYZE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "1.0.11",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/dateformat/-/dateformat-1.0.11.tgz",
+      "integrity": "sha1-8ny+56ASu/uC6gUVYtOXf2CT27E=",
+      "dev": true,
+      "dependencies": {
+        "get-stdin": "*",
+        "meow": "*"
+      },
+      "bin": {
+        "dateformat": "bin/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -878,6 +1325,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha1-HTf1dm87v/Tuljjocah2jBc7gdo=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/detect-file": {
@@ -966,6 +1424,114 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha1-Lb04wYBzXumD93WFFAonBqlj7Zo=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-abstract-get": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "integrity": "sha1-Hq6HEB9Cvt62p0DoxQUSca74kIg=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.2",
+        "is-callable": "^1.2.7",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-abstract-get/node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha1-hz8+hEGN5O4Zxb51KZCy5EcY0J4=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "dev": true,
@@ -991,6 +1557,43 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha1-8x274MGDsAptJutjJcgQwP0YvU0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "integrity": "sha1-DIVCkc8Ne0Oda55XceqDf/rx+ZE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-abstract-get": "^1.0.0",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.1.0",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/escalade": {
@@ -1130,6 +1733,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+      "dev": true,
+      "engines": {
+        "node": "> 0.1.90"
       }
     },
     "node_modules/fast-fifo": {
@@ -1293,6 +1905,22 @@
         }
       }
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha1-1lBogCeCaSD+6wr3R+57lCGkHUc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/for-in": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/for-in/-/for-in-1.0.2.tgz",
@@ -1331,6 +1959,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fs-mkdirp-stream": {
       "version": "1.0.0",
       "dev": true,
@@ -1368,6 +2003,82 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "integrity": "sha1-dY8+hPpUJnJFS9XhTLCBpc4H9ww=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.4",
+        "is-callable": "^1.2.7",
+        "is-document.all": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name/node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha1-OaZEcAyAvH0MqRAvxtHUOy/X7uc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name/node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha1-BAT+TuK6L2B/Dg7DyAuumUEzuDQ=",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha1-DnXdQQ0SQ2h6C6LpUblO7bj3N6I=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-caller-file": {
@@ -1415,6 +2126,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stdin": {
+      "version": "10.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-stdin/-/get-stdin-10.0.0.tgz",
+      "integrity": "sha1-Q46pPQKK5fMS46OviMEdMNvPwZU=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-stream": {
       "version": "8.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-stream/-/get-stream-8.0.1.tgz",
@@ -1426,6 +2150,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha1-e91U4L7+j/yfO04gMiDZ8eiBtu4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob": {
@@ -1627,6 +2369,23 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha1-dDDtOpddl7+1m8zkH1yruvplEjY=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glogg": {
@@ -2123,6 +2882,19 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha1-KGB+llrJZ+A80qLHCiY2oe2tSf4=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "dev": true,
@@ -2134,10 +2906,42 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha1-XeWm6r2V/f/ZgYtDBV6AZeOf6dU=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha1-LNxC1AvvLltO6rfAGnPFTOerWrw=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -2255,6 +3059,13 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "dev": true,
@@ -2275,6 +3086,21 @@
       "integrity": "sha1-op2kJbSIBvNHZ6Tvzjlyaa8oQyw=",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha1-HqyRdilH0vcFa8g42T4TsulgSWE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/interpret": {
       "version": "3.1.1",
@@ -2298,6 +3124,60 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha1-ZXQuHmh70sxmYlMGj9hwf+TUQoA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha1-PmkBjI4E5ztzh5PQIL/ohLn9NSM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha1-3aejRF31ekJYPbQihoLrp8QXBnI=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "dev": true,
@@ -2309,10 +3189,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha1-cGf0dwmAmjk8cf9bs+E12KkhXZ4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-buffer": {
       "version": "1.1.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha1-O8KoXqdC2eNiBdys3XLKH9xRsFU=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
@@ -2322,6 +3232,73 @@
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha1-uuCkG5aImGwhiN2mZX5WuPnmO44=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha1-rYVUGZb8eqiycpcB0ntzGfldgvc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha1-kAk6oxBid9inelkQ265xdH4VogA=",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-document.all": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-document.all/-/is-document.all-1.0.0.tgz",
+      "integrity": "sha1-FjpL+zYsbtexGM5GzezE433uMZU=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2360,6 +3337,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha1-7v3NxslN3QZ02chYh7+T+USpfJA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2368,6 +3361,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha1-rjth49XqTkg5uQutIrAjNQUaF9U=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -2381,12 +3394,74 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha1-6B+6aZZi6zHb2vJnZqYdSBRxfqQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha1-7elrf+HicLPERl46RlZYdkkm1i4=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-negated-glob": {
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha1-ztkDoCespjgbd3pXQwadc3akl0c=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha1-FEsh6VobwUggXcwoFKkTTsQbJUE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-plain-obj": {
@@ -2409,6 +3484,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha1-dtcKPtEO+b5I61d4h9dCBb8MrSI=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-relative": {
       "version": "1.0.0",
       "dev": true,
@@ -2418,6 +3512,35 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha1-irIJ6kJGCBQTct7W4MsgDvHZ0B0=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha1-m2eES9m38ka6BwjDqT40Jpx3T28=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-stream": {
@@ -2431,6 +3554,57 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha1-kuo/PVxbbgOcqGd+WsjQfqdzy7k=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha1-9HdhJ59TLisFpwJKdQbbvtrNBjQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha1-S/tKRbYc7oOlpG+6d45OjVnAzgs=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-unc-path": {
@@ -2470,12 +3644,90 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha1-v3JhXWSd/l9pkHnFS4PkfRrhnP0=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha1-7qQwGCvo1kF0vZa/+8RvIb8/kpM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha1-yfXesLwZBsbW8QJ/KE3fRZJJ2so=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-windows": {
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha1-MniXsmgyo+sRfabCdJLQTKEyWU8=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is64bit": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is64bit/-/is64bit-2.0.0.tgz",
+      "integrity": "sha1-GYxifLyxmLvsQCJR+I5eGlEjbAc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "system-architecture": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -2496,6 +3748,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jackspeak": {
       "version": "4.2.3",
       "dev": true,
@@ -2509,6 +3768,20 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.3.0",
@@ -2533,10 +3806,40 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-in-place": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/json-in-place/-/json-in-place-1.0.1.tgz",
+      "integrity": "sha1-ih7NJaac4ZAFUs1xUr2TdU3k4fA=",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "json-lexer": "1.1.1"
+      }
+    },
+    "node_modules/json-lexer": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/json-lexer/-/json-lexer-1.1.1.tgz",
+      "integrity": "sha1-vT7V1+Vgudma0iNPKMpwb7N3t9Q=",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha1-NK7nDrGOofrsL1iSCKFX0f6wkcI=",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
     },
     "node_modules/last-run": {
       "version": "2.0.0",
@@ -2568,6 +3871,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha1-3Pgt7lRfRgdNryAMfBxaCOD0D2o=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/liftoff": {
@@ -2604,6 +3917,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha1-/ytmwfYybVlRPeJAe/iBQ5gSdxw=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -2724,6 +4044,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/meow": {
+      "version": "14.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/meow/-/meow-14.1.0.tgz",
+      "integrity": "sha1-PNLRatU0gpqxL8tQEPwv24n6zTE=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "dev": true,
@@ -2782,6 +4115,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "dev": true,
@@ -2793,12 +4133,35 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mocha": {
@@ -3032,6 +4395,13 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0=",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/nodejs-file-downloader": {
       "version": "4.13.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
@@ -3149,6 +4519,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object.getownpropertydescriptors": {
+      "version": "2.1.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.9.tgz",
+      "integrity": "sha1-v551IPFNUN6I3uK5yeyoQRZjItw=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.reduce": "^1.0.8",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "gopd": "^1.2.0",
+        "safe-array-concat": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object.pick": {
       "version": "1.3.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object.pick/-/object.pick-1.3.0.tgz",
@@ -3168,6 +4560,15 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onecolor": {
+      "version": "2.5.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onecolor/-/onecolor-2.5.0.tgz",
+      "integrity": "sha1-Ila2UdyAfBAfAK7b1JklxXpEMcE=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.8"
       }
     },
     "node_modules/onetime": {
@@ -3190,6 +4591,34 @@
       "license": "MIT",
       "dependencies": {
         "readable-stream": "^2.0.1"
+      }
+    },
+    "node_modules/os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha1-5ABpEKK/kTWFKJZ27r1vOQz1E1g=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-limit": {
@@ -3228,6 +4657,13 @@
       "version": "1.0.1",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parse-filepath": {
       "version": "1.0.2",
@@ -3357,6 +4793,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha1-k+NYK8DlQmWG2dB7ee5A/IQd5K4=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "dev": true,
@@ -3369,6 +4815,30 @@
       "dependencies": {
         "asap": "~2.0.3"
       }
+    },
+    "node_modules/prompt": {
+      "version": "1.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/prompt/-/prompt-1.3.0.tgz",
+      "integrity": "sha1-sfbUfLG2vu1PBmC0cPXT7BV6184=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.5.0",
+        "async": "3.2.3",
+        "read": "1.0.x",
+        "revalidator": "0.1.x",
+        "winston": "2.x"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/prompt/node_modules/async": {
+      "version": "3.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/async/-/async-3.2.3.tgz",
+      "integrity": "sha1-rFPa/T9HIO6eihYGKPGOqR3xlsk=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "2.0.1",
@@ -3434,6 +4904,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/read": {
+      "version": "1.0.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "dev": true,
@@ -3475,6 +4958,50 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha1-xikhnnijMW2LYEx2XvaJlpZOe/k=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha1-GtbGLUSiWQB+VbOXDgD3Ru+8qhk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/remove-bom-buffer": {
@@ -3593,6 +5120,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/revalidator": {
+      "version": "0.1.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
+      "dev": true,
+      "license": "Apache 2.0",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -3615,6 +5152,52 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha1-pUzJthpX8ztCq608vdo6KzjMVxk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-array-concat/node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha1-OaZEcAyAvH0MqRAvxtHUOy/X7uc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-array-concat/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "dev": true,
@@ -3633,6 +5216,48 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha1-AYUOmBwWAtOYyFCB82Dk5tA9J/U=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha1-f4fftnoxUHguqvGFg/9dFxGsEME=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -3705,6 +5330,44 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha1-FqcFxaDcL15jjKltiozU4cK5CYU=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha1-B2Dbz/MLLX6AH9bhmYPlbaM3Vl4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3891,6 +5554,30 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha1-9IH/cKVI9hJNAxLDqhTL+nqlQq0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/stream-composer": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/stream-composer/-/stream-composer-1.0.2.tgz",
@@ -3949,6 +5636,130 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.11",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha1-5r0ZzaOYXQWkLdox89300100MOM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trim/node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha1-OaZEcAyAvH0MqRAvxtHUOy/X7uc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trim/node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.10",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha1-vmvPTz/gRgvezNss9PlxsxD4NG4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend/node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha1-OaZEcAyAvH0MqRAvxtHUOy/X7uc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend/node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha1-fug03ajHwX7/MRhHK7Nb/tqjTd4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -4029,6 +5840,49 @@
         "then-request": "^2.0.1"
       }
     },
+    "node_modules/system-architecture": {
+      "version": "0.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/system-architecture/-/system-architecture-0.1.0.tgz",
+      "integrity": "sha1-cQErOsFBQn2XxnxWvHkhr2v/Ei0=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "1.6.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha1-jqVdqzeXIlPZqa+Q/c1VmuQ1xVU=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/bl": {
+      "version": "1.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha1-Ho3YAULqyA1xWMnczAR/tiDgNec=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "node_modules/teex": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/teex/-/teex-1.0.1.tgz",
@@ -4047,6 +5901,118 @@
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/tfx-cli": {
+      "version": "0.21.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tfx-cli/-/tfx-cli-0.21.3.tgz",
+      "integrity": "sha1-b3Biw9FDZpUqPBhaSxze4wSnA0c=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-root-path": "1.0.0",
+        "archiver": "2.0.3",
+        "azure-devops-node-api": "^14.0.0",
+        "clipboardy": "^4.0.0",
+        "colors": "~1.3.0",
+        "glob": "7.1.2",
+        "jju": "^1.4.0",
+        "json-in-place": "^1.0.1",
+        "jszip": "^3.10.1",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.6",
+        "mkdirp": "^1.0.4",
+        "onecolor": "^2.5.0",
+        "os-homedir": "^1.0.1",
+        "prompt": "^1.3.0",
+        "read": "^1.0.6",
+        "shelljs": "^0.8.5",
+        "tmp": "^0.2.4",
+        "tracer": "0.7.4",
+        "util.promisify": "^1.0.0",
+        "uuid": "^3.0.1",
+        "validator": "^13.7.0",
+        "winreg": "0.0.12",
+        "xml2js": "^0.5.0"
+      },
+      "bin": {
+        "tfx": "_build/tfx-cli.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/tfx-cli/node_modules/glob": {
+      "version": "7.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tfx-cli/node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/tfx-cli/node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/tfx-cli/node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha1-3gVUCNg2G+1mxmnS8ABTjO2O4gw=",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tfx-cli/node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha1-2UQGMfuy7YACA/rRBvJyT2LEk7c=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/then-request": {
@@ -4085,6 +6051,26 @@
         "xtend": "~4.0.0"
       }
     },
+    "node_modules/tinytim": {
+      "version": "0.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tinytim/-/tinytim-0.1.1.tgz",
+      "integrity": "sha1-yWih5VWa2VUyJO92J7qzTjyu+Kg=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.2.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha1-JvTbEdFgHOgBLcuKeY7OHAapkFk=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/to-absolute-glob": {
       "version": "2.0.2",
       "dev": true,
@@ -4096,6 +6082,28 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha1-/+We91Iq2gotHLXf4Du4q8PNwTM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/to-buffer/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -4127,6 +6135,31 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/tracer": {
+      "version": "0.7.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tracer/-/tracer-0.7.4.tgz",
+      "integrity": "sha1-d/oEN8+Ct2vNvNRLhHRHcuWeUlk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colors": "1.0.3",
+        "dateformat": "1.0.11",
+        "tinytim": "0.1.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/tracer/node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -4135,6 +6168,130 @@
       "license": "WTFPL",
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha1-pyOVRQpIaewDP9VJNxtHrzou5TY=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha1-hAegT314aE89JSqhoUPSt3tBYM4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha1-rjaYuOyRqKuUUBYQiu8A1b/xI1U=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha1-C3Dpgsnp2v4t721kWP9LPy0rbXA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length/node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha1-OaZEcAyAvH0MqRAvxtHUOy/X7uc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/typedarray": {
@@ -4154,6 +6311,25 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha1-jZ0snt7qhGDH81AzqIhnlEk00eI=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/unc-path-regex": {
       "version": "0.1.2",
       "dev": true,
@@ -4161,6 +6337,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha1-qTohGGwEnb8OhHSW26cre9jB6Ss=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undertaker": {
       "version": "2.0.0",
@@ -4215,6 +6398,33 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/util.promisify": {
+      "version": "1.1.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/util.promisify/-/util.promisify-1.1.3.tgz",
+      "integrity": "sha1-PXfPVmKLSq10PlrN6OXETOp9vxw=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "for-each": "^0.3.3",
+        "get-intrinsic": "^1.2.6",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "object.getownpropertydescriptors": "^2.1.8",
+        "safe-array-concat": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/uuid": {
       "version": "3.4.0",
@@ -4362,6 +6572,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/walkdir": {
+      "version": "0.0.11",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/walkdir/-/walkdir-0.0.11.tgz",
+      "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -4374,6 +6594,156 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha1-127Cfff6Fl8Y1YCDdKX+I8KbF24=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha1-iRg9obSQerCJprAgKcxdjWV0Jw4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha1-Yn73YkOSChB+fOjpYZHevksWwqA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha1-jzzHiu+0C0NzRt1Aodv6XR2kP+k=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array/node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha1-OaZEcAyAvH0MqRAvxtHUOy/X7uc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/winreg": {
+      "version": "0.0.12",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/winreg/-/winreg-0.0.12.tgz",
+      "integrity": "sha1-BxBVVLoanQiXklHRKUdb/64wBrc=",
+      "dev": true,
+      "license": "BSD"
+    },
+    "node_modules/winston": {
+      "version": "2.4.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/winston/-/winston-2.4.7.tgz",
+      "integrity": "sha1-V5H+COp+kNsJDxyzHvmPMlMQYvE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^2.6.4",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "stack-trace": "0.0.x"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/winston/node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/workerpool": {
@@ -4465,6 +6835,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/zip-stream/-/zip-stream-1.2.0.tgz",
+      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^1.3.0",
+        "compress-commons": "^1.2.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@types/adm-zip": "^0.4.34",
+    "gulp-cli": "^3.0.0",
     "tfx-cli": "^0.21.1",
     "@types/gulp": "^4.0.17",
     "@types/gulp-mocha": "^0.0.37",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@types/adm-zip": "^0.4.34",
+    "tfx-cli": "^0.21.1",
     "@types/gulp": "^4.0.17",
     "@types/gulp-mocha": "^0.0.37",
     "@types/node": "^20.19.41",


### PR DESCRIPTION
**Description**: Fixes the extension publish pipeline failures caused by 1ES Network Isolation, which blocks access to external registries (e.g.  registry.npmjs.org ) and fails the global installs of  tfx-cli  and  gulp-cli . 

[Failing run](https://dev.azure.com/mseng/AzureDevOps/AzureDevOps%20Team/_build/results?buildId=31775380&view=logs&j=9936566d-898e-5ce3-0331-2c20a4700207&t=c12f02ff-8409-5f5f-a7a0-f37f67bac9f6&l=18)

Changes:
1. Move CLIs to root  devDependencies 
• Added  tfx-cli@^0.21.1  and  gulp-cli@^3.0.0  so they are installed locally from the internal CFS-upstream feed during  npm install , instead of via global installs /  TfxInstaller@5  which require external network access.
2. Pipeline updates ( azure-pipelines.yml  and  azure-pipelines-integration.yml )
• Removed the global  npm install -g tfx-cli  /  gulp-cli  steps and the  TfxInstaller@5  task.
• Added a step to prepend the local  node_modules/.bin  to  PATH  and set __tfxpath variable which is used by  PublishAzureDevOpsExtension task to resolve tfx.


**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [ ] Checked that applied changes work as expected.
