### PR TITLE
Add npm audit as a CI check in the build process

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -667,7 +667,112 @@ gulp.task("tscBuildTasks", function (cb) {
     cb();
 });
 
-gulp.task("build", gulp.series("syncVersions", "compileNode", "tscBuildTasks", "updateTestIds"));
+// ---------------------------------------------------------------------------
+// gulp audit — runs `npm audit` on affected package roots and fails on
+// vulnerabilities at or above the "high" severity level. Wired into `build`
+// so the existing CI build step enforces it (no separate CI step needed).
+// ---------------------------------------------------------------------------
+
+// Directories that never contain auditable project roots. Used to filter out
+// dependency lockfiles (node_modules) and build output when discovering roots.
+const AUDIT_SKIP_DIRS = ['node_modules', '_build', '_temp', '_package', '_nuget', '.git'];
+
+/**
+ * Discover every directory that contains a package.json (an auditable root).
+ * Paths are returned relative to the repo root, forward-slash normalized, with
+ * the repo root itself represented as '.'.
+ * @returns {string[]}
+ */
+function discoverAuditRoots() {
+    return fs.readdirSync(__dirname, { recursive: true, encoding: 'utf-8' })
+        .filter((p) => path.basename(p) === 'package.json'
+            && !p.split(path.sep).some((seg) => AUDIT_SKIP_DIRS.includes(seg)))
+        .map((p) => {
+            const dir = path.dirname(p);
+            return dir === '.' ? '.' : dir.split(path.sep).join('/');
+        });
+}
+
+/**
+ * Map changed files to the audit roots they belong to. Each file is attributed
+ * to the most specific (deepest) enclosing audit root so a change under an
+ * extension task folder audits only that folder, not the repo root.
+ * @param {string[]} files
+ * @param {string[]} roots
+ * @returns {string[]}
+ */
+function resolveAffectedAuditRoots(files, roots) {
+    /** @type {Set<string>} */
+    const selected = new Set();
+    for (const f of files) {
+        let best = null;
+        let bestLen = -1;
+        for (const root of roots) {
+            const prefix = root === '.' ? '' : `${root}/`;
+            if (f.startsWith(prefix) && prefix.length > bestLen) {
+                best = root;
+                bestLen = prefix.length;
+            }
+        }
+        if (best !== null) selected.add(best);
+    }
+    return [...selected];
+}
+
+gulp.task("audit", (done) => {
+    const roots = discoverAuditRoots();
+    console.log(`Auditable roots (${roots.length}): ${roots.join(', ')}`);
+
+    const files = getChangedFiles(true);
+    let affected;
+    if (files === null) {
+        console.log("Cannot determine changed files -> auditing all roots.");
+        done();
+        return;
+    } else {
+        affected = resolveAffectedAuditRoots(files, roots);
+    }
+
+    if (affected.length === 0) {
+        console.log("No auditable roots affected by this change. Skipping npm audit.");
+        done();
+        return;
+    }
+
+    console.log(`Auditing affected roots (${affected.length}): ${affected.join(', ')}`);
+
+    /** @type {string[]} */
+    const failures = [];
+
+    for (const root of affected) {
+        const cwd = root === '.' ? __dirname : path.join(__dirname, root);
+        console.log('\n========================================');
+        console.log(`npm audit --audit-level=high in ${root}`);
+        console.log('========================================');
+
+        const result = cp.spawnSync('npm audit --audit-level=high', {
+            cwd,
+            stdio: 'inherit',
+            env: process.env,
+            shell: true
+        });
+        if (result.error) {
+            console.error(`Failed to run npm audit in ${root}: ${result.error.message}`);
+            failures.push(root);
+        } else if (result.status !== 0) {
+            failures.push(root);
+        }
+    }
+
+    if (failures.length > 0) {
+        done(new Error(`npm audit found high/critical vulnerabilities in: ${failures.join(', ')}`));
+        return;
+    }
+    console.log('\nnpm audit passed for all affected roots.');
+    done();
+});
+
+gulp.task("build", gulp.series("syncVersions", "compileNode", "tscBuildTasks", "updateTestIds", "audit"));
 
 gulp.task("default", gulp.series("build"));
 
