### PR TITLE
Add unit tests for Ansible task failures and mock utilities

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleTowerInterface.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleTowerInterface.ts
@@ -89,9 +89,9 @@ export class ansibleTowerInterface extends ansibleInterface {
         request.method = 'GET';
         request.uri = util.format(this._jobTemplateIdUrlFormat, this._hostname, this._jobTemplateName);
         request.headers = this.getBasicRequestHeader();
-        
+
         var response = await beginRequest(request);
-        if (response.statusCode === 200) {
+        if (response.statusCode === 200 && response.body && response.body['results'] && response.body['results'].length > 0) {
             jobTemplateId = response.body['results'][0]['id'];
         } else {
             throw (tl.loc('JobTemplateNotPresent', this._jobTemplateName));
@@ -105,7 +105,7 @@ export class ansibleTowerInterface extends ansibleInterface {
         request.method = 'GET';
         request.uri = this.getJobApi(jobId);
         request.headers = this.getBasicRequestHeader();
-        
+
         var response = await beginRequest(request);
         if (response.statusCode === 200) {
             status = response.body['status'];

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 277,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "instanceNameFormat": "Run playbook",

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 277,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [],
     "instanceNameFormat": "Run playbook",

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 276,
-        "Patch": 3
+        "Minor": 277,
+        "Patch": 1
     },
     "demands": [],
     "instanceNameFormat": "Run playbook",

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 277,
-        "Patch": 3
+        "Patch": 4
     },
     "demands": [],
     "instanceNameFormat": "Run playbook",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.277.3",
+  "version": "0.277.4",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.277.2",
+  "version": "0.277.3",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.277.1",
+  "version": "0.277.2",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.277.0",
+  "version": "0.277.1",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Tests/Tasks/Ansible/_suite.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/_suite.ts
@@ -90,10 +90,14 @@ function ensureTaskMainJs(): void {
     }
 }
 
-const nodeVersions = getDeclaredNodeVersions().filter((v) => v >= 20);
+const nodeVersions = getDeclaredNodeVersions();
 
 describe('Ansible Suite', function () {
     this.timeout(120000);
+
+    it('discovers at least one declared Node handler', function () {
+        assert(nodeVersions.length > 0, 'expected at least one Node handler in task.json execution block');
+    });
 
     before(function () {
         ensureTaskMainJs();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/_suite.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/_suite.ts
@@ -1,186 +1,346 @@
 import assert = require('assert');
+import childProcess = require('child_process');
+import fs = require('fs');
 import path = require('path');
-import {TestGuid} from './mockAnsibleUtils';
+import { TestGuid } from './mockAnsibleUtils';
 
-var mocktest = require('azure-pipelines-task-lib/mock-test');
+const mocktest = require('azure-pipelines-task-lib/mock-test');
+
+process.env['DISTRIBUTEDTASK_TASKS_NODE_SKIPDEBUGLOGSWHENDEBUGMODEOFF'] = 'true';
+
+const taskJsonPath = path.join(process.cwd(), 'Extensions', 'Ansible', 'Src', 'Tasks', 'Ansible', 'task.json');
+const taskFolderPath = path.join(process.cwd(), '_build', 'Extensions', 'Ansible', 'Src', 'Tasks', 'Ansible');
+const taskMainPath = path.join(taskFolderPath, 'main.js');
+
+function getDeclaredNodeVersions(): number[] {
+    const taskJson = JSON.parse(fs.readFileSync(taskJsonPath, 'utf-8'));
+    const versions = new Set<number>();
+    const exec = taskJson.execution || {};
+
+    for (const key of Object.keys(exec)) {
+        const match = /^Node(\d*)/i.exec(key);
+        if (!match) {
+            continue;
+        }
+
+        versions.add(parseInt(match[1], 10) || 6);
+    }
+
+    return Array.from(versions).sort((a, b) => a - b);
+}
+
+function newRunner(scenario: string): any {
+    return new mocktest.MockTestRunner(path.join(__dirname, scenario + '.js'), taskJsonPath);
+}
+
+async function runAndDump(runner: any, nodeVersion: number): Promise<void> {
+    try {
+        await runner.runAsync(nodeVersion);
+    } catch (err) {
+        console.log('--- runner threw ---');
+        console.log(err);
+        throw err;
+    }
+}
+
+function fail(runner: any, msg: string): never {
+    console.log('--- STDOUT ---');
+    console.log(runner.stdout);
+    console.log('--- STDERR ---');
+    console.log(runner.stderr);
+    throw new Error(msg);
+}
+
+function expectSuccess(runner: any, message: string): void {
+    if (!runner.succeeded) {
+        fail(runner, message);
+    }
+}
+
+function expectFailure(runner: any, message: string): void {
+    if (!runner.failed) {
+        fail(runner, message);
+    }
+}
+
+function outputContains(runner: any, value: string): boolean {
+    const stdout = runner.stdout || '';
+    const stderr = runner.stderr || '';
+    return stdout.indexOf(value) >= 0 || stderr.indexOf(value) >= 0;
+}
+
+function ensureTaskMainJs(): void {
+    if (fs.existsSync(taskMainPath)) {
+        return;
+    }
+
+    const tscCmd = 'node "' + path.join(process.cwd(), 'node_modules', 'typescript', 'bin', 'tsc') +
+        '" --project "' + path.join(taskFolderPath, 'tsconfig.json') + '" --noEmit false';
+    const result = childProcess.spawnSync(tscCmd, {
+        cwd: process.cwd(),
+        shell: true,
+        stdio: 'pipe',
+        encoding: 'utf8'
+    });
+
+    if (result.status !== 0 || !fs.existsSync(taskMainPath)) {
+        const stderr = result.stderr || '';
+        const stdout = result.stdout || '';
+        throw new Error('Failed to compile Ansible task JavaScript for tests.\nSTDOUT:\n' + stdout + '\nSTDERR:\n' + stderr);
+    }
+}
+
+const nodeVersions = getDeclaredNodeVersions().filter((v) => v >= 20);
 
 describe('Ansible Suite', function () {
-    before(() => {
-    });
-    after(() => {
-    });
+    this.timeout(120000);
 
-    it('should run with playbook and inventory on agent machine for remote machine', async function () {
-        this.timeout(30000);
-        let testPath = path.join(__dirname, 'testPlaybookAndInventoryOnAgentMachineForRemoteMachine');
-        let runner = new mocktest.MockTestRunner(testPath);
-        await runner.runAsync();
-
-        try {
-            assert(runner.succeeded, "Should have succeeded");
-            assert(runner.stdOutContained('copied file to remote machine = /path/to/ansiblePlaybookRoot'), 'should able to copy playbook to remote machine');
-            assert(runner.stdOutContained('copied file to remote machine = /path/to/ansibleInventory'), 'should able to copy inventory file to remote machine');
-            assert(runner.stdOutContained('cmd run on remote machine = ansible-playbook -i /tmp/ansibleInventory /tmp/ansiblePlaybookRoot/ansiblePlaybook.yml'), 'should able to run playbook on remote machine');
-            assert(runner.stdOutContained('cmd run on remote machine = rm -rf /tmp/ansiblePlaybookRoot'), 'should clean all the temporary playbook file copied to remote machine');
-            assert(runner.stdOutContained('cmd run on remote machine = rm -f /tmp/ansibleInventory', 'should clean all the temporary inventory file copied to remote machine'));
-            assert(runner.stdOutContained('connection to dummy client established'), 'should able connect to client');
-            assert(runner.stdOutContained('connection to dummy client terminated'), 'should able disconnect to client');
-        }
-        catch (error) {
-            console.log("STDERR", runner.stderr);
-            console.log("STDOUT", runner.stdout);
-            throw error;
-        }
+    before(function () {
+        ensureTaskMainJs();
     });
 
-    it('should run with playbook and inventory on ansible machine for remote machine', async function () {
-        this.timeout(30000);
-        let testPath = path.join(__dirname, 'testPlaybookAndInventoryOnAnsibleMachineForRemoteMachine');
-        let runner = new mocktest.MockTestRunner(testPath);
-        await runner.runAsync();
+    nodeVersions.forEach(function (nodeVersion) {
+        describe('Node ' + nodeVersion, function () {
+            it('runs remote playbook and inventory copied from agent machine', async function () {
+                const runner = newRunner('testPlaybookAndInventoryOnAgentMachineForRemoteMachine');
+                await runAndDump(runner, nodeVersion);
+                expectSuccess(runner, 'expected remote playbook copy scenario to succeed');
+                assert(runner.stdOutContained('copied file to remote machine = /path/to/ansiblePlaybookRoot'), 'should copy playbook root');
+                assert(runner.stdOutContained('copied file to remote machine = /path/to/ansibleInventory'), 'should copy inventory');
+                assert(runner.stdOutContained('cmd run on remote machine = ansible-playbook -i /tmp/ansibleInventory /tmp/ansiblePlaybookRoot/ansiblePlaybook.yml'), 'should execute playbook');
+                assert(runner.stdOutContained('cmd run on remote machine = rm -rf /tmp/ansiblePlaybookRoot'), 'should clean up copied playbook root');
+                assert(runner.stdOutContained('cmd run on remote machine = rm -f /tmp/ansibleInventory'), 'should clean up copied inventory');
+                assert(runner.stdOutContained('connection to dummy client terminated'), 'should close the SSH client');
+            });
 
-        try {
-            assert(runner.succeeded, "Should have succeeded");
-            assert(runner.stdOutContained('cmd run on remote machine = ansible-playbook -i /path/to/ansibleInventory /path/to/ansiblePlaybookRoot/ansiblePlaybook.yml'), 'should able to run playbook on remote machine');
-            assert(runner.stdOutContained('connection to dummy client established'), 'should able connect to client');
-            assert(runner.stdOutContained('connection to dummy client terminated'), 'should able disconnect to client');
-        }
-        catch (error) {
-            console.log("STDERR", runner.stderr);
-            console.log("STDOUT", runner.stdout);
-            throw error;
-        }
-    });
+            it('runs remote playbook and inventory already on ansible machine', async function () {
+                const runner = newRunner('testPlaybookAndInventoryOnAnsibleMachineForRemoteMachine');
+                await runAndDump(runner, nodeVersion);
+                expectSuccess(runner, 'expected ansible machine source scenario to succeed');
+                assert(runner.stdOutContained('cmd run on remote machine = ansible-playbook -i /path/to/ansibleInventory /path/to/ansiblePlaybookRoot/ansiblePlaybook.yml'), 'should execute playbook with provided paths');
+            });
 
-    it('should run when inventory is the host list for remote machine', async function () {
-        this.timeout(30000);
-        let testPath = path.join(__dirname, 'testInventoryToBeHostListForRemoteMachine');
-        let runner = new mocktest.MockTestRunner(testPath);
-        await runner.runAsync();
+            it('runs remote host list inventory flow', async function () {
+                const runner = newRunner('testInventoryToBeHostListForRemoteMachine');
+                await runAndDump(runner, nodeVersion);
+                expectSuccess(runner, 'expected remote host list scenario to succeed');
+                assert(runner.stdOutContained('cmd run on remote machine = ansible-playbook -i "Dummy_IP_Address," /path/to/ansiblePlaybookRoot/ansiblePlaybook.yml'), 'should append host list comma');
+            });
 
-        try {
-            assert(runner.succeeded, "Should have succeeded");
-            assert(runner.stdOutContained('cmd run on remote machine = ansible-playbook -i "Dummy_IP_Address," /path/to/ansiblePlaybookRoot/ansiblePlaybook.yml'), 'should able to run playbook on remote machine');
-            assert(runner.stdOutContained('connection to dummy client established'), 'should able connect to client');
-            assert(runner.stdOutContained('connection to dummy client terminated'), 'should able disconnect to client');
-        }
-        catch (error) {
-            console.log("STDERR", runner.stderr);
-            console.log("STDOUT", runner.stdout);
-            throw error;
-        }
-    });
+            it('keeps remote host list comma when already present', async function () {
+                const runner = newRunner('testInventoryHostListWithTrailingCommaForRemoteMachine');
+                await runAndDump(runner, nodeVersion);
+                expectSuccess(runner, 'expected remote host list trailing comma scenario to succeed');
+                assert(runner.stdOutContained('cmd run on remote machine = ansible-playbook -i "Dummy_IP_Address," /path/to/ansiblePlaybookRoot/ansiblePlaybook.yml'), 'should not add duplicate comma for remote host list');
+            });
 
-    it('should run when inventory is inline content for remote machine', async function () {
-        this.timeout(30000);
-        let testPath = path.join(__dirname, 'testInventoryToBeInlineForRemoteMachine');
-        let runner = new mocktest.MockTestRunner(testPath);
-        await runner.runAsync();
+            it('runs remote inline dynamic inventory flow', async function () {
+                const runner = newRunner('testInventoryToBeInlineForRemoteMachine');
+                await runAndDump(runner, nodeVersion);
+                expectSuccess(runner, 'expected remote inline dynamic scenario to succeed');
+                assert(runner.stdOutContained(`cmd run on remote machine = echo DUMMY_IP_ADDRESS > /tmp/${TestGuid}inventory.ini`), 'should create inline inventory');
+                assert(runner.stdOutContained(`cmd run on remote machine = chmod +x /tmp/${TestGuid}inventory.ini`), 'should chmod dynamic inventory');
+            });
 
-        try {
-            assert(runner.succeeded, "Should have succeeded");
-            assert(runner.stdOutContained(`cmd run on remote machine = echo DUMMY_IP_ADDRESS > /tmp/${TestGuid}inventory.ini`), 'should able to copy the inline content to inventory.ini file on remote machine');
-            assert(runner.stdOutContained(`cmd run on remote machine = chmod +x /tmp/${TestGuid}inventory.ini`), 'should able to make the inventory.ini file as executable for dynamic inventory');
-            assert(runner.stdOutContained(`cmd run on remote machine = ansible-playbook -i /tmp/${TestGuid}inventory.ini /path/to/ansiblePlaybookRoot/ansiblePlaybook.yml`), 'should able to run playbook on remote machine');
-            assert(runner.stdOutContained('connection to dummy client established'), 'should able connect to client');
-            assert(runner.stdOutContained('connection to dummy client terminated'), 'should able disconnect to client');
-            assert(runner.stdOutContained(`cmd run on remote machine = rm -f /tmp/${TestGuid}inventory.ini`, 'should clean all the temporary inventory file on remote machine'));
-        }
-        catch (error) {
-            console.log("STDERR", runner.stderr);
-            console.log("STDOUT", runner.stdout);
-            throw error;
-        }
-    });
+            it('runs remote inline static inventory flow', async function () {
+                const runner = newRunner('testInventoryInlineStaticForRemoteMachine');
+                await runAndDump(runner, nodeVersion);
+                expectSuccess(runner, 'expected remote inline static scenario to succeed');
+                assert(!runner.stdOutContained(`cmd run on remote machine = chmod +x /tmp/${TestGuid}inventory.ini`), 'should not chmod static inventory');
+                assert(runner.stdOutContained(`cmd run on remote machine = rm -f /tmp/${TestGuid}inventory.ini`), 'should clean up temporary remote inventory');
+            });
 
-    it('should run when sudo and additional parameters is present for remote machine', async function () {
-        this.timeout(30000);
-        let testPath = path.join(__dirname, 'testSudoUserAndAdditionalParamsProvidedForRemoteMachine');
-        let runner = new mocktest.MockTestRunner(testPath);
-        await runner.runAsync();
+            it('runs remote sudo and additional args flow', async function () {
+                const runner = newRunner('testSudoUserAndAdditionalParamsProvidedForRemoteMachine');
+                await runAndDump(runner, nodeVersion);
+                expectSuccess(runner, 'expected remote sudo flow to succeed');
+                assert(runner.stdOutContained('cmd run on remote machine = ansible-playbook -i "Dummy_IP_Address," /path/to/ansiblePlaybookRoot/ansiblePlaybook.yml -b --become-user root --extra-variables "pass=123"'), 'should execute with sudo and additional args');
+            });
 
-        try {
-            assert(runner.succeeded, "Should have succeeded");
-            assert(runner.stdOutContained('cmd run on remote machine = ansible-playbook -i "Dummy_IP_Address," /path/to/ansiblePlaybookRoot/ansiblePlaybook.yml -b --become-user root --extra-variables "pass=123"'), 'should able to run playbook on remote machine');
-            assert(runner.stdOutContained('connection to dummy client established'), 'should able connect to client');
-            assert(runner.stdOutContained('connection to dummy client terminated'), 'should able disconnect to client');
-        }
-        catch (error) {
-            console.log("STDERR", runner.stderr);
-            console.log("STDOUT", runner.stdout);
-            throw error;
-        }
-    });
+            it('runs remote flow with explicit sudo user', async function () {
+                const runner = newRunner('testSudoUserProvidedForRemoteMachine');
+                await runAndDump(runner, nodeVersion);
+                expectSuccess(runner, 'expected explicit sudo user scenario to succeed');
+                assert(runner.stdOutContained('cmd run on remote machine = ansible-playbook -i "Dummy_IP_Address," /path/to/ansiblePlaybookRoot/ansiblePlaybook.yml -b --become-user deployer'), 'should honor provided sudo user');
+            });
 
-    it('should run playbook via ansible tower', async function () {
-        this.timeout(30000);
-        let testPath = path.join(__dirname, 'testTower.js');
-        let runner = new mocktest.MockTestRunner(testPath);
-        await runner.runAsync();
+            it('runs remote flow with default SSH port fallback', async function () {
+                const runner = newRunner('testRemoteUsesDefaultPort');
+                await runAndDump(runner, nodeVersion);
+                expectSuccess(runner, 'expected default SSH port scenario to succeed');
+                assert(outputContains(runner, 'loc_mock_UseDefaultPort'), 'should print default port localization token');
+            });
 
-        try {
-            assert(runner.stdOutContained('Dummy stdout 1'), 'should output log 1');
-            assert(runner.stdOutContained('Dummy stdout 2'), 'should output log 2');
-            assert(runner.stdOutContained('Dummy stdout 3'), 'should output log 3');
-        }
-        catch (error) {
-            console.log("STDERR", runner.stderr);
-            console.log("STDOUT", runner.stdout);
-            throw error;
-        }
-    });
+            it('runs remote flow with private key auth', async function () {
+                const runner = newRunner('testRemoteUsesPrivateKeyAuth');
+                await runAndDump(runner, nodeVersion);
+                expectSuccess(runner, 'expected private key auth scenario to succeed');
+                assert(outputContains(runner, 'loc_mock_SettingUpSshConnection DummyUser true dummy host 22'), 'should setup ssh connection using endpoint data');
+            });
 
-    it('should run with playbook and inventory on agent machine for agent machine', async function () {
-        this.timeout(30000);
-        let testPath = path.join(__dirname, 'testPlaybookAndInventoryOnAgentMachineForAgentMachine');
-        let runner = new mocktest.MockTestRunner(testPath);
-        await runner.runAsync();
+            it('runs agent machine file inventory flow', async function () {
+                const runner = newRunner('testPlaybookAndInventoryOnAgentMachineForAgentMachine');
+                await runAndDump(runner, nodeVersion);
+                expectSuccess(runner, 'expected agent file inventory scenario to succeed');
+                assert(runner.stdOutContained('cmd run on agent machine = ansible-playbook -i /path/to/ansibleInventory ansiblePlaybook.yml'), 'should execute on agent machine');
+            });
 
-        try {
-            assert(runner.succeeded, "Should have succeeded");
-            assert(runner.stdOutContained('cmd run on agent machine = ansible-playbook -i /path/to/ansibleInventory ansiblePlaybook.yml'), 'should able to run playbook on agent machine');
-        }
-        catch (error) {
-            console.log("STDERR", runner.stderr);
-            console.log("STDOUT", runner.stdout);
-            throw error;
-        }
-    });
+            it('runs agent machine host list flow', async function () {
+                const runner = newRunner('testInventoryToBeHostListForAgentMachine');
+                await runAndDump(runner, nodeVersion);
+                expectSuccess(runner, 'expected agent host list scenario to succeed');
+                assert(runner.stdOutContained('cmd run on agent machine = ansible-playbook -i "Dummy_IP_Address," /path/to/ansiblePlaybookRoot/ansiblePlaybook.yml'), 'should execute using host list');
+            });
 
-    it('should run when inventory is the host list for agent machine', async function () {
-        this.timeout(30000);
-        let testPath = path.join(__dirname, 'testInventoryToBeHostListForAgentMachine');
-        let runner = new mocktest.MockTestRunner(testPath);
-        await runner.runAsync();
+            it('keeps host list comma when already present', async function () {
+                const runner = newRunner('testInventoryHostListWithTrailingCommaForAgentMachine');
+                await runAndDump(runner, nodeVersion);
+                expectSuccess(runner, 'expected host list trailing comma scenario to succeed');
+                assert(runner.stdOutContained('cmd run on agent machine = ansible-playbook -i "Dummy_IP_Address," ansiblePlaybook.yml'), 'should not add duplicate comma');
+            });
 
-        try {
-            assert(runner.succeeded, "Should have succeeded");
-            assert(runner.stdOutContained('cmd run on agent machine = ansible-playbook -i "Dummy_IP_Address," /path/to/ansiblePlaybookRoot/ansiblePlaybook.yml'), 'should able to run playbook on remote machine');
-        }
-        catch (error) {
-            console.log("STDERR", runner.stderr);
-            console.log("STDOUT", runner.stdout);
-            throw error;
-        }
-    });
+            it('runs agent machine inline inventory flow', async function () {
+                const runner = newRunner('testInventoryToBeInlineForAgentMachine');
+                await runAndDump(runner, nodeVersion);
+                expectSuccess(runner, 'expected agent inline scenario to succeed');
+                assert(runner.stdOutContained(`cmd run on agent machine = echo DUMMY_IP_ADDRESS > /tmp/${TestGuid}inventory.ini`), 'should write inline inventory on agent');
+            });
 
-    it('should run when inventory is inline content for agent machine', async function () {
-        this.timeout(30000);
-        let testPath = path.join(__dirname, 'testInventoryToBeInlineForAgentMachine');
-        let runner = new mocktest.MockTestRunner(testPath);
-        await runner.runAsync();
+            it('runs agent machine static inline inventory flow without chmod', async function () {
+                const runner = newRunner('testInventoryInlineStaticForAgentMachine');
+                await runAndDump(runner, nodeVersion);
+                expectSuccess(runner, 'expected agent static inline scenario to succeed');
+                assert(!runner.stdOutContained(`cmd run on agent machine = chmod +x /tmp/${TestGuid}inventory.ini`), 'should not chmod static inventory on agent machine');
+                assert(runner.stdOutContained(`cmd run on agent machine = rm -f /tmp/${TestGuid}inventory.ini`), 'should clean up temporary agent inventory');
+            });
 
-        try {
-            assert(runner.succeeded, "Should have succeeded");
-            assert(runner.stdOutContained(`cmd run on agent machine = echo DUMMY_IP_ADDRESS > /tmp/${TestGuid}inventory.ini`), 'should able to copy the inline content to inventory.ini file on remote machine');
-            assert(runner.stdOutContained(`cmd run on agent machine = chmod +x /tmp/${TestGuid}inventory.ini`), 'should able to make the inventory.ini file as executable for dynamic inventory');
-            assert(runner.stdOutContained(`cmd run on agent machine = ansible-playbook -i /tmp/${TestGuid}inventory.ini /path/to/ansiblePlaybookRoot/ansiblePlaybook.yml`), 'should able to run playbook on remote machine');
-            assert(runner.stdOutContained(`cmd run on agent machine = rm -f /tmp/${TestGuid}inventory.ini`, 'should clean all the temporary inventory file on remote machine'));
-        }
-        catch (error) {
-            console.log("STDERR", runner.stderr);
-            console.log("STDOUT", runner.stdout);
-            throw error;
-        }
+            it('fails on windows agent platform', async function () {
+                const runner = newRunner('failAgentWindowsMachine');
+                await runAndDump(runner, nodeVersion);
+                expectFailure(runner, 'expected windows agent to fail');
+                assert(outputContains(runner, 'loc_mock_AgentOnWindowsMachine'), 'should fail with windows-agent token');
+            });
+
+            it('fails when ansible binary is missing', async function () {
+                const runner = newRunner('failAgentAnsibleNotInstalled');
+                await runAndDump(runner, nodeVersion);
+                expectFailure(runner, 'expected missing ansible to fail');
+                assert(outputContains(runner, 'loc_mock_AnisbleNotPresent'), 'should fail when ansible is unavailable');
+            });
+
+            it('fails when agent command reports stderr with failOnStdErr', async function () {
+                const runner = newRunner('failAgentCommandWhenFailOnStdErr');
+                await runAndDump(runner, nodeVersion);
+                expectFailure(runner, 'expected failOnStdErr on agent machine to fail');
+                assert(outputContains(runner, 'mock stderr from agent command'), 'should surface mock agent stderr failure');
+            });
+
+            it('fails when playbook root is not a directory', async function () {
+                const runner = newRunner('failRemotePlaybookRootNotDirectory');
+                await runAndDump(runner, nodeVersion);
+                expectFailure(runner, 'expected invalid playbook root to fail');
+                assert(outputContains(runner, 'loc_mock_PlaybookRootNotDirectory'), 'should fail with directory validation token');
+            });
+
+            it('fails when playbook file is missing in root', async function () {
+                const runner = newRunner('failRemotePlaybookMissingUnderRoot');
+                await runAndDump(runner, nodeVersion);
+                expectFailure(runner, 'expected missing playbook in root to fail');
+                assert(outputContains(runner, 'loc_mock_PlaybookNotPresent'), 'should fail with playbook missing token');
+            });
+
+            it('fails when inventory file is missing on agent source', async function () {
+                const runner = newRunner('failRemoteInventoryFileMissing');
+                await runAndDump(runner, nodeVersion);
+                expectFailure(runner, 'expected missing inventory file to fail');
+                assert(outputContains(runner, 'loc_mock_InventoryFileNotPresent'), 'should fail with inventory missing token');
+            });
+
+            it('fails when ssh setup fails', async function () {
+                const runner = newRunner('failRemoteSshConnection');
+                await runAndDump(runner, nodeVersion);
+                expectFailure(runner, 'expected ssh setup failure');
+                assert(outputContains(runner, 'mock ssh connect failed'), 'should surface ssh setup failure reason');
+            });
+
+            it('fails when playbook copy fails', async function () {
+                const runner = newRunner('failRemoteCopyPlaybook');
+                await runAndDump(runner, nodeVersion);
+                expectFailure(runner, 'expected remote copy failure');
+                assert(outputContains(runner, 'mock scp failed'), 'should surface copy failure reason');
+            });
+
+            it('fails when remote command reports stderr with failOnStdErr', async function () {
+                const runner = newRunner('failRemoteCommandWhenFailOnStdErr');
+                await runAndDump(runner, nodeVersion);
+                expectFailure(runner, 'expected remote failOnStdErr failure');
+                assert(outputContains(runner, 'mock stderr from remote command'), 'should surface mock remote stderr failure');
+            });
+
+            it('fails when remote command execution rejects', async function () {
+                const runner = newRunner('failRemoteCommandError');
+                await runAndDump(runner, nodeVersion);
+                expectFailure(runner, 'expected remote command rejection failure');
+                assert(outputContains(runner, 'mock remote command failed'), 'should surface remote command rejection reason');
+            });
+
+            it('runs ansible tower success baseline', async function () {
+                const runner = newRunner('testTower');
+                await runAndDump(runner, nodeVersion);
+                expectSuccess(runner, 'expected tower baseline scenario to succeed');
+                assert(runner.stdOutContained('Dummy stdout 1'), 'should output tower event 1');
+                assert(runner.stdOutContained('Dummy stdout 2'), 'should output tower event 2');
+                assert(runner.stdOutContained('Dummy stdout 3'), 'should output tower event 3');
+            });
+
+            it('runs ansible tower pagination scenario', async function () {
+                const runner = newRunner('testTowerPagination');
+                await runAndDump(runner, nodeVersion);
+                expectSuccess(runner, 'expected tower pagination scenario to succeed');
+                assert(runner.stdOutContained('Page1 stdout'), 'should output first page event');
+                assert(runner.stdOutContained('Page2 stdout'), 'should output second page event');
+            });
+
+            it('fails when tower job template is not found', async function () {
+                const runner = newRunner('failTowerTemplateNotFound');
+                await runAndDump(runner, nodeVersion);
+                expectFailure(runner, 'expected tower template-not-found to fail');
+                assert(outputContains(runner, 'loc_mock_JobTemplateNotPresent'), 'should fail with template-not-found token');
+            });
+
+            it('fails when tower template lookup succeeds with no results', async function () {
+                const runner = newRunner('failTowerTemplateEmptyResults');
+                await runAndDump(runner, nodeVersion);
+                expectFailure(runner, 'expected empty tower template lookup to fail');
+                assert(outputContains(runner, 'loc_mock_JobTemplateNotPresent'), 'should fail cleanly when tower template search returns no matches');
+            });
+
+            it('fails when tower launch returns non-201', async function () {
+                const runner = newRunner('failTowerLaunch');
+                await runAndDump(runner, nodeVersion);
+                expectFailure(runner, 'expected tower launch error to fail');
+                assert(outputContains(runner, 'loc_mock_CouldnotLaunchJob'), 'should fail when launch API does not return 201');
+            });
+
+            it('fails when tower job status becomes failed', async function () {
+                const runner = newRunner('testTowerFailedJob');
+                await runAndDump(runner, nodeVersion);
+                expectFailure(runner, 'expected tower failed-job status to fail task');
+            });
+
+            it('fails when tower job status api returns non-200', async function () {
+                const runner = newRunner('failTowerJobStatusApi');
+                await runAndDump(runner, nodeVersion);
+                expectFailure(runner, 'expected tower job status API error to fail');
+                assert(outputContains(runner, 'loc_mock_FailedToGetJobDetails'), 'should fail with job status fetch token');
+            });
+
+            it('fails when tower events api returns non-200', async function () {
+                const runner = newRunner('failTowerEventsApi');
+                await runAndDump(runner, nodeVersion);
+                expectFailure(runner, 'expected tower events API error to fail');
+                assert(outputContains(runner, 'loc_mock_FailedToGetJobDetails'), 'should fail with job details fetch token');
+            });
+        });
     });
 });

--- a/Extensions/Ansible/Tests/Tasks/Ansible/failAgentAnsibleNotInstalled.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/failAgentAnsibleNotInstalled.ts
@@ -1,0 +1,8 @@
+import { createRunner, configureBaseAgentMachine, getMockUtils } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseAgentMachine(runner);
+
+getMockUtils().setMockAnsibleAvailable(false);
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/failAgentCommandWhenFailOnStdErr.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/failAgentCommandWhenFailOnStdErr.ts
@@ -1,0 +1,10 @@
+import { createRunner, configureBaseAgentMachine, getMockUtils } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseAgentMachine(runner);
+runner.setInput('failOnStdErr', 'true');
+
+const mockUtils = getMockUtils();
+mockUtils.setMockFailAgentOnStdErr(true);
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/failAgentWindowsMachine.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/failAgentWindowsMachine.ts
@@ -1,0 +1,8 @@
+import { createRunner, configureBaseAgentMachine, getMockUtils } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseAgentMachine(runner);
+
+getMockUtils().setMockAgentPlatform('win32');
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/failRemoteCommandError.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/failRemoteCommandError.ts
@@ -1,0 +1,9 @@
+import { createRunner, configureBaseRemoteMachine, setSshEndpointEnvironment, getMockUtils } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseRemoteMachine(runner);
+
+setSshEndpointEnvironment();
+getMockUtils().setMockRemoteCommandError('mock remote command failed');
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/failRemoteCommandWhenFailOnStdErr.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/failRemoteCommandWhenFailOnStdErr.ts
@@ -1,0 +1,10 @@
+import { createRunner, configureBaseRemoteMachine, setSshEndpointEnvironment, getMockUtils } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseRemoteMachine(runner);
+runner.setInput('failOnStdErr', 'true');
+
+setSshEndpointEnvironment();
+getMockUtils().setMockFailRemoteOnStdErr(true);
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/failRemoteCopyPlaybook.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/failRemoteCopyPlaybook.ts
@@ -1,0 +1,17 @@
+import { createRunner, setSshEndpointEnvironment, getMockUtils } from './scenarioHelpers';
+
+const runner = createRunner();
+runner.setInput('ansibleInterface', 'remoteMachine');
+runner.setInput('connectionOverSsh', '8b04f8a5-9a17-474d-836c-60c24edcfa50');
+runner.setInput('playbookSourceRemoteMachine', 'agentMachine');
+runner.setInput('playbookRootRemoteMachine', '/path/to/ansiblePlaybookRoot');
+runner.setInput('playbookPathLinkedArtifactOnRemoteMachine', 'ansiblePlaybook.yml');
+runner.setInput('inventoriesRemoteMachine', 'hostList');
+runner.setInput('inventoryHostListRemoteMachine', 'Dummy_IP_Address');
+runner.setInput('sudoEnabled', 'false');
+runner.setInput('args', '');
+
+setSshEndpointEnvironment();
+getMockUtils().setMockCopyError('mock scp failed');
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/failRemoteInventoryFileMissing.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/failRemoteInventoryFileMissing.ts
@@ -1,0 +1,17 @@
+import { createRunner, setSshEndpointEnvironment, getMockUtils } from './scenarioHelpers';
+
+const runner = createRunner();
+runner.setInput('ansibleInterface', 'remoteMachine');
+runner.setInput('connectionOverSsh', '8b04f8a5-9a17-474d-836c-60c24edcfa50');
+runner.setInput('playbookSourceRemoteMachine', 'ansibleMachine');
+runner.setInput('playbookPathAnsibleMachineOnRemoteMachine', '/path/to/ansiblePlaybookRoot/ansiblePlaybook.yml');
+runner.setInput('inventoriesRemoteMachine', 'file');
+runner.setInput('inventoryFileSourceRemoteMachine', 'agentMachine');
+runner.setInput('inventoryFileLinkedArtifactOnRemoteMachine', '/path/to/ansibleInventory');
+runner.setInput('sudoEnabled', 'false');
+runner.setInput('args', '');
+
+setSshEndpointEnvironment();
+getMockUtils().setMockFileExists('/path/to/ansibleInventory', false);
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/failRemotePlaybookMissingUnderRoot.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/failRemotePlaybookMissingUnderRoot.ts
@@ -1,0 +1,17 @@
+import { createRunner, setSshEndpointEnvironment, getMockUtils } from './scenarioHelpers';
+
+const runner = createRunner();
+runner.setInput('ansibleInterface', 'remoteMachine');
+runner.setInput('connectionOverSsh', '8b04f8a5-9a17-474d-836c-60c24edcfa50');
+runner.setInput('playbookSourceRemoteMachine', 'agentMachine');
+runner.setInput('playbookRootRemoteMachine', '/path/to/ansiblePlaybookRoot');
+runner.setInput('playbookPathLinkedArtifactOnRemoteMachine', 'ansiblePlaybook.yml');
+runner.setInput('inventoriesRemoteMachine', 'hostList');
+runner.setInput('inventoryHostListRemoteMachine', 'Dummy_IP_Address');
+runner.setInput('sudoEnabled', 'false');
+runner.setInput('args', '');
+
+setSshEndpointEnvironment();
+getMockUtils().setMockFileExists('/path/to/ansiblePlaybookRoot/ansiblePlaybook.yml', false);
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/failRemotePlaybookRootNotDirectory.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/failRemotePlaybookRootNotDirectory.ts
@@ -1,0 +1,17 @@
+import { createRunner, setSshEndpointEnvironment, getMockUtils } from './scenarioHelpers';
+
+const runner = createRunner();
+runner.setInput('ansibleInterface', 'remoteMachine');
+runner.setInput('connectionOverSsh', '8b04f8a5-9a17-474d-836c-60c24edcfa50');
+runner.setInput('playbookSourceRemoteMachine', 'agentMachine');
+runner.setInput('playbookRootRemoteMachine', '/path/to/ansiblePlaybookRoot');
+runner.setInput('playbookPathLinkedArtifactOnRemoteMachine', 'ansiblePlaybook.yml');
+runner.setInput('inventoriesRemoteMachine', 'hostList');
+runner.setInput('inventoryHostListRemoteMachine', 'Dummy_IP_Address');
+runner.setInput('sudoEnabled', 'false');
+runner.setInput('args', '');
+
+setSshEndpointEnvironment();
+getMockUtils().setMockDirectoryExists('/path/to/ansiblePlaybookRoot', false);
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/failRemoteSshConnection.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/failRemoteSshConnection.ts
@@ -1,0 +1,9 @@
+import { createRunner, configureBaseRemoteMachine, setSshEndpointEnvironment, getMockUtils } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseRemoteMachine(runner);
+
+setSshEndpointEnvironment();
+getMockUtils().setMockSshSetupError('mock ssh connect failed');
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/failTowerEventsApi.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/failTowerEventsApi.ts
@@ -1,0 +1,11 @@
+import { createRunner, configureBaseTower, setTowerEnvironment, getMockUtils } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseTower(runner);
+setTowerEnvironment();
+
+const mockUtils = getMockUtils();
+mockUtils.setMockTowerStatusSequence(['running']);
+mockUtils.setMockTowerEventsStatusCode(500);
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/failTowerJobStatusApi.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/failTowerJobStatusApi.ts
@@ -1,0 +1,9 @@
+import { createRunner, configureBaseTower, setTowerEnvironment, getMockUtils } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseTower(runner);
+setTowerEnvironment();
+
+getMockUtils().setMockTowerStatusStatusCode(500);
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/failTowerLaunch.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/failTowerLaunch.ts
@@ -1,0 +1,9 @@
+import { createRunner, configureBaseTower, setTowerEnvironment, getMockUtils } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseTower(runner);
+setTowerEnvironment();
+
+getMockUtils().setMockTowerLaunchStatusCode(500);
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/failTowerTemplateEmptyResults.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/failTowerTemplateEmptyResults.ts
@@ -1,0 +1,9 @@
+import { createRunner, configureBaseTower, setTowerEnvironment, getMockUtils } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseTower(runner);
+setTowerEnvironment();
+
+getMockUtils().setMockTowerTemplate(200, false);
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/failTowerTemplateNotFound.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/failTowerTemplateNotFound.ts
@@ -4,6 +4,6 @@ const runner = createRunner();
 configureBaseTower(runner);
 setTowerEnvironment();
 
-getMockUtils().setMockTowerTemplate(200, false);
+getMockUtils().setMockTowerTemplate(404, false);
 
 runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/failTowerTemplateNotFound.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/failTowerTemplateNotFound.ts
@@ -1,0 +1,9 @@
+import { createRunner, configureBaseTower, setTowerEnvironment, getMockUtils } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseTower(runner);
+setTowerEnvironment();
+
+getMockUtils().setMockTowerTemplate(200, false);
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/mockAnsibleUtils.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/mockAnsibleUtils.ts
@@ -2,6 +2,156 @@ import Q = require("q");
 
 export const TestGuid: string = "7d9b7f32-41e5-43ed-8b0e-c6f2874836f8";
 
+const DEFAULT_TOWER_HOST = "true dummy host";
+
+interface MockState {
+    platform: string;
+    hasAnsible: boolean;
+    sshSetupError: string;
+    remoteCommandError: string;
+    sameMachineCommandError: string;
+    copyError: string;
+    failRemoteOnStdErr: boolean;
+    failAgentOnStdErr: boolean;
+    fileExists: { [path: string]: boolean };
+    directoryExists: { [path: string]: boolean };
+    towerTemplateStatusCode: number;
+    towerTemplateFound: boolean;
+    towerLaunchStatusCode: number;
+    towerJobStatusStatusCode: number;
+    towerJobStatusSequence: string[];
+    towerEventsPages: any[];
+    towerEventsStatusCode: number;
+}
+
+let state: MockState = getDefaultState();
+
+function getDefaultState(): MockState {
+    return {
+        platform: 'linux',
+        hasAnsible: true,
+        sshSetupError: "",
+        remoteCommandError: "",
+        sameMachineCommandError: "",
+        copyError: "",
+        failRemoteOnStdErr: false,
+        failAgentOnStdErr: false,
+        fileExists: {},
+        directoryExists: {},
+        towerTemplateStatusCode: 200,
+        towerTemplateFound: true,
+        towerLaunchStatusCode: 201,
+        towerJobStatusStatusCode: 200,
+        towerJobStatusSequence: ['successful'],
+        towerEventsPages: [{
+            count: 3,
+            next: null,
+            previous: null,
+            results: [
+                {
+                    id: 5813,
+                    type: "job_event",
+                    job: 559,
+                    counter: 2,
+                    stdout: "Dummy stdout 2"
+                },
+                {
+                    id: 5814,
+                    type: "job_event",
+                    job: 559,
+                    counter: 1,
+                    stdout: "Dummy stdout 1"
+                },
+                {
+                    id: 5815,
+                    type: "job_event",
+                    job: 559,
+                    counter: 3,
+                    stdout: "Dummy stdout 3"
+                }
+            ]
+        }],
+        towerEventsStatusCode: 200
+    };
+}
+
+    function normalizePathKey(value: string): string {
+        return (value || '').replace(/\\/g, '/');
+    }
+
+function getTowerHost(): string {
+    return process.env["ENDPOINT_URL_8b04f8a5-9a17-474d-836c-60c24edcfa50"] || DEFAULT_TOWER_HOST;
+}
+
+export function resetMockState(): void {
+    state = getDefaultState();
+}
+
+export function setMockAgentPlatform(platform: string): void {
+    state.platform = platform;
+}
+
+export function setMockAnsibleAvailable(isAvailable: boolean): void {
+    state.hasAnsible = isAvailable;
+}
+
+export function setMockSshSetupError(message: string): void {
+    state.sshSetupError = message;
+}
+
+export function setMockRemoteCommandError(message: string): void {
+    state.remoteCommandError = message;
+}
+
+export function setMockSameMachineCommandError(message: string): void {
+    state.sameMachineCommandError = message;
+}
+
+export function setMockCopyError(message: string): void {
+    state.copyError = message;
+}
+
+export function setMockFailRemoteOnStdErr(shouldFail: boolean): void {
+    state.failRemoteOnStdErr = shouldFail;
+}
+
+export function setMockFailAgentOnStdErr(shouldFail: boolean): void {
+    state.failAgentOnStdErr = shouldFail;
+}
+
+export function setMockFileExists(path: string, exists: boolean): void {
+    state.fileExists[normalizePathKey(path)] = exists;
+}
+
+export function setMockDirectoryExists(path: string, exists: boolean): void {
+    state.directoryExists[normalizePathKey(path)] = exists;
+}
+
+export function setMockTowerTemplate(statusCode: number, found: boolean): void {
+    state.towerTemplateStatusCode = statusCode;
+    state.towerTemplateFound = found;
+}
+
+export function setMockTowerLaunchStatusCode(statusCode: number): void {
+    state.towerLaunchStatusCode = statusCode;
+}
+
+export function setMockTowerStatusStatusCode(statusCode: number): void {
+    state.towerJobStatusStatusCode = statusCode;
+}
+
+export function setMockTowerStatusSequence(sequence: string[]): void {
+    state.towerJobStatusSequence = sequence && sequence.length > 0 ? sequence.slice(0) : ['successful'];
+}
+
+export function setMockTowerEventsPages(pages: any[]): void {
+    state.towerEventsPages = pages && pages.length > 0 ? pages.slice(0) : [{ count: 0, next: null, previous: null, results: [] }];
+}
+
+export function setMockTowerEventsStatusCode(statusCode: number): void {
+    state.towerEventsStatusCode = statusCode;
+}
+
 export function _writeLine(str) {
     console.log(str);
 }
@@ -21,6 +171,10 @@ export class DummyClient {
 
 export function setupSshClientConnection(cfg) {
     var defer = Q.defer<any>();
+    if (state.sshSetupError) {
+        defer.reject(state.sshSetupError);
+        return defer.promise;
+    }
     var client = new this.DummyClient();
     defer.resolve(client);
     return defer.promise;
@@ -28,6 +182,17 @@ export function setupSshClientConnection(cfg) {
 
 export function runCommandOnRemoteMachine(cmd: string, sshClient: any, options: RemoteCommandOptions) {
     var defer = Q.defer<string>();
+    if (state.remoteCommandError) {
+        defer.reject(state.remoteCommandError);
+        return defer.promise;
+    }
+
+    if (state.failRemoteOnStdErr && options && options.failOnStdErr) {
+        defer.reject("mock stderr from remote command");
+        return defer.promise;
+    }
+
+    this._writeLine("[mock-remote-cmd] " + cmd);
     this._writeLine("cmd run on remote machine = " + cmd);
     defer.resolve("0");
     return defer.promise;
@@ -35,6 +200,11 @@ export function runCommandOnRemoteMachine(cmd: string, sshClient: any, options: 
 
 export function copyFileToRemoteMachine(scriptFile: string, dest: string, scpConfig: any): Q.Promise<string> {
     var defer = Q.defer<string>();
+    if (state.copyError) {
+        defer.reject(state.copyError);
+        return defer.promise;
+    }
+    this._writeLine("[mock-copy] " + scriptFile + " -> " + dest);
     this._writeLine("copied file to remote machine = " + scriptFile);
     defer.resolve("0");
     return defer.promise;
@@ -42,25 +212,46 @@ export function copyFileToRemoteMachine(scriptFile: string, dest: string, scpCon
 
 export function runCommandOnSameMachine(cmd: string, options: RemoteCommandOptions) {
     var defer = Q.defer<string>();
+    if (state.sameMachineCommandError) {
+        defer.reject(state.sameMachineCommandError);
+        return defer.promise;
+    }
+
+    if (state.failAgentOnStdErr && options && options.failOnStdErr) {
+        defer.reject("mock stderr from agent command");
+        return defer.promise;
+    }
+
+    this._writeLine("[mock-agent-cmd] " + cmd);
     this._writeLine("cmd run on agent machine = " + cmd);
     defer.resolve("0");
     return defer.promise;
 }
 
 export function testIfFileExist(filePath: string): boolean {
+    var normalizedPath = normalizePathKey(filePath);
+    if (state.fileExists.hasOwnProperty(normalizedPath)) {
+        return state.fileExists[normalizedPath];
+    }
+
     return true;
 }
 
 export function testIfDirectoryExist(directoryPath: string): boolean {
+    var normalizedPath = normalizePathKey(directoryPath);
+    if (state.directoryExists.hasOwnProperty(normalizedPath)) {
+        return state.directoryExists[normalizedPath];
+    }
+
     return true;
 }
 
 export function getAgentPlatform(): string {
-    return 'linux';
+    return state.platform;
 }
 
 export function getShellWhich(moduleName: string): string {
-    return "somePath";
+    return state.hasAnsible ? "somePath" : "";
 }
 
 export class WebResponse {
@@ -78,81 +269,92 @@ export class WebRequest {
 }
 
 export function beginRequest(request) {
-    var paths = request.uri.split('/');
+    var res = new WebResponse();
+    var host = getTowerHost();
 
-    if (paths[3] == 'job_templates' && paths[5] != 'launch') {
-        var body =`{
-                    "count": 1,
-                    "results": [
-                        {
-                            "id": 9,
-                            "type": "job_template",
-                            "url": "/api/v1/job_templates/9/" 
-                        }
-                    ]
-                }`;
-        var res = new WebResponse();
-        res.statusCode = 200;
-        res.body = JSON.parse(body);
+    if (request.uri.indexOf('/job_templates/?name__exact=') >= 0) {
+        res.statusCode = state.towerTemplateStatusCode;
+        if (state.towerTemplateStatusCode === 200) {
+            res.body = {
+                count: state.towerTemplateFound ? 1 : 0,
+                results: state.towerTemplateFound ? [{ id: 9, type: 'job_template', url: '/api/v1/job_templates/9/' }] : []
+            };
+        } else {
+            res.statusMessage = "mock template error";
+            res.body = {};
+        }
         return res;
     }
-    if(paths[3] == 'job_templates' && paths[5] == 'launch') {
-        var body = `{
-                        "id": 559,
-                        "type": "job",
-                        "url": "/api/v1/jobs/559/"
-                    }`;
-        var res = new WebResponse();
-        res.statusCode = 201;
-        res.body = JSON.parse(body);
+
+    if (request.uri.indexOf('/job_templates/') >= 0 && request.uri.indexOf('/launch/') >= 0) {
+        res.statusCode = state.towerLaunchStatusCode;
+        if (state.towerLaunchStatusCode === 201) {
+            res.body = { id: 559, type: 'job', url: '/api/v1/jobs/559/' };
+        } else {
+            res.statusMessage = "mock launch error";
+            res.body = {};
+        }
         return res;
     }
-    if(paths[3] == 'jobs' && paths[5] != 'job_events') {
-        var body = `{
-                        "id": 559,
-                        "type": "job",
-                        "url": "/api/v1/jobs/559/",
-                        "status": "successful"
-                    }`;
-        var res = new WebResponse();
-        res.statusCode = 200;
-        res.body = JSON.parse(body);
+
+    if (request.uri.indexOf('/jobs/') >= 0 && request.uri.indexOf('/job_events/') < 0) {
+        res.statusCode = state.towerJobStatusStatusCode;
+        if (state.towerJobStatusStatusCode !== 200) {
+            res.statusMessage = 'mock job status error';
+            res.body = {};
+            return res;
+        }
+
+        var nextStatus = state.towerJobStatusSequence.length > 0 ? state.towerJobStatusSequence.shift() : 'successful';
+        res.body = {
+            id: 559,
+            type: 'job',
+            url: '/api/v1/jobs/559/',
+            status: nextStatus
+        };
         return res;
     }
-    if(paths[3] == 'jobs' && paths[5] == 'job_events') {
-        var body = `{
-                        "count": 3,
-                        "next": null,
-                        "previous": null,
-                        "results": [
-                            {
-                                "id": 5813,
-                                "type": "job_event",
-                                "job": 559,
-                                "counter": 2,
-                                "stdout": "Dummy stdout 2"
-                            },
-                            {
-                                "id": 5814,
-                                "type": "job_event",
-                                "job": 559,
-                                "counter": 1,
-                                "stdout": "Dummy stdout 1"
-                            },      
-                            {
-                                "id": 5815,
-                                "type": "job_event",
-                                "job": 559,
-                                "counter": 3,
-                                "stdout": "Dummy stdout 3"
-                            }  
-                        ]
-                    }`;
-        var res = new WebResponse();
-        res.statusCode = 200;
-        res.body = JSON.parse(body);
+
+    if (request.uri.indexOf('/job_events/') >= 0) {
+        res.statusCode = state.towerEventsStatusCode;
+        if (state.towerEventsStatusCode !== 200) {
+            res.statusMessage = "mock events error";
+            res.body = {};
+            return res;
+        }
+
+        var page = 1;
+        var match = /[?&]page=(\d+)/.exec(request.uri);
+        if (match && match[1]) {
+            page = parseInt(match[1], 10);
+        }
+
+        var index = page - 1;
+        var selectedPage = state.towerEventsPages[index] || { count: 0, next: null, previous: null, results: [] };
+        var nextLink = selectedPage.next;
+
+        if (nextLink === true) {
+            nextLink = '/api/v1/jobs/559/job_events/?page_size=10&page=' + (page + 1);
+        }
+
+        if (typeof nextLink === 'string' && nextLink.indexOf('http') !== 0 && nextLink.indexOf('/') === 0) {
+            selectedPage.next = nextLink;
+        }
+
+        res.body = {
+            count: selectedPage.count || 0,
+            next: selectedPage.next || null,
+            previous: selectedPage.previous || null,
+            results: selectedPage.results || []
+        };
         return res;
     }
+
+    res.statusCode = 404;
+    res.statusMessage = "mock not found";
+    res.body = {};
+    this._writeLine('[mock-http-unknown] ' + request.uri + ' on ' + host);
+    return res;
 }
 
 export function getTemporaryInventoryFilePath(): string {

--- a/Extensions/Ansible/Tests/Tasks/Ansible/scenarioHelpers.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/scenarioHelpers.ts
@@ -49,8 +49,17 @@ export function setTowerEnvironment(options?: {
     password?: string;
     url?: string;
 }): void {
-    process.env['ENDPOINT_AUTH_PARAMETER_' + EndpointId + '_USERNAME'] = (options && options.username) || 'DummyUser';
-    process.env['ENDPOINT_AUTH_PARAMETER_' + EndpointId + '_PASSWORD'] = (options && options.password) || 'DummyPassword';
+    const username = (options && options.username) || 'DummyUser';
+    const password = (options && options.password) || 'DummyPassword';
+
+    process.env['ENDPOINT_AUTH_PARAMETER_' + EndpointId + '_USERNAME'] = username;
+    process.env['ENDPOINT_AUTH_PARAMETER_' + EndpointId + '_PASSWORD'] = password;
+    process.env['ENDPOINT_AUTH_' + EndpointId] = JSON.stringify({
+        parameters: {
+            username: username,
+            password: password
+        }
+    });
     process.env['ENDPOINT_URL_' + EndpointId] = (options && options.url) || 'true dummy host';
 }
 

--- a/Extensions/Ansible/Tests/Tasks/Ansible/scenarioHelpers.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/scenarioHelpers.ts
@@ -13,6 +13,7 @@ export function createRunner(): mockrun.TaskMockRunner {
 
     const runner = new mockrun.TaskMockRunner(taskPath);
     runner.registerMock('azure-pipelines-task-lib/toolrunner', require('azure-pipelines-task-lib/mock-toolrunner'));
+    runner.registerMock('azure-pipelines-task-lib/task', require('azure-pipelines-task-lib/mock-task'));
     runner.registerMock('./ansibleUtils', mockUtils);
 
     process.env['AZURE_HTTP_USER_AGENT'] = 'TFS_useragent';

--- a/Extensions/Ansible/Tests/Tasks/Ansible/scenarioHelpers.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/scenarioHelpers.ts
@@ -1,4 +1,3 @@
-import mockanswer = require('azure-pipelines-task-lib/mock-answer');
 import mockrun = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 

--- a/Extensions/Ansible/Tests/Tasks/Ansible/scenarioHelpers.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/scenarioHelpers.ts
@@ -13,7 +13,6 @@ export function createRunner(): mockrun.TaskMockRunner {
 
     const runner = new mockrun.TaskMockRunner(taskPath);
     runner.registerMock('azure-pipelines-task-lib/toolrunner', require('azure-pipelines-task-lib/mock-toolrunner'));
-    runner.registerMock('azure-pipelines-task-lib/task', require('azure-pipelines-task-lib/mock-task'));
     runner.registerMock('./ansibleUtils', mockUtils);
 
     process.env['AZURE_HTTP_USER_AGENT'] = 'TFS_useragent';

--- a/Extensions/Ansible/Tests/Tasks/Ansible/scenarioHelpers.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/scenarioHelpers.ts
@@ -1,0 +1,85 @@
+import mockanswer = require('azure-pipelines-task-lib/mock-answer');
+import mockrun = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+const mockUtils = require('./mockAnsibleUtils');
+
+export const EndpointId = '8b04f8a5-9a17-474d-836c-60c24edcfa50';
+
+const taskPath = path.join(__dirname, '../../../Src/Tasks/Ansible/main.js');
+
+export function createRunner(): mockrun.TaskMockRunner {
+    mockUtils.resetMockState();
+
+    const runner = new mockrun.TaskMockRunner(taskPath);
+    runner.registerMock('azure-pipelines-task-lib/toolrunner', require('azure-pipelines-task-lib/mock-toolrunner'));
+    runner.registerMock('./ansibleUtils', mockUtils);
+
+    process.env['AZURE_HTTP_USER_AGENT'] = 'TFS_useragent';
+
+    return runner;
+}
+
+export function setSshEndpointEnvironment(options?: {
+    username?: string;
+    password?: string;
+    host?: string;
+    port?: string;
+    privateKey?: string;
+}): void {
+    const username = options && options.username ? options.username : 'DummyUser';
+    const password = options && options.password ? options.password : 'DummyPassword';
+    const host = options && options.host ? options.host : 'true dummy host';
+    const port = options && options.port !== undefined ? options.port : '22';
+
+    process.env['ENDPOINT_AUTH_PARAMETER_' + EndpointId + '_USERNAME'] = username;
+    process.env['ENDPOINT_AUTH_PARAMETER_' + EndpointId + '_PASSWORD'] = password;
+    process.env['ENDPOINT_DATA_' + EndpointId + '_HOST'] = host;
+    process.env['ENDPOINT_DATA_' + EndpointId + '_PORT'] = port;
+
+    if (options && options.privateKey !== undefined) {
+        process.env['ENDPOINT_DATA_' + EndpointId + '_PRIVATEKEY'] = options.privateKey;
+    } else {
+        delete process.env['ENDPOINT_DATA_' + EndpointId + '_PRIVATEKEY'];
+    }
+}
+
+export function setTowerEnvironment(options?: {
+    username?: string;
+    password?: string;
+    url?: string;
+}): void {
+    process.env['ENDPOINT_AUTH_PARAMETER_' + EndpointId + '_USERNAME'] = (options && options.username) || 'DummyUser';
+    process.env['ENDPOINT_AUTH_PARAMETER_' + EndpointId + '_PASSWORD'] = (options && options.password) || 'DummyPassword';
+    process.env['ENDPOINT_URL_' + EndpointId] = (options && options.url) || 'true dummy host';
+}
+
+export function configureBaseRemoteMachine(runner: mockrun.TaskMockRunner): void {
+    runner.setInput('ansibleInterface', 'remoteMachine');
+    runner.setInput('connectionOverSsh', EndpointId);
+    runner.setInput('playbookSourceRemoteMachine', 'ansibleMachine');
+    runner.setInput('playbookPathAnsibleMachineOnRemoteMachine', '/path/to/ansiblePlaybookRoot/ansiblePlaybook.yml');
+    runner.setInput('inventoriesRemoteMachine', 'hostList');
+    runner.setInput('inventoryHostListRemoteMachine', 'Dummy_IP_Address');
+    runner.setInput('sudoEnabled', 'false');
+    runner.setInput('args', '');
+}
+
+export function configureBaseAgentMachine(runner: mockrun.TaskMockRunner): void {
+    runner.setInput('ansibleInterface', 'agentMachine');
+    runner.setInput('playbookPathOnAgentMachine', 'ansiblePlaybook.yml');
+    runner.setInput('inventoriesAgentMachine', 'file');
+    runner.setInput('inventoryFileOnAgentMachine', '/path/to/ansibleInventory');
+    runner.setInput('sudoEnabled', 'false');
+    runner.setInput('args', '');
+}
+
+export function configureBaseTower(runner: mockrun.TaskMockRunner): void {
+    runner.setInput('ansibleInterface', 'ansibleTower');
+    runner.setInput('connectionAnsibleTower', EndpointId);
+    runner.setInput('jobTemplateName', 'Demo Job Template 3');
+}
+
+export function getMockUtils(): any {
+    return mockUtils;
+}

--- a/Extensions/Ansible/Tests/Tasks/Ansible/testInventoryHostListWithTrailingCommaForAgentMachine.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/testInventoryHostListWithTrailingCommaForAgentMachine.ts
@@ -1,0 +1,8 @@
+import { createRunner, configureBaseAgentMachine } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseAgentMachine(runner);
+runner.setInput('inventoriesAgentMachine', 'hostList');
+runner.setInput('inventoryHostListAgentMachine', 'Dummy_IP_Address,');
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/testInventoryHostListWithTrailingCommaForRemoteMachine.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/testInventoryHostListWithTrailingCommaForRemoteMachine.ts
@@ -1,0 +1,9 @@
+import { createRunner, configureBaseRemoteMachine, setSshEndpointEnvironment } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseRemoteMachine(runner);
+runner.setInput('inventoryHostListRemoteMachine', 'Dummy_IP_Address,');
+
+setSshEndpointEnvironment();
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/testInventoryInlineStaticForAgentMachine.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/testInventoryInlineStaticForAgentMachine.ts
@@ -1,0 +1,10 @@
+import { createRunner, configureBaseAgentMachine } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseAgentMachine(runner);
+runner.setInput('inventoriesAgentMachine', 'inlineContent');
+runner.setInput('inventoryInlineDynamicAgentMachine', 'false');
+runner.setInput('inventoryInlineContentAgentMachine', 'DUMMY_IP_ADDRESS');
+runner.setInput('playbookPathOnAgentMachine', '/path/to/ansiblePlaybookRoot/ansiblePlaybook.yml');
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/testInventoryInlineStaticForRemoteMachine.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/testInventoryInlineStaticForRemoteMachine.ts
@@ -1,0 +1,12 @@
+import { createRunner, configureBaseRemoteMachine, setSshEndpointEnvironment } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseRemoteMachine(runner);
+
+runner.setInput('inventoriesRemoteMachine', 'inlineContent');
+runner.setInput('inventoryInlineDynamicRemoteMachine', 'false');
+runner.setInput('inventoryInlineContentRemoteMachine', 'DUMMY_IP_ADDRESS');
+
+setSshEndpointEnvironment();
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/testRemoteUsesDefaultPort.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/testRemoteUsesDefaultPort.ts
@@ -1,0 +1,8 @@
+import { createRunner, configureBaseRemoteMachine, setSshEndpointEnvironment } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseRemoteMachine(runner);
+
+setSshEndpointEnvironment({ port: '' });
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/testRemoteUsesPrivateKeyAuth.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/testRemoteUsesPrivateKeyAuth.ts
@@ -1,0 +1,11 @@
+import { createRunner, configureBaseRemoteMachine, setSshEndpointEnvironment } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseRemoteMachine(runner);
+
+setSshEndpointEnvironment({
+    password: 'passphrase',
+    privateKey: '-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----'
+});
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/testRemoteUsesPrivateKeyAuth.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/testRemoteUsesPrivateKeyAuth.ts
@@ -5,7 +5,7 @@ configureBaseRemoteMachine(runner);
 
 setSshEndpointEnvironment({
     password: 'passphrase',
-    privateKey: '-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----'
+    privateKey: 'mock-private-key'
 });
 
 runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/testSudoUserProvidedForRemoteMachine.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/testSudoUserProvidedForRemoteMachine.ts
@@ -1,0 +1,10 @@
+import { createRunner, configureBaseRemoteMachine, setSshEndpointEnvironment } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseRemoteMachine(runner);
+runner.setInput('sudoEnabled', 'true');
+runner.setInput('sudoUser', 'deployer');
+
+setSshEndpointEnvironment();
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/testTower.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/testTower.ts
@@ -1,23 +1,7 @@
-import mockanswer = require('azure-pipelines-task-lib/mock-answer');
-import mockrun = require('azure-pipelines-task-lib/mock-run');
-import path = require('path');
+import { createRunner, configureBaseTower, setTowerEnvironment } from './scenarioHelpers';
 
-
-let taskPath = path.join(__dirname, '../../../Src/Tasks/Ansible/main.js');
-let runner = new mockrun.TaskMockRunner(taskPath);
-runner.setInput('ansibleInterface', 'ansibleTower');
-runner.setInput('connectionAnsibleTower', '8b04f8a5-9a17-474d-836c-60c24edcfa50');
-runner.setInput('jobTemplateName', 'Demo Job Template 3');
-
-process.env["AZURE_HTTP_USER_AGENT"] = "TFS_useragent";
-process.env["ENDPOINT_AUTH_PARAMETER_8b04f8a5-9a17-474d-836c-60c24edcfa50_USERNAME"] = "DummyUser";
-process.env["ENDPOINT_AUTH_PARAMETER_8b04f8a5-9a17-474d-836c-60c24edcfa50_PASSWORD"] = "DummyPassword";
-process.env["ENDPOINT_URL_8b04f8a5-9a17-474d-836c-60c24edcfa50"] = "true dummy host";
-
-var tl = require('azure-pipelines-task-lib/mock-task');
-runner.registerMock('azure-pipelines-task-lib/toolrunner', require('azure-pipelines-task-lib/mock-toolrunner'));
-runner.registerMock('azure-pipelines-task-lib/task', require('azure-pipelines-task-lib/mock-task'));
-
-runner.registerMock('./ansibleUtils', require('./mockAnsibleUtils'));
+const runner = createRunner();
+configureBaseTower(runner);
+setTowerEnvironment();
 
 runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/testTowerFailedJob.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/testTowerFailedJob.ts
@@ -1,0 +1,9 @@
+import { createRunner, configureBaseTower, setTowerEnvironment, getMockUtils } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseTower(runner);
+setTowerEnvironment();
+
+getMockUtils().setMockTowerStatusSequence(['failed']);
+
+runner.run();

--- a/Extensions/Ansible/Tests/Tasks/Ansible/testTowerPagination.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/testTowerPagination.ts
@@ -1,0 +1,40 @@
+import { createRunner, configureBaseTower, setTowerEnvironment, getMockUtils } from './scenarioHelpers';
+
+const runner = createRunner();
+configureBaseTower(runner);
+setTowerEnvironment();
+
+const mockUtils = getMockUtils();
+mockUtils.setMockTowerStatusSequence(['successful']);
+mockUtils.setMockTowerEventsPages([
+    {
+        count: 2,
+        next: '/api/v1/jobs/559/job_events/?page_size=10&page=2',
+        previous: null,
+        results: [
+            {
+                id: 100,
+                type: 'job_event',
+                job: 559,
+                counter: 1,
+                stdout: 'Page1 stdout'
+            }
+        ]
+    },
+    {
+        count: 2,
+        next: null,
+        previous: '/api/v1/jobs/559/job_events/?page_size=10&page=1',
+        results: [
+            {
+                id: 101,
+                type: 'job_event',
+                job: 559,
+                counter: 2,
+                stdout: 'Page2 stdout'
+            }
+        ]
+    }
+]);
+
+runner.run();


### PR DESCRIPTION
**Description**: Adds comprehensive unit test coverage for Ansible task failure paths and hardens `ansibleTowerInterface` against an unhandled crash.
- Adds failure-scenario tests: Ansible not installed, stderr command failures (agent and remote), Windows agent machine, remote command errors, missing inventory files/playbooks, SSH connection failures, and Ansible Tower API failures (launch, job status, events) incl. pagination.
- Adds success-scenario tests: inventory variants (host list with/without trailing comma, inline static/dynamic), SSH auth (password, private key, default port fallback), sudo user handling, and Tower job pagination.
- Extends `mockAnsibleUtils` with new mock state setters (platform, ansible availability, ssh/copy/command errors, file/directory existence, Tower template/launch/status/events responses).
- Adds `scenarioHelpers.ts` with shared runner/environment setup helpers to reduce duplication across test files.
- Fixes `ansibleTowerInterface.getJobTemplateId` to guard against an empty/missing `results` array in the Tower API response, throwing `JobTemplateNotPresent` instead of crashing.

**Documentation changes required:** N

**Added unit tests:** Y

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