@@ -897,11 +1002,15 @@ gulp.task("test", gulp.series("testResources", function () {
 // Shared git-diff logic
 // ---------------------------------------------------------------------------
 
-// Returns an array of changed file paths (forward-slash normalized) from the
-// diff against the target branch. Works for PR builds (uses PR target) and
-// manual/CI builds (diffs selected branch against master).
-// Returns null only if the diff cannot be determined (fetch failure, etc.).
-function getChangedFiles() {
+/**
+ * Returns an array of changed file paths (forward-slash normalized) from the
+ * diff against the target branch. Works for PR builds (uses PR target) and
+ * manual/CI builds (diffs selected branch against master).
+ * Returns null only if the diff cannot be determined (fetch failure, etc.).
+ * @param {boolean} filterLocalChanges
+ * @returns {string[] | null}
+ */
+function getChangedFiles(filterLocalChanges) {
     var buildReason = process.env['BUILD_REASON'];
     var target;
 
@@ -916,11 +1025,19 @@ function getChangedFiles() {
         // Manual or CI trigger — diff current branch against master.
         target = 'master';
         var sourceBranch = (process.env['BUILD_SOURCEBRANCH'] || '').replace(/^refs\/heads\//, '');
+        if (!sourceBranch && filterLocalChanges) {
+            try {
+                sourceBranch = cp.execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' }).trim();
+            } catch (e) {
+                console.log("Could not resolve current git branch: " + e.message + " -> running all.");
+                return null;
+            }
+        }
         if (!sourceBranch || sourceBranch === target) {
             console.log("Source branch is " + (sourceBranch || 'empty') + " (target: " + target + ") -> running all.");
             return null;
         }
-        console.log("Non-PR build (BUILD_REASON=" + buildReason + "). Diffing against " + target + ".");
+        console.log("Non-PR build (BUILD_REASON=" + (buildReason || 'local') + "). Diffing against " + target + ".");
     }
     var changedFiles;
     try {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -667,32 +667,6 @@ gulp.task("tscBuildTasks", function (cb) {
     cb();
 });
 
-// ---------------------------------------------------------------------------
-// gulp audit — runs `npm audit` on affected package roots and fails on
-// vulnerabilities at or above the "high" severity level. Wired into `build`
-// so the existing CI build step enforces it (no separate CI step needed).
-// ---------------------------------------------------------------------------
-
-// Directories that never contain auditable project roots. Used to filter out
-// dependency lockfiles (node_modules) and build output when discovering roots.
-const AUDIT_SKIP_DIRS = ['node_modules', '_build', '_temp', '_package', '_nuget', '.git'];
-
-/**
- * Discover every directory that contains a package.json (an auditable root).
- * Paths are returned relative to the repo root, forward-slash normalized, with
- * the repo root itself represented as '.'.
- * @returns {string[]}
- */
-function discoverAuditRoots() {
-    return fs.readdirSync(__dirname, { recursive: true, encoding: 'utf-8' })
-        .filter((p) => path.basename(p) === 'package.json'
-            && !p.split(path.sep).some((seg) => AUDIT_SKIP_DIRS.includes(seg)))
-        .map((p) => {
-            const dir = path.dirname(p);
-            return dir === '.' ? '.' : dir.split(path.sep).join('/');
-        });
-}
-
 /**
  * Map changed files to the audit roots they belong to. Each file is attributed
  * to the most specific (deepest) enclosing audit root so a change under an
@@ -720,8 +694,10 @@ function resolveAffectedAuditRoots(files, roots) {
 }
 
 gulp.task("audit", (done) => {
-    const roots = discoverAuditRoots();
-    console.log(`Auditable roots (${roots.length}): ${roots.join(', ')}`);
+    const roots = cp.execSync('git ls-files -- "*package.json"', { cwd: __dirname, encoding: 'utf-8' })
+        .split('\n')
+        .map((p) => p.trim())
+        .map((p) => path.posix.dirname(p));
 
     const files = getChangedFiles(true);
     let affected;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -726,7 +726,7 @@ gulp.task("audit", (done) => {
     const files = getChangedFiles(true);
     let affected;
     if (files === null) {
-        console.log("Cannot determine changed files -> auditing all roots.");
+        console.log("Cannot determine changed files -> skip the check.");
         done();
         return;
     } else {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -983,7 +983,7 @@ gulp.task("test", gulp.series("testResources", function () {
  * diff against the target branch. Works for PR builds (uses PR target) and
  * manual/CI builds (diffs selected branch against master).
  * Returns null only if the diff cannot be determined (fetch failure, etc.).
- * @param {boolean} [filterLocalChanges] - If true, attempts to resolve the current branch name for local builds (BUILD_REASON=Manual) and filters out changes that are not on the current branch. If false, all changes in the working directory are included.
+ * @param {boolean} [filterLocalChanges] - When true and BUILD_SOURCEBRANCH is not set (local runs), resolve the current branch via `git rev-parse --abbrev-ref HEAD` so the diff can still be computed; returns null (run all) if it can't be resolved. When false, the local branch fallback is skipped and such runs return null (run all).
  * @returns {string[] | null} The list of changed files, or null if the diff cannot be determined (e.g. fetch failure, no target branch, etc.).
  */
 function getChangedFiles(filterLocalChanges) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1007,8 +1007,8 @@ gulp.task("test", gulp.series("testResources", function () {
  * diff against the target branch. Works for PR builds (uses PR target) and
  * manual/CI builds (diffs selected branch against master).
  * Returns null only if the diff cannot be determined (fetch failure, etc.).
- * @param {boolean} filterLocalChanges
- * @returns {string[] | null}
+ * @param {boolean} [filterLocalChanges] - If true, attempts to resolve the current branch name for local builds (BUILD_REASON=Manual) and filters out changes that are not on the current branch. If false, all changes in the working directory are included.
+ * @returns {string[] | null} The list of changed files, or null if the diff cannot be determined (e.g. fetch failure, no target branch, etc.).
  */
 function getChangedFiles(filterLocalChanges) {
     var buildReason = process.env['BUILD_REASON'];


### PR DESCRIPTION
**Description**: Adds an `npm audit` security check to the build system and wires it into the existing `build` gulp task, so it runs as part of the current CI build step (no separate CI step needed).

- New `gulp audit` task runs `npm audit --audit-level=high` and fails the build on **high/critical** vulnerabilities.
- Runs **only on affected package roots**: changed files (via the existing `getChangedFiles` git-diff logic) are mapped to the deepest enclosing `package.json` directory, so a change under one task only audits that task. When no auditable root is affected, the audit is skipped.
- Added to the `build` series (`syncVersions → compileNode → tscBuildTasks → updateTestIds → audit`).
- Extended `getChangedFiles` with a `filterLocalChanges` flag so local runs resolve the current git branch (`git rev-parse --abbrev-ref HEAD`) when `BUILD_SOURCEBRANCH` isn't set, enabling change-based auditing outside CI.

**Documentation changes required:** (N)

**Added unit tests:** (N)

**Attached related issue:** (N)

**Checklist**:
- [ ] Version was bumped — N/A (build infrastructure only; no task/extension/library version change)
- [x] Checked that applied changes work as expected — verified `gulp audit` locally audits only affected roots and fails on high/critical.
