### PR TITLE
Update adm-zip to 0.6.0 and bump affected extension versions

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "azure-pipelines-task-lib": "5.2.8",
+        "azure-pipelines-task-lib": "5.278.0",
         "shell-quote": "^1.9.0",
         "shelljs": "^0.10.0",
         "ssh2": "1.4.0",
@@ -125,18 +125,17 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
-      "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
+      "version": "5.278.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.278.0.tgz",
+      "integrity": "sha1-ZdWwBh1+xNDN4Q5u9sIcP0mUXFQ=",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/balanced-match": {

--- a/Extensions/Ansible/Src/Tasks/Ansible/package.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package.json
@@ -6,16 +6,13 @@
   "author": "Microsoft",
   "license": "ISC",
   "dependencies": {
-    "azure-pipelines-task-lib": "5.2.8",
+    "azure-pipelines-task-lib": "5.278.0",
     "shell-quote": "^1.9.0",
     "shelljs": "^0.10.0",
     "ssh2": "1.4.0",
     "ssh2-sftp-client": "^8.1.0",
     "uuid": "^3.3.2",
     "vso-node-api": "6.0.1-preview"
-  },
-  "overrides": {
-    "adm-zip": "0.6.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -20,6 +20,7 @@
         "Patch": 7
     },
     "demands": [],
+    "minimumAgentVersion": "2.206.1",
     "instanceNameFormat": "Run playbook",
     "groups": [
         {
@@ -324,7 +325,7 @@
         }
     ],
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "main.js",
             "argumentFormat": ""
         },

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 279,
-        "Patch": 6
+        "Patch": 7
     },
     "demands": [],
     "instanceNameFormat": "Run playbook",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.10",
+  "version": "0.279.12",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.9",
+  "version": "0.279.10",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/ArtifactEngine/package-lock.json
+++ b/Extensions/ArtifactEngine/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-engine",
-  "version": "1.273.1",
+  "version": "1.278.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-engine",
-      "version": "1.273.1",
+      "version": "1.278.0",
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.2.8",
@@ -30,28 +30,14 @@
         "xml2js": "^0.6.2"
       }
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha1-7UQbb6YAByUgzhi0PSyMyMrsx/Q=",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha1-IA9xXmbVKiOyIalDVTSpHME61b4=",
+      "version": "7.29.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha1-8vu/6ofESiFZDsUVt3iywm2IZuc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -60,9 +46,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/compat-data/-/compat-data-7.28.0.tgz",
-      "integrity": "sha1-n8b9WMKmoVJDzROYMiSWg5IHB5A=",
+      "version": "7.29.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha1-bwI38PNtLlHAVwpjb67Z0tDv5ik=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -70,22 +56,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/core/-/core-7.28.0.tgz",
-      "integrity": "sha1-VdrYCNW/NEWhCO78iOo/3wNHSaQ=",
+      "version": "7.29.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha1-gMELFySAgpaLV6hXuRZAlx8gcPc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.27.3",
-        "@babel/helpers": "^7.27.6",
-        "@babel/parser": "^7.28.0",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.0",
-        "@babel/types": "^7.28.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -118,14 +104,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/generator/-/generator-7.28.0.tgz",
-      "integrity": "sha1-nML3vW6wVNd9xmwmZBSKDFEYrNI=",
+      "version": "7.29.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha1-zKC4gn5rzzuhdniOfzsYCtbbL6M=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@babel/types": "^7.28.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -135,14 +121,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha1-RqD276uAjVHSnOloWN0Qzocycz0=",
+      "version": "7.29.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha1-eh3vcEMCQBxH9k+oVYnpdK4hcEI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -162,9 +148,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha1-uUMN8qpOF7woZl6t6uiqHZheZnQ=",
+      "version": "7.29.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha1-8EqW+9hHMkGxB5JD9bPwOjAQq3s=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -172,29 +158,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha1-fvdpoyPiZV4SZnO7bS1pE7vq0gQ=",
+      "version": "7.29.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha1-7yUEilGOgo1zk/rFiC3dc5Idc5Y=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.27.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-      "integrity": "sha1-2wu8+6WAL573hwcFp++HiFCO3gI=",
+      "version": "7.29.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha1-sGJ0elmXuhOGNyATKLv/d5YFdK4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -204,9 +190,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha1-VNp5YJerGc5n7Z+ItHuy7Ek2doc=",
+      "version": "7.29.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha1-fwhx2Zgk0jE31g+G/PYTD9WhtR8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -214,9 +200,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha1-pwVNzBRaln3U3I/uhFpXwTFsnfg=",
+      "version": "7.29.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha1-vYcITO0MeW7Ea9pJLeboPSnon8I=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -224,9 +210,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha1-+lL1sefbGrBJRFtCHERxMDiXcC8=",
+      "version": "7.29.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha1-zzFb6UAhOzVOtKvMC9Aevj9zvCo=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -234,27 +220,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helpers/-/helpers-7.28.2.tgz",
-      "integrity": "sha1-gPCRj+y/6+qa+FbEGXYyMAQO6FA=",
+      "version": "7.29.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha1-Rav951SJl+NDdsPmn+tHXP+0pgc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/parser/-/parser-7.28.0.tgz",
-      "integrity": "sha1-l5gp+6tRop4TkB5agHE9vLhAgl4=",
+      "version": "7.29.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha1-g3uHOHy/XsVTDLY0s8Yi9o7bkzQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -264,33 +250,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha1-+njO7TxOe2Pr9ss55YUvykX2gJ0=",
+      "version": "7.29.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha1-TZ1ABPZFzdME3pWMclFieE7KxwA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/traverse/-/traverse-7.28.0.tgz",
-      "integrity": "sha1-UYqhEzWbBiBCN54zPbGDgLU340s=",
+      "version": "7.29.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha1-xHsHpBuV2gkH0Ca13YlNmN59Ly0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.0",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -298,14 +284,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/types/-/types-7.28.2.tgz",
-      "integrity": "sha1-2p2whWqaiOChOwGYgddRNYjPcSs=",
+      "version": "7.29.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha1-gAXjHYJxLuetrvbiPGO3GmJ3CpI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -327,91 +313,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha1-YCFu6kZNhkWXzigyAAc4oFiWUME=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha1-wETV3MUhoHZBNHJZehrLHxA8QEE=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha1-hAyIA7DYBH9P8M+WMXazLU7z7XI=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha1-FPja7G2B5yIdKjV+Zoyrc728p5Q=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha1-Eyh1q95njH6o1pFTPy5+Irt0Tbo=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha1-VtwiNo7lcPrOG0mBmXXZuaXq0hQ=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -441,16 +342,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/find-up/-/find-up-4.1.0.tgz",
@@ -466,9 +357,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha1-d0hc4d1/M8Bh/RsW7OojtV/LBLA=",
+      "version": "3.15.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha1-WG5SFOr+Pok3VqQel5tQ2J0+Smc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -522,9 +413,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha1-5F44TkuOwWvOL9kDr3hFD2v37Jg=",
+      "version": "0.1.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha1-jcmvoqwVBssaWPiZQPHBJERsjfM=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -532,13 +423,24 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.12",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
-      "integrity": "sha1-IjTOJsYoifA9s9f+pDwZMqs+kns=",
+      "version": "0.3.13",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha1-Y0Khn0Q0dRjJPkOxrGnes8Rlah8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha1-N1xHbRlylHhRuh4Vro8SMEdEWqE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -553,16 +455,16 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha1-c1gENDOy5dpWmqAsvEwSHaOvJ9c=",
+      "version": "1.5.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha1-aRKwDSxjHA0Vzhp6tXzWV/Ko+Lo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.29",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
-      "integrity": "sha1-pY0x6q2vksZpVoCy4dRkqbj79/w=",
+      "version": "0.3.31",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha1-2xXWeByTHzolGj2sOVAcmKYIL9A=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -571,9 +473,9 @@
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.39.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@mswjs/interceptors/-/interceptors-0.39.3.tgz",
-      "integrity": "sha1-0niG2ylcmn28QaoimmRLx7uwRyM=",
+      "version": "0.41.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha1-nZC71g0d3DDby7gnqbsuRwSTUw0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -741,12 +643,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk=",
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -776,13 +678,16 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+      "version": "6.2.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha1-YCFu6kZNhkWXzigyAAc4oFiWUME=",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
@@ -853,9 +758,9 @@
       "license": "MIT"
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
-      "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
+      "version": "5.277.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
+      "integrity": "sha1-IzR+ExQL+R24uw1eROr0Nv+olTQ=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -863,8 +768,7 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/balanced-match": {
@@ -872,6 +776,19 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.43",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha1-e10RWQzlrNvkhZRD48lA6BzowC0=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.16",
@@ -903,9 +820,9 @@
       "license": "ISC"
     },
     "node_modules/browserslist": {
-      "version": "4.25.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/browserslist/-/browserslist-4.25.1.tgz",
-      "integrity": "sha1-up6ObymKHYb4Kcm5deB5SJZ7sRE=",
+      "version": "4.28.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha1-fPg6/NacVf3m+y3MUDn/D0ukJhA=",
       "dev": true,
       "funding": [
         {
@@ -923,10 +840,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001726",
-        "electron-to-chromium": "^1.5.173",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -952,22 +870,19 @@
       }
     },
     "node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha1-VoW5XrIJrJwMF3Rnd4ychN9Yupo=",
+      "version": "5.3.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=6"
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001731",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
-      "integrity": "sha1-J3wHQW6kYT7FZOWw/7R+e2DzLi8=",
+      "version": "1.0.30001806",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha1-G8jlArcj+jk0Vd++3VzOwMKbt04=",
       "dev": true,
       "funding": [
         {
@@ -1042,15 +957,81 @@
       }
     },
     "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
+      "version": "8.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha1-DASwddsCy/5g3I5s8vVIaxo2CKo=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/color-convert": {
@@ -1108,9 +1089,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha1-5ai8bLxMbNPmQwiwaTo9T6VQGJs=",
+      "version": "4.4.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1125,16 +1106,13 @@
       }
     },
     "node_modules/decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha1-qkcte/Zg6xXzSU79UxyrfypwmDc=",
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/default-require-extensions": {
@@ -1171,16 +1149,16 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.199",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.199.tgz",
-      "integrity": "sha1-TYvpx4NiwF8JXrc5LppU8fsU/To=",
+      "version": "1.5.393",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+      "integrity": "sha1-rslx3ypvT35R+6yyANZs6/x9PBc=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "version": "9.2.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha1-hAyIA7DYBH9P8M+WMXazLU7z7XI=",
       "dev": true,
       "license": "MIT"
     },
@@ -1251,6 +1229,12 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
+      "license": "ISC"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -1268,9 +1252,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha1-1Q6rqAPIhGqIPBZJKCHrzSzaVfU=",
+      "version": "1.20.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha1-ynUKENySW8ixiDn9ID4+9LPO1nU=",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -1334,9 +1318,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha1-d31z1yqS+OxNLkEOtHNSpWuOg0A=",
+      "version": "1.16.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha1-KEdKFZ07nRHvYgUKFO1g5N9tYbw=",
       "funding": [
         {
           "type": "individual",
@@ -1354,17 +1338,20 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/foreground-child/-/foreground-child-2.0.0.tgz",
-      "integrity": "sha1-cbMoAMnxWqjy+D9Ka9m/812GGlM=",
+      "version": "3.3.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha1-Mujp7Rtoo0l777msK2rfkqY4V28=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "signal-exit": "^3.0.2"
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/formatio": {
@@ -1449,22 +1436,21 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "version": "10.5.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha1-jsA1WRnNMzjChCiiPU8k7MX+c4w=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
-      "engines": {
-        "node": "*"
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1609,9 +1595,9 @@
       }
     },
     "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
       "dev": true,
       "license": "ISC"
     },
@@ -1814,16 +1800,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -1856,9 +1832,9 @@
       }
     },
     "node_modules/istanbul-lib-report/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha1-Z9mf3NNc7CHm+Lh6f9UVoz+YK1g=",
+      "version": "7.8.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1897,9 +1873,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
-      "integrity": "sha1-2u0SueHcpRjhXAVuHlN+dBKA+gs=",
+      "version": "3.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha1-y0U1FitXhKpiPO4hpyUs8sgHrJM=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1934,10 +1910,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha1-hUwpJGdwW2mUduGi3swMijRYgGs=",
+      "version": "4.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha1-0ZAFcqf3zwtfVAyDZz5gutNDZZI=",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2003,9 +1989,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha1-8ROwN4OGEDvk9okziMc9C95/LFo=",
+      "version": "4.18.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha1-/ytmwfYybVlRPeJAe/iBQ5gSdxw=",
       "dev": true,
       "license": "MIT"
     },
@@ -2163,19 +2149,19 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha1-k6libOXl5mvU24aEnnUV6SNApwc=",
+      "version": "7.1.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha1-eTibTrG7LQA6m7qH1JLyvTe9xls=",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mocha/-/mocha-11.7.5.tgz",
-      "integrity": "sha1-WPW7+l4CEc5+XuYSgQfO/CUVpic=",
+      "version": "11.7.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mocha/-/mocha-11.7.6.tgz",
+      "integrity": "sha1-674imJ0Ey7lCSjYwcyBHZiTEGjM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2219,151 +2205,6 @@
         "mocha": "*"
       }
     },
-    "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/mocha/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha1-DASwddsCy/5g3I5s8vVIaxo2CKo=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mocha/node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha1-Mujp7Rtoo0l777msK2rfkqY4V28=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha1-jsA1WRnNMzjChCiiPU8k7MX+c4w=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/mocha/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha1-10+d1rV9g9jpjPuCEzsDl4vJKeU=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha1-mR3zmspnWhkrgW4eA2P5110qomk=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mocha/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha1-kJa87r+ZDSG7MfqVFuDt4pSnfTU=",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
@@ -2391,6 +2232,110 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/nconf/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nconf/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/nconf/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nconf/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nconf/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nconf/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/nconf/node_modules/yargs": {
+      "version": "16.2.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yargs/-/yargs-16.2.2.tgz",
+      "integrity": "sha1-xWcx3KDSeIrghm3TyDkH1rq4X30=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nconf/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha1-LrfcOwKJcY/ClfNidThFxBoMlO4=",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/neo-async": {
@@ -2424,13 +2369,13 @@
       }
     },
     "node_modules/nock": {
-      "version": "14.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/nock/-/nock-14.0.6.tgz",
-      "integrity": "sha1-H4UQiJ0QNofbycJnwP3DfGN2RTk=",
+      "version": "14.0.16",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/nock/-/nock-14.0.16.tgz",
+      "integrity": "sha1-2S3Mhez3BHke8LrLJEf4HqXsUvQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@mswjs/interceptors": "^0.39.3",
+        "@mswjs/interceptors": "^0.41.0",
         "json-stringify-safe": "^5.0.1",
         "propagate": "^2.0.0"
       },
@@ -2452,11 +2397,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha1-nkRaUpUJUexNF32EOvNwtBHK8xQ=",
+      "version": "2.0.51",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha1-zcCEM1d/WzKtAWlEgXJuIu61Su8=",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nodejs-file-downloader": {
       "version": "4.13.0",
@@ -2524,14 +2472,14 @@
         "node": ">=8.9"
       }
     },
-    "node_modules/nyc/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+    "node_modules/nyc/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/nyc/node_modules/cliui": {
@@ -2546,15 +2494,12 @@
         "wrap-ansi": "^6.2.0"
       }
     },
-    "node_modules/nyc/node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+    "node_modules/nyc/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "license": "MIT"
     },
     "node_modules/nyc/node_modules/find-up": {
       "version": "4.1.0",
@@ -2568,6 +2513,42 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha1-cbMoAMnxWqjy+D9Ka9m/812GGlM=",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/nyc/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/nyc/node_modules/locate-path": {
@@ -2607,6 +2588,41 @@
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/nyc/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -3077,6 +3093,28 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3130,20 +3168,23 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha1-dV69dSBFkxl34wsgJdNA18kJA3g=",
+      "version": "1.6.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha1-trOevtm9GhiYuFxcAwidp0WQ1vg=",
       "license": "WTFPL OR ISC",
       "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"
       }
     },
     "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha1-RMyJiDd/EmME07P8EBDHM7kp7w8=",
+      "version": "1.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha1-2lljdikwe5fnxMso4ICnvDhWDVs=",
       "dev": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/secure-keys": {
       "version": "1.0.0",
@@ -3213,10 +3254,17 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
-      "license": "ISC"
+      "version": "4.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/sinon": {
       "version": "4.0.1",
@@ -3242,23 +3290,13 @@
       }
     },
     "node_modules/sinon/node_modules/diff": {
-      "version": "3.5.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
+      "version": "3.5.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/diff/-/diff-3.5.1.tgz",
+      "integrity": "sha1-5/rkgDedLpRMaP8PXhwptuKMd6s=",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/sinon/node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha1-3rJFPo8I3K566YxiaxPd2wFVkGw=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/source-map": {
@@ -3288,6 +3326,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/spawn-wrap/node_modules/foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha1-cbMoAMnxWqjy+D9Ka9m/812GGlM=",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/spawn-wrap/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -3303,18 +3362,21 @@
       "license": "MIT"
     },
     "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+      "version": "5.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha1-FPja7G2B5yIdKjV+Zoyrc728p5Q=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/string-width-cjs": {
@@ -3333,7 +3395,24 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-ansi": {
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
@@ -3346,6 +3425,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha1-0iomlSKDamJ6+NBLXD/Sx/o+MuM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
@@ -3356,6 +3451,16 @@
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3423,6 +3528,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/text-encoding": {
       "version": "0.6.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/text-encoding/-/text-encoding-0.6.4.tgz",
@@ -3459,6 +3586,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha1-3rJFPo8I3K566YxiaxPd2wFVkGw=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -3509,9 +3646,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha1-NIN33SRSFvnnBg/1CxWht0C3VCA=",
+      "version": "1.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha1-ZNdttYcTE2rL60xJEUNmzGzC6A0=",
       "dev": true,
       "funding": [
         {
@@ -3555,21 +3692,14 @@
         "inherits": "2.0.1"
       }
     },
-    "node_modules/util/node_modules/inherits": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inherits/-/inherits-2.0.1.tgz",
-      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
+      "dev": true,
       "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/which": {
@@ -3608,18 +3738,18 @@
       "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+      "version": "8.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha1-VtwiNo7lcPrOG0mBmXXZuaXq0hQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -3644,6 +3774,64 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha1-wETV3MUhoHZBNHJZehrLHxA8QEE=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
@@ -3663,6 +3851,13 @@
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
       }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/xml2js": {
       "version": "0.6.2",
@@ -3706,32 +3901,32 @@
       "license": "ISC"
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
+      "version": "17.7.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha1-d53/5ryv7FlqcXLpgyiaWIZH+qo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha1-LrfcOwKJcY/ClfNidThFxBoMlO4=",
+      "version": "21.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha1-kJa87r+ZDSG7MfqVFuDt4pSnfTU=",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-unparser": {
@@ -3748,6 +3943,77 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha1-VoW5XrIJrJwMF3Rnd4ychN9Yupo=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha1-qkcte/Zg6xXzSU79UxyrfypwmDc=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/Extensions/ArtifactEngine/package-lock.json
+++ b/Extensions/ArtifactEngine/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.278.0",
       "license": "MIT",
       "dependencies": {
-        "azure-pipelines-task-lib": "^5.2.8",
+        "azure-pipelines-task-lib": "^5.278.0",
         "handlebars": "4.7.9",
         "minimatch": "3.1.5",
         "tunnel": "0.0.4"
@@ -758,12 +758,12 @@
       "license": "MIT"
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.277.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
-      "integrity": "sha1-IzR+ExQL+R24uw1eROr0Nv+olTQ=",
+      "version": "5.278.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.278.0.tgz",
+      "integrity": "sha1-ZdWwBh1+xNDN4Q5u9sIcP0mUXFQ=",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",

--- a/Extensions/ArtifactEngine/package.json
+++ b/Extensions/ArtifactEngine/package.json
@@ -16,13 +16,12 @@
     "email": "omeshp@microsoft.com"
   },
   "dependencies": {
-    "azure-pipelines-task-lib": "^5.2.8",
+    "azure-pipelines-task-lib": "^5.278.0",
     "handlebars": "4.7.9",
     "minimatch": "3.1.5",
     "tunnel": "0.0.4"
   },
   "overrides": {
-    "adm-zip": "0.6.0",
     "minimatch": "3.1.5",
     "picomatch": "2.3.2"
   },

--- a/Extensions/ArtifactEngine/package.json
+++ b/Extensions/ArtifactEngine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "1.273.1",
+  "version": "1.278.0",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",
@@ -22,6 +22,7 @@
     "tunnel": "0.0.4"
   },
   "overrides": {
+    "adm-zip": "0.6.0",
     "minimatch": "3.1.5",
     "picomatch": "2.3.2"
   },

--- a/Extensions/ArtifactEngineV2/package-lock.json
+++ b/Extensions/ArtifactEngineV2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-engine",
-  "version": "2.276.1",
+  "version": "2.278.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-engine",
-      "version": "2.276.1",
+      "version": "2.278.0",
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.2.8",
@@ -356,9 +356,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha1-d0hc4d1/M8Bh/RsW7OojtV/LBLA=",
+      "version": "3.15.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha1-WG5SFOr+Pok3VqQel5tQ2J0+Smc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -573,9 +573,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.20.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-22.20.0.tgz",
-      "integrity": "sha1-Qx9QBzlrwaGke5x99g8+XgtbcwQ=",
+      "version": "22.20.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha1-hOfN9jzaogwTSqMXzMkBqiHhbw4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -593,12 +593,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha1-XAtl83ruxcKpSZXAJPkx9i5LvFo=",
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -701,9 +701,9 @@
       "license": "MIT"
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.11.tgz",
-      "integrity": "sha1-4WT2NUK4K1n7dRDmeuRuTTC/J94=",
+      "version": "5.277.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
+      "integrity": "sha1-IzR+ExQL+R24uw1eROr0Nv+olTQ=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -711,20 +711,7 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
-      }
-    },
-    "node_modules/azure-pipelines-task-lib/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/balanced-match": {
@@ -734,9 +721,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.38",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-      "integrity": "sha1-yE0JPEv3MlxQU8J52Q8VPGZSYEI=",
+      "version": "2.10.43",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha1-e10RWQzlrNvkhZRD48lA6BzowC0=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -776,9 +763,9 @@
       "license": "ISC"
     },
     "node_modules/browserslist": {
-      "version": "4.28.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/browserslist/-/browserslist-4.28.4.tgz",
-      "integrity": "sha1-3YuBZ6MoRf9fjNbOE/WruhbNBMk=",
+      "version": "4.28.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha1-fPg6/NacVf3m+y3MUDn/D0ukJhA=",
       "dev": true,
       "funding": [
         {
@@ -796,10 +783,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -865,9 +852,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha1-XJCROMJ/GmEhnT4JIHHBzH0y3FU=",
+      "version": "1.0.30001806",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha1-G8jlArcj+jk0Vd++3VzOwMKbt04=",
       "dev": true,
       "funding": [
         {
@@ -1158,9 +1145,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.378",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.378.tgz",
-      "integrity": "sha1-nOlZHr7SPoqRGZcDBQhLQ6KQZFQ=",
+      "version": "1.5.393",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+      "integrity": "sha1-rslx3ypvT35R+6yyANZs6/x9PBc=",
       "dev": true,
       "license": "ISC"
     },
@@ -1925,16 +1912,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -2051,9 +2028,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha1-K9noVoLdkb1GmvuAnYFgQ7PUlSQ=",
+      "version": "4.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha1-0ZAFcqf3zwtfVAyDZz5gutNDZZI=",
       "dev": true,
       "funding": [
         {
@@ -2261,6 +2238,18 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
       "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/minimist": {
       "version": "1.2.8",
@@ -2538,9 +2527,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.49",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/node-releases/-/node-releases-2.0.49.tgz",
-      "integrity": "sha1-Gh9BdraD0iYU9hrcHIQsGHQxhBo=",
+      "version": "2.0.51",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha1-zcCEM1d/WzKtAWlEgXJuIu61Su8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2689,19 +2678,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/nyc/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/nyc/node_modules/p-limit": {
@@ -3276,19 +3252,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3780,19 +3743,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3812,6 +3762,15 @@
       "license": "WTFPL",
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
     },
     "node_modules/type-detect": {
@@ -3848,15 +3807,6 @@
       },
       "engines": {
         "node": ">= 16.0.0"
-      }
-    },
-    "node_modules/typed-rest-client/node_modules/tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
     },
     "node_modules/typedarray-to-buffer": {
@@ -3964,13 +3914,13 @@
       "license": "ISC"
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
+      "dev": true,
       "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/which": {

--- a/Extensions/ArtifactEngineV2/package-lock.json
+++ b/Extensions/ArtifactEngineV2/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.278.0",
       "license": "MIT",
       "dependencies": {
-        "azure-pipelines-task-lib": "^5.2.8",
+        "azure-pipelines-task-lib": "^5.278.0",
         "handlebars": "4.7.9",
         "typed-rest-client": "^3.0.0"
       },
@@ -701,12 +701,12 @@
       "license": "MIT"
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.277.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
-      "integrity": "sha1-IzR+ExQL+R24uw1eROr0Nv+olTQ=",
+      "version": "5.278.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.278.0.tgz",
+      "integrity": "sha1-ZdWwBh1+xNDN4Q5u9sIcP0mUXFQ=",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",

--- a/Extensions/ArtifactEngineV2/package.json
+++ b/Extensions/ArtifactEngineV2/package.json
@@ -16,12 +16,11 @@
     "email": "omeshp@microsoft.com"
   },
   "dependencies": {
-    "azure-pipelines-task-lib": "^5.2.8",
+    "azure-pipelines-task-lib": "^5.278.0",
     "handlebars": "4.7.9",
     "typed-rest-client": "^3.0.0"
   },
   "overrides": {
-    "adm-zip": "0.6.0",
     "picomatch": "2.3.2"
   },
   "devDependencies": {

--- a/Extensions/ArtifactEngineV2/package.json
+++ b/Extensions/ArtifactEngineV2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "2.276.1",
+  "version": "2.278.0",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",
@@ -21,6 +21,7 @@
     "typed-rest-client": "^3.0.0"
   },
   "overrides": {
+    "adm-zip": "0.6.0",
     "picomatch": "2.3.2"
   },
   "devDependencies": {

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package-lock.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package-lock.json
@@ -55,12 +55,12 @@
       "license": "MIT"
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk=",
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package-lock.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "DownloadArtifactsBitbucket",
       "dependencies": {
-        "azure-pipelines-task-lib": "5.2.8"
+        "azure-pipelines-task-lib": "5.278.0"
       },
       "devDependencies": {
         "@types/node": "^6.14.13"
@@ -76,18 +76,17 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
-      "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
+      "version": "5.278.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.278.0.tgz",
+      "integrity": "sha1-ZdWwBh1+xNDN4Q5u9sIcP0mUXFQ=",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/balanced-match": {
@@ -622,16 +621,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha1-+fY5ENFVNu4rLV3UZlOJcV6sXB4=",
       "license": "(WTFPL OR MIT)"
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package.json
@@ -6,5 +6,8 @@
   },
   "devDependencies": {
     "@types/node": "^6.14.13"
+  },
+  "overrides": {
+    "adm-zip": "0.6.0"
   }
 }

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/package.json
@@ -2,12 +2,9 @@
   "name": "DownloadArtifactsBitbucket",
   "main": "download.js",
   "dependencies": {
-    "azure-pipelines-task-lib": "5.2.8"
+    "azure-pipelines-task-lib": "5.278.0"
   },
   "devDependencies": {
     "@types/node": "^6.14.13"
-  },
-  "overrides": {
-    "adm-zip": "0.6.0"
   }
 }

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 15,
     "Minor": 278,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "1.99.0",
   "instanceNameFormat": "Download Artifacts - Bitbucket",

--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
@@ -16,7 +16,7 @@
     "Minor": 278,
     "Patch": 1
   },
-  "minimumAgentVersion": "1.99.0",
+  "minimumAgentVersion": "2.206.1",
   "instanceNameFormat": "Download Artifacts - Bitbucket",
   "inputs": [
     {
@@ -99,7 +99,7 @@
     }
   ],
   "execution": {
-    "Node": {
+    "Node16": {
       "target": "downloadBitbucket.js",
       "argumentFormat": ""
     },

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.17",
+  "version": "15.279.18",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
@@ -294,12 +294,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha1-XAtl83ruxcKpSZXAJPkx9i5LvFo=",
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@azure/msal-node": "^2.7.0",
         "azure-devops-node-api": "14.1.0",
-        "azure-pipelines-task-lib": "^5.2.8",
+        "azure-pipelines-task-lib": "^5.278.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.272.1"
       },
       "devDependencies": {
@@ -334,28 +334,17 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
+      "version": "5.278.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.278.0.tgz",
+      "integrity": "sha1-ZdWwBh1+xNDN4Q5u9sIcP0mUXFQ=",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
-      }
-    },
-    "node_modules/azure-pipelines-task-lib/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "@types/node": "^16.18.126"
+  },
+  "overrides": {
+    "adm-zip": "0.6.0"
   }
 }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
@@ -4,13 +4,10 @@
   "dependencies": {
     "@azure/msal-node": "^2.7.0",
     "azure-devops-node-api": "14.1.0",
-    "azure-pipelines-task-lib": "^5.2.8",
+    "azure-pipelines-task-lib": "^5.278.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.272.1"
   },
   "devDependencies": {
     "@types/node": "^16.18.126"
-  },
-  "overrides": {
-    "adm-zip": "0.6.0"
   }
 }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 16,
     "Minor": 279,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "Download Artifacts - External TFS Git",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
@@ -16,7 +16,7 @@
     "Minor": 279,
     "Patch": 1
   },
-  "minimumAgentVersion": "2.144.0",
+  "minimumAgentVersion": "2.206.1",
   "instanceNameFormat": "Download Artifacts - External TFS Git",
   "inputs": [
     {

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
@@ -295,12 +295,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha1-XAtl83ruxcKpSZXAJPkx9i5LvFo=",
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
@@ -9,7 +9,7 @@
         "@azure/msal-node": "^3.7.3",
         "artifact-engine": "^1.271.1",
         "azure-devops-node-api": "14.1.0",
-        "azure-pipelines-task-lib": "^5.2.8",
+        "azure-pipelines-task-lib": "^5.278.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.267.0"
       },
       "devDependencies": {
@@ -356,28 +356,17 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
+      "version": "5.278.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.278.0.tgz",
+      "integrity": "sha1-ZdWwBh1+xNDN4Q5u9sIcP0mUXFQ=",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
-      }
-    },
-    "node_modules/azure-pipelines-task-lib/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
@@ -12,6 +12,7 @@
     "typescript": "5.1.6"
   },
   "overrides": {
+    "adm-zip": "0.6.0",
     "underscore": "1.13.8",
     "artifact-engine": {
       "handlebars": "4.7.9"

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
@@ -5,14 +5,13 @@
     "@azure/msal-node": "^3.7.3",
     "artifact-engine": "^1.271.1",
     "azure-devops-node-api": "14.1.0",
-    "azure-pipelines-task-lib": "^5.2.8",
+    "azure-pipelines-task-lib": "^5.278.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.267.0"
   },
   "devDependencies": {
     "typescript": "5.1.6"
   },
   "overrides": {
-    "adm-zip": "0.6.0",
     "underscore": "1.13.8",
     "artifact-engine": {
       "handlebars": "4.7.9"

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
@@ -12,7 +12,7 @@
     "Patch": 1
   },
   "demands": [],
-  "minimumAgentVersion": "2.144.0",
+  "minimumAgentVersion": "2.206.1",
   "inputs": [
     {
       "name": "connectionType",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 16,
     "Minor": 279,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.loc.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.loc.json
@@ -12,7 +12,7 @@
     "Patch": 1
   },
   "demands": [],
-  "minimumAgentVersion": "2.144.0",
+  "minimumAgentVersion": "2.206.1",
   "inputs": [
     {
       "name": "connectionType",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.loc.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 16,
     "Minor": 279,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.9",
+  "version": "16.279.10",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.10",
+  "version": "1.279.11",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.279.10",
+  "version": "4.279.11",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package-lock.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package-lock.json
@@ -47,12 +47,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha1-XAtl83ruxcKpSZXAJPkx9i5LvFo=",
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package-lock.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package-lock.json
@@ -7,7 +7,7 @@
       "name": "DownloadTeamCityArtifacts",
       "dependencies": {
         "artifact-engine": "^1.271.1",
-        "azure-pipelines-task-lib": "^5.2.8",
+        "azure-pipelines-task-lib": "^5.278.0",
         "underscore": "^1.13.8"
       }
     },
@@ -80,18 +80,17 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
+      "version": "5.278.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.278.0.tgz",
+      "integrity": "sha1-ZdWwBh1+xNDN4Q5u9sIcP0mUXFQ=",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/balanced-match": {
@@ -699,16 +698,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha1-+fY5ENFVNu4rLV3UZlOJcV6sXB4=",
       "license": "(WTFPL OR MIT)"
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package.json
@@ -7,6 +7,7 @@
     "underscore": "^1.13.8"
   },
   "overrides": {
+    "adm-zip": "0.6.0",
     "artifact-engine": {
       "handlebars": "4.7.9"
     },

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/package.json
@@ -3,11 +3,10 @@
   "main": "download.js",
   "dependencies": {
     "artifact-engine": "^1.271.1",
-    "azure-pipelines-task-lib": "^5.2.8",
+    "azure-pipelines-task-lib": "^5.278.0",
     "underscore": "^1.13.8"
   },
   "overrides": {
-    "adm-zip": "0.6.0",
     "artifact-engine": {
       "handlebars": "4.7.9"
     },

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 15,
     "Minor": 279,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
@@ -12,7 +12,7 @@
     "Patch": 2
   },
   "demands": [],
-  "minimumAgentVersion": "2.0.0",
+  "minimumAgentVersion": "2.206.1",
   "inputs": [
     {
       "name": "connection",
@@ -101,7 +101,7 @@
   ],
   "instanceNameFormat": "Download Artifacts - TeamCity",
   "execution": {
-    "Node": {
+    "Node16": {
       "target": "download.js",
       "argumentFormat": ""
     },

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.loc.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.loc.json
@@ -12,7 +12,7 @@
     "Patch": 2
   },
   "demands": [],
-  "minimumAgentVersion": "2.0.0",
+  "minimumAgentVersion": "2.206.1",
   "inputs": [
     {
       "name": "connection",
@@ -101,7 +101,7 @@
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "execution": {
-    "Node": {
+    "Node16": {
       "target": "download.js",
       "argumentFormat": ""
     }

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.loc.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 15,
     "Minor": 279,
-    "Patch": 0
+    "Patch": 2
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.13",
+  "version": "15.279.14",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,8 +46,6 @@ const artifactEngineV2Path = path.join(_extnBuildRoot, "ArtifactEngineV2");
 const _taskModuleBuildRoot = "_build/TaskModules/";
 const sourcePaths = "@(definitions|Extensions)/**/*";
 const ExtensionFolder = "Extensions";
-const artifactEngineSourcePath = path.join(ExtensionFolder, "ArtifactEngine");
-const artifactEngineV2SourcePath = path.join(ExtensionFolder, "ArtifactEngineV2");
 const _tempPath = path.join(__dirname, '_temp');
 const _testRoot = "_build/";
 const _testTemp = "_build/Temp";
@@ -185,8 +183,8 @@ gulp.task("compileNode", gulp.series("compilePS", function (cb) {
         return fs.statSync(path.join(_extnBuildRoot, file)).isDirectory() && file != "Common";
     }).forEach(copyCommonModules);
 
-    runNpmInstall(artifactEnginePath, artifactEngineSourcePath);
-    runNpmInstall(artifactEngineV2Path, artifactEngineV2SourcePath);
+    runNpmInstall(artifactEnginePath);
+    runNpmInstall(artifactEngineV2Path);
 
     // Compile tasks
     const tasksProject = gts.createProject(rootTsconfigPath, { typescript: typescript, declaration: true });
@@ -417,17 +415,23 @@ function createResjson(callback) {
 }
 
 /**
- * Run npm install for a given package path, using a .npmrc file from the source directory to ensure consistent registry and authentication settings.
- * This is necessary for packages like ArtifactEngine that have their own node_modules and dependencies that must be installed as part of the build process.
+ * Run npm install for a given package path, using the repository-root .npmrc so the
+ * install always has feed credentials. Authentication (NpmAuthenticate@0 in CI, or
+ * vsts-npm-auth locally) is applied to the root .npmrc only; the per-extension .npmrc
+ * files carry the registry URL but no auth token, so a sub-install that has to fetch any
+ * package not already in the npm cache would fail with E401. Pointing --userconfig at the
+ * root .npmrc mirrors the UI-contribution install in package.js and keeps every
+ * extension's npm ci authenticated without per-extension pipeline wiring.
+ * This is necessary for packages like ArtifactEngine that have their own node_modules and
+ * dependencies that must be installed as part of the build process.
  * @param {string} packagePath - The path to the package where npm install should be run.
- * @param {string} sourcePath - The path to the source directory containing the .npmrc file.
  */
-function runNpmInstall(packagePath, sourcePath) {
+function runNpmInstall(packagePath) {
     var originalDir = shell.pwd();
     util.cd(packagePath);
     var packageJsonPath = util.rp('package.json');
     if (util.test('-f', packageJsonPath)) {
-        util.run(`npm ci --userconfig ${path.join(__dirname, sourcePath, ".npmrc")}`);
+        util.run(`npm ci --userconfig ${path.join(__dirname, ".npmrc")}`);
     }
     util.cd(originalDir);
 }
@@ -655,7 +659,7 @@ gulp.task("tscBuildTasks", function (cb) {
             const taskPath = path.dirname(configPath);
 
             try {
-                pkgm.installDependencies(taskPath, path.basename(taskPath), path.join(taskPath, ".npmrc"));
+                pkgm.installDependencies(taskPath, path.basename(taskPath));
                 cp.execFileSync(process.execPath, [tscCliPath, '-p', configPath], { stdio: util.isDebug() ? 'inherit' : 'ignore' });
             } catch (err) {
                 console.error(`TypeScript compilation failed for ${configPath}: ${err.message}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/through2": "^2.0.41",
         "@types/validator": "^5.7.35",
         "@types/xml2js": "^0.4.14",
-        "adm-zip": "0.4.11",
+        "adm-zip": "0.6.0",
         "azure-pipelines-task-lib": "5.2.8",
         "gulp": "^5.0.1",
         "gulp-cli": "^3.0.0",
@@ -72,6 +72,8 @@
     },
     "node_modules/@isaacs/cliui": {
       "version": "9.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha1-TQo/EnBYBDvy5+4Wnq8w7ZATAvM=",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -80,6 +82,8 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -92,6 +96,8 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -100,6 +106,8 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -112,6 +120,8 @@
     },
     "node_modules/@types/adm-zip": {
       "version": "0.4.34",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/adm-zip/-/adm-zip-0.4.34.tgz",
+      "integrity": "sha1-YqyFnrKvYCQ2Khs+Q1J6t54MYk4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -120,11 +130,15 @@
     },
     "node_modules/@types/expect": {
       "version": "1.20.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/expect/-/expect-1.20.4.tgz",
+      "integrity": "sha1-gojlFze/fjq118d7+mlYg3RSZOU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/glob-stream": {
       "version": "8.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/glob-stream/-/glob-stream-8.0.3.tgz",
+      "integrity": "sha1-AQMwYuGl5Y2v877+k3j8DjKbU4o=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -135,6 +149,8 @@
     },
     "node_modules/@types/gulp": {
       "version": "4.0.18",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/gulp/-/gulp-4.0.18.tgz",
+      "integrity": "sha1-LdQ/QyRS8QQS7yR51E5NTwyPU/Y=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -146,6 +162,8 @@
     },
     "node_modules/@types/gulp-mocha": {
       "version": "0.0.37",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/gulp-mocha/-/gulp-mocha-0.0.37.tgz",
+      "integrity": "sha1-OMXFpYALR5cKEemD92AmhtSma1Q=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -155,13 +173,15 @@
     },
     "node_modules/@types/mocha": {
       "version": "10.0.10",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha1-kfYpBejSPL1mIlMS8jlFSiO+v6A=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.41",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-20.19.41.tgz",
-      "integrity": "sha1-uyZqHgqqL0U30Uro6/I43ZynPOY=",
+      "version": "20.19.43",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha1-/Oz1gLpCoNtVz0BMNyyXlzw3bJc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -169,12 +189,16 @@
       }
     },
     "node_modules/@types/picomatch": {
-      "version": "4.0.2",
+      "version": "4.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha1-2Su/JBZkeMVFfIu5ukGn9J1V4JQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/shelljs": {
       "version": "0.8.17",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/shelljs/-/shelljs-0.8.17.tgz",
+      "integrity": "sha1-iyG493AVryY6fj5Qk/8rdzIORdI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -184,6 +208,8 @@
     },
     "node_modules/@types/streamx": {
       "version": "2.9.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/streamx/-/streamx-2.9.5.tgz",
+      "integrity": "sha1-Kkoo1z5SHGeZ4G5/qk2rwhOcVzM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -192,6 +218,8 @@
     },
     "node_modules/@types/through2": {
       "version": "2.0.41",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/through2/-/through2-2.0.41.tgz",
+      "integrity": "sha1-Pl4XINcf/foDwi8qrWWT0SpHA08=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -200,6 +228,8 @@
     },
     "node_modules/@types/undertaker": {
       "version": "1.2.12",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/undertaker/-/undertaker-1.2.12.tgz",
+      "integrity": "sha1-3Nnm6FqZT7sXDdAb3Vy8SpcMG0Q=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -210,16 +240,22 @@
     },
     "node_modules/@types/undertaker-registry": {
       "version": "1.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/undertaker-registry/-/undertaker-registry-1.0.4.tgz",
+      "integrity": "sha1-LqS2ir0LOtZxarisKHNAksHRUsQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/validator": {
       "version": "5.7.35",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/validator/-/validator-5.7.35.tgz",
+      "integrity": "sha1-L1cI2eVhRAMCoWpqTXeeuT7pXj4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/vinyl": {
       "version": "2.0.12",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/vinyl/-/vinyl-2.0.12.tgz",
+      "integrity": "sha1-F2QsqaiuEPPbAY6fiF2kGI20xuY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -228,7 +264,9 @@
       }
     },
     "node_modules/@types/vinyl-fs": {
-      "version": "3.0.7",
+      "version": "3.0.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/vinyl-fs/-/vinyl-fs-3.0.8.tgz",
+      "integrity": "sha1-mgNTJtPyuejgnrHXBUGfpRRagyg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -239,6 +277,8 @@
     },
     "node_modules/@types/xml2js": {
       "version": "0.4.14",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/xml2js/-/xml2js-0.4.14.tgz",
+      "integrity": "sha1-XUYqKnMwNF4jCca1SaGDo3bej5o=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -246,11 +286,13 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.4.11",
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=0.3.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -267,14 +309,13 @@
       }
     },
     "node_modules/ansi-colors": {
-      "version": "1.1.0",
+      "version": "3.2.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-colors/-/ansi-colors-3.2.4.tgz",
+      "integrity": "sha1-46PaS/uubIapwoViXeEkojQCb78=",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "ansi-wrap": "^0.1.0"
-      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
@@ -287,16 +328,36 @@
         "node": ">=8"
       }
     },
-    "node_modules/ansi-wrap": {
-      "version": "0.1.0",
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true,
+      "license": "MIT (https://github.com/jonschlinkert/ansi-wrap/blob/master/LICENSE)",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha1-eQxYsZuhcgqEIFtXxhjVrYUklz4=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -316,6 +377,8 @@
     },
     "node_modules/append-buffer": {
       "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/append-buffer/-/append-buffer-1.0.2.tgz",
+      "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -430,6 +493,8 @@
     },
     "node_modules/arr-diff": {
       "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -438,6 +503,8 @@
     },
     "node_modules/arr-union": {
       "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -528,11 +595,15 @@
     },
     "node_modules/asap": {
       "version": "2.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -551,6 +622,8 @@
     },
     "node_modules/async-done": {
       "version": "1.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/async-done/-/async-done-1.3.2.tgz",
+      "integrity": "sha1-XhWqcplipLB0FPUoqIzfGOCykKI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -647,20 +720,10 @@
         "uuid": "^3.0.1"
       }
     },
-    "node_modules/azure-pipelines-task-lib/node_modules/adm-zip": {
-      "version": "0.5.18",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.18.tgz",
-      "integrity": "sha1-KDoF8r8eP9MV8PMc3im3puPBYZ0=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0"
-      }
-    },
     "node_modules/b4a": {
-      "version": "1.8.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/b4a/-/b4a-1.8.0.tgz",
-      "integrity": "sha1-HKO6DtyUaaqr71ZH52moPVAYCxo=",
+      "version": "1.8.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha1-fxYzTKgBJ66yYGSiiEGsvxdIQKQ=",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -702,28 +765,17 @@
         "node": ">= 10.13.0"
       }
     },
-    "node_modules/bach/node_modules/now-and-later": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/now-and-later/-/now-and-later-3.0.0.tgz",
-      "integrity": "sha1-zcBF3FuJSzV5PPJ2zDIGB3u3MC0=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.8.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha1-ez4QvY4fyA2vOLtRaSFnj1ZquJ8=",
+      "version": "2.9.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha1-XIZhaWY0O8sDobMVX+qyU+rb80k=",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -758,6 +810,8 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha1-9uFKl4WNMnJSIAJC1Mz+UixEVSI=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -768,30 +822,14 @@
       }
     },
     "node_modules/bl": {
-      "version": "5.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bl/-/bl-5.1.0.tgz",
-      "integrity": "sha1-GDcV9njHGI7O+f5HXZAglABiQnM=",
+      "version": "1.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha1-Ho3YAULqyA1xWMnczAR/tiDgNec=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "buffer": "^6.0.3",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha1-VqmzbqllwAxak+8x6xEaDxEFaWc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/brace-expansion": {
@@ -807,6 +845,8 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -824,9 +864,9 @@
       "license": "ISC"
     },
     "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha1-Ks5XhFnMj74qcKqo9S7mO2p0xsY=",
+      "version": "5.7.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha1-umLnwTEzBTWCGXFghRqPZI6Z7tA=",
       "dev": true,
       "funding": [
         {
@@ -845,7 +885,7 @@
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-alloc": {
@@ -878,6 +918,8 @@
     },
     "node_modules/buffer-equal": {
       "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-equal/-/buffer-equal-1.0.1.tgz",
+      "integrity": "sha1-L3ZRvlsbPwV/zW5+4WzzR2cHfZA=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -896,17 +938,21 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
+      "version": "1.0.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha1-OaZEcAyAvH0MqRAvxtHUOy/X7uc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -918,6 +964,8 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha1-S1QowiK+mF15w9gmV0edvgtZstY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -930,6 +978,8 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha1-I43pNdKippKSjFOMfM+pEGf9Bio=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -956,8 +1006,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/caseless": {
+      "version": "0.11.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha1-GXxsxmnvKo3F57TZfuTgksPrDVs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -997,8 +1073,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
     "node_modules/clone": {
       "version": "2.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1007,6 +1097,8 @@
     },
     "node_modules/clone-buffer": {
       "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1015,11 +1107,15 @@
     },
     "node_modules/clone-stats": {
       "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/clone-stats/-/clone-stats-1.0.0.tgz",
+      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cloneable-readable": {
       "version": "1.1.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
+      "integrity": "sha1-EgoAywU7+2OiIucJ+Wg+ouEdjOw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1027,6 +1123,26 @@
         "process-nextick-args": "^2.0.0",
         "readable-stream": "^2.3.5"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/colors": {
       "version": "1.3.3",
@@ -1069,11 +1185,15 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "dev": true,
       "engines": [
         "node >= 0.8"
@@ -1087,7 +1207,9 @@
       }
     },
     "node_modules/convert-source-map": {
-      "version": "1.9.0",
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha1-S1YPZJ/E6RjdCrdc9JYei8iC2Co=",
       "dev": true,
       "license": "MIT"
     },
@@ -1107,6 +1229,8 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U=",
       "dev": true,
       "license": "MIT"
     },
@@ -1118,31 +1242,6 @@
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.1.0"
-      }
-    },
-    "node_modules/crc/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha1-umLnwTEzBTWCGXFghRqPZI6Z7tA=",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/crc32-stream": {
@@ -1161,6 +1260,8 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1297,6 +1398,8 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha1-iU3BQbt9MGCuQ2b2oBB+aPvkjF4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1313,6 +1416,8 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha1-EHgcxhbrlRqAoDS6/Kpzd/avK2w=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1360,6 +1465,8 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha1-165mfh3INIL4tw/Q9u78UNow9Yo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1373,6 +1480,8 @@
     },
     "node_modules/duplexify": {
       "version": "3.7.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1418,6 +1527,8 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha1-c0TXEd6kDgt0q8LtSXeHQ8ztsIw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1512,19 +1623,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es-abstract-get/node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-array-method-boxes-properly": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
@@ -1534,6 +1632,8 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha1-mD6y+aZyTpMD9hrd8BHHLgngsPo=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1542,6 +1642,8 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1549,7 +1651,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1606,6 +1710,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/events-universal": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/events-universal/-/events-universal-1.0.1.tgz",
@@ -1640,71 +1757,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/execa/node_modules/human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha1-QmZaKE+a4NreO6QevDfrS4UvOig=",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16.17.0"
-      }
-    },
-    "node_modules/execa/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha1-5r/XqmvvafT0cs6btoHj5XtDGaw=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/execa/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha1-YKkFUNXLCyOcymXYk7GlOymHHsw=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/execa/node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha1-fCTBjtH9LpvKS9JoBqM2E8d9NLQ=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/execa/node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha1-UolMMT+/8xiDUoCu1g/3Hr8SuP0=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -1720,11 +1772,15 @@
     },
     "node_modules/extend": {
       "version": "3.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/extend-shallow": {
       "version": "3.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1753,6 +1809,8 @@
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha1-0G1YXOjbqQoWsFBcVDw8z7OuuBg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1788,6 +1846,8 @@
     },
     "node_modules/fastq": {
       "version": "1.20.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha1-ynUKENySW8ixiDn9ID4+9LPO1nU=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1796,6 +1856,8 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1877,6 +1939,8 @@
     },
     "node_modules/flush-write-stream": {
       "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+      "integrity": "sha1-jdfYc6G6vCB9lOrQwuDkQnbr8ug=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1946,6 +2010,8 @@
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha1-Mujp7Rtoo0l777msK2rfkqY4V28=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1967,19 +2033,23 @@
       "license": "MIT"
     },
     "node_modules/fs-mkdirp-stream": {
-      "version": "1.0.0",
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs-mkdirp-stream/-/fs-mkdirp-stream-2.0.1.tgz",
+      "integrity": "sha1-HoJXXEAjkprTXPaSafhPGoyXOqc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "through2": "^2.0.3"
+        "graceful-fs": "^4.2.8",
+        "streamx": "^2.12.0"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true,
       "license": "ISC"
     },
@@ -1999,6 +2069,8 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2027,38 +2099,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/function.prototype.name/node_modules/call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha1-OaZEcAyAvH0MqRAvxtHUOy/X7uc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/function.prototype.name/node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/functions-have-names": {
@@ -2093,6 +2133,8 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha1-dD8OO2lkqTpUke0b/6rgVNf5jQE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2116,6 +2158,8 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha1-FQs/J0OGnvPoUewMSdFbHRTQDuE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2172,6 +2216,8 @@
     },
     "node_modules/glob": {
       "version": "11.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha1-T4JlduTrmcfa04N5PS+fCPZ+UKY=",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -2194,6 +2240,8 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2204,62 +2252,36 @@
       }
     },
     "node_modules/glob-stream": {
-      "version": "6.1.0",
+      "version": "8.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob-stream/-/glob-stream-8.0.3.tgz",
+      "integrity": "sha1-h+YxU6rfBb0CB83holPuOdkUWLk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "extend": "^3.0.0",
-        "glob": "^7.1.1",
-        "glob-parent": "^3.1.0",
+        "@gulpjs/to-absolute-glob": "^4.0.0",
+        "anymatch": "^3.1.3",
+        "fastq": "^1.13.0",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
         "is-negated-glob": "^1.0.0",
-        "ordered-read-streams": "^1.0.0",
-        "pumpify": "^1.3.5",
-        "readable-stream": "^2.1.5",
-        "remove-trailing-separator": "^1.0.1",
-        "to-absolute-glob": "^2.0.0",
-        "unique-stream": "^2.0.2"
+        "normalize-path": "^3.0.0",
+        "streamx": "^2.12.5"
       },
       "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/glob-stream/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/glob-stream/node_modules/glob-parent": {
-      "version": "3.1.0",
+      "version": "6.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha1-bSN9mQg5UMeSkPJMdkKj3poo+eM=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      }
-    },
-    "node_modules/glob-stream/node_modules/is-glob": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.0"
+        "is-glob": "^4.0.3"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/glob-watcher": {
@@ -2293,6 +2315,8 @@
     },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "4.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2313,11 +2337,13 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha1-vUhoegvjjtKWE5kQVgD4MglYYdE=",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2403,6 +2429,8 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha1-ifVrghe9vIgCvSmd9tfxCB1+UaE=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2414,6 +2442,8 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM=",
       "dev": true,
       "license": "ISC"
     },
@@ -2461,131 +2491,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/gulp-cli/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/gulp-cli/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/gulp-cli/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/gulp-cli/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/gulp-cli/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/gulp-cli/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gulp-cli/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gulp-cli/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/gulp-cli/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/gulp-mocha": {
@@ -2662,6 +2567,8 @@
     },
     "node_modules/gulp-typescript": {
       "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/gulp-typescript/-/gulp-typescript-5.0.1.tgz",
+      "integrity": "sha1-lsZWWm6zHgjCquHIV7GgeeYibZQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2679,16 +2586,162 @@
         "typescript": "~2.7.1 || >=2.8.0-dev || >=2.9.0-dev || ~3.0.0 || >=3.0.0-dev || >=3.1.0-dev || >= 3.2.0-dev || >= 3.3.0-dev"
       }
     },
-    "node_modules/gulp-typescript/node_modules/ansi-colors": {
-      "version": "3.2.4",
+    "node_modules/gulp-typescript/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha1-f6rmI1P7QhM2bQypg1jSLoNosF8=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/gulp-typescript/node_modules/fs-mkdirp-stream": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+      "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "through2": "^2.0.3"
+      },
       "engines": {
-        "node": ">=6"
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/gulp-typescript/node_modules/fs-mkdirp-stream/node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/gulp-typescript/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gulp-typescript/node_modules/glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      }
+    },
+    "node_modules/gulp-typescript/node_modules/glob-stream": {
+      "version": "6.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob-stream/-/glob-stream-6.1.0.tgz",
+      "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.0",
+        "glob": "^7.1.1",
+        "glob-parent": "^3.1.0",
+        "is-negated-glob": "^1.0.0",
+        "ordered-read-streams": "^1.0.0",
+        "pumpify": "^1.3.5",
+        "readable-stream": "^2.1.5",
+        "remove-trailing-separator": "^1.0.1",
+        "to-absolute-glob": "^2.0.0",
+        "unique-stream": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/gulp-typescript/node_modules/is-glob": {
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-glob/-/is-glob-3.1.0.tgz",
+      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gulp-typescript/node_modules/lead": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lead/-/lead-1.0.0.tgz",
+      "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flush-write-stream": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/gulp-typescript/node_modules/normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gulp-typescript/node_modules/now-and-later": {
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/now-and-later/-/now-and-later-2.0.1.tgz",
+      "integrity": "sha1-jlechoV2SnzALLaAOA6U9DzLH3w=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.3.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/gulp-typescript/node_modules/resolve-options": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/resolve-options/-/resolve-options-1.1.0.tgz",
+      "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "value-or-function": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/gulp-typescript/node_modules/through2": {
       "version": "3.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha1-mfiJMc/HYex2eLQdXXM2tbage/Q=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2696,177 +2749,97 @@
         "readable-stream": "2 || 3"
       }
     },
-    "node_modules/gulp/node_modules/convert-source-map": {
+    "node_modules/gulp-typescript/node_modules/to-through": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha1-S1YPZJ/E6RjdCrdc9JYei8iC2Co=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/gulp/node_modules/fs-mkdirp-stream": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs-mkdirp-stream/-/fs-mkdirp-stream-2.0.1.tgz",
-      "integrity": "sha1-HoJXXEAjkprTXPaSafhPGoyXOqc=",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-through/-/to-through-2.0.0.tgz",
+      "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "graceful-fs": "^4.2.8",
-        "streamx": "^2.12.0"
+        "through2": "^2.0.3"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">= 0.10"
       }
     },
-    "node_modules/gulp/node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha1-bSN9mQg5UMeSkPJMdkKj3poo+eM=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/gulp/node_modules/glob-stream": {
-      "version": "8.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob-stream/-/glob-stream-8.0.3.tgz",
-      "integrity": "sha1-h+YxU6rfBb0CB83holPuOdkUWLk=",
+    "node_modules/gulp-typescript/node_modules/to-through/node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@gulpjs/to-absolute-glob": "^4.0.0",
-        "anymatch": "^3.1.3",
-        "fastq": "^1.13.0",
-        "glob-parent": "^6.0.2",
-        "is-glob": "^4.0.3",
-        "is-negated-glob": "^1.0.0",
-        "normalize-path": "^3.0.0",
-        "streamx": "^2.12.5"
-      },
-      "engines": {
-        "node": ">=10.13.0"
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
       }
     },
-    "node_modules/gulp/node_modules/lead": {
-      "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lead/-/lead-4.0.0.tgz",
-      "integrity": "sha1-Uxeknv+w5+w6DI+5wbJPtxaquTk=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/gulp/node_modules/now-and-later": {
+    "node_modules/gulp-typescript/node_modules/value-or-function": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/now-and-later/-/now-and-later-3.0.0.tgz",
-      "integrity": "sha1-zcBF3FuJSzV5PPJ2zDIGB3u3MC0=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/gulp/node_modules/resolve-options": {
-      "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/resolve-options/-/resolve-options-2.0.0.tgz",
-      "integrity": "sha1-oaV6mUnbVJ3Qdd4/VVBnXwLx5MU=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "value-or-function": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/gulp/node_modules/to-through": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-through/-/to-through-3.0.0.tgz",
-      "integrity": "sha1-v0lW6spaBHZHSFClNnK+1pBqzlQ=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "streamx": "^2.12.5"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/gulp/node_modules/value-or-function": {
-      "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/value-or-function/-/value-or-function-4.0.0.tgz",
-      "integrity": "sha1-cINraodqAQ3DoriE55AunbBkN40=",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/value-or-function/-/value-or-function-3.0.0.tgz",
+      "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10.13.0"
+        "node": ">= 0.10"
       }
     },
-    "node_modules/gulp/node_modules/vinyl": {
-      "version": "3.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/vinyl/-/vinyl-3.0.1.tgz",
-      "integrity": "sha1-X1/4UlW9orXaJeSzvYCz/Ad/tak=",
+    "node_modules/gulp-typescript/node_modules/vinyl-fs": {
+      "version": "3.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+      "integrity": "sha1-yFhJQF9nQo/qu71cXb3WT0fTG8c=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "clone": "^2.1.2",
-        "remove-trailing-separator": "^1.1.0",
-        "replace-ext": "^2.0.0",
-        "teex": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/gulp/node_modules/vinyl-fs": {
-      "version": "4.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/vinyl-fs/-/vinyl-fs-4.0.2.tgz",
-      "integrity": "sha1-1GVXZT5KcQnynWJqnPR4aAx/jHA=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fs-mkdirp-stream": "^2.0.1",
-        "glob-stream": "^8.0.3",
-        "graceful-fs": "^4.2.11",
-        "iconv-lite": "^0.6.3",
+        "fs-mkdirp-stream": "^1.0.0",
+        "glob-stream": "^6.1.0",
+        "graceful-fs": "^4.0.0",
         "is-valid-glob": "^1.0.0",
-        "lead": "^4.0.0",
-        "normalize-path": "3.0.0",
-        "resolve-options": "^2.0.0",
-        "stream-composer": "^1.0.2",
-        "streamx": "^2.14.0",
-        "to-through": "^3.0.0",
-        "value-or-function": "^4.0.0",
-        "vinyl": "^3.0.1",
-        "vinyl-sourcemap": "^2.0.0"
+        "lazystream": "^1.0.0",
+        "lead": "^1.0.0",
+        "object.assign": "^4.0.4",
+        "pumpify": "^1.3.5",
+        "readable-stream": "^2.3.3",
+        "remove-bom-buffer": "^3.0.0",
+        "remove-bom-stream": "^1.2.0",
+        "resolve-options": "^1.1.0",
+        "through2": "^2.0.0",
+        "to-through": "^2.0.0",
+        "value-or-function": "^3.0.0",
+        "vinyl": "^2.0.0",
+        "vinyl-sourcemap": "^1.1.0"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">= 0.10"
       }
     },
-    "node_modules/gulp/node_modules/vinyl-sourcemap": {
-      "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/vinyl-sourcemap/-/vinyl-sourcemap-2.0.0.tgz",
-      "integrity": "sha1-Qi9BCg6pfLVM69aY1WoG16IuAnc=",
+    "node_modules/gulp-typescript/node_modules/vinyl-fs/node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "convert-source-map": "^2.0.0",
-        "graceful-fs": "^4.2.10",
-        "now-and-later": "^3.0.0",
-        "streamx": "^2.12.5",
-        "vinyl": "^3.0.0",
-        "vinyl-contents": "^2.0.0"
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/gulp-typescript/node_modules/vinyl-sourcemap": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+      "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "append-buffer": "^1.0.2",
+        "convert-source-map": "^1.5.0",
+        "graceful-fs": "^4.1.6",
+        "normalize-path": "^2.1.1",
+        "now-and-later": "^2.0.0",
+        "remove-bom-buffer": "^3.0.0",
+        "vinyl": "^2.0.0"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">= 0.10"
       }
     },
     "node_modules/gulplog": {
@@ -2895,8 +2868,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha1-lj7X0HHce/XwhMW/vg0bYiJYaFQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2924,6 +2909,8 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha1-/JxqeDoISVHQuXH+EBjegTcHozg=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2950,7 +2937,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
+      "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2985,6 +2974,8 @@
     },
     "node_modules/http-basic": {
       "version": "2.5.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/http-basic/-/http-basic-2.5.1.tgz",
+      "integrity": "sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2993,13 +2984,10 @@
         "http-response-object": "^1.0.0"
       }
     },
-    "node_modules/http-basic/node_modules/caseless": {
-      "version": "0.11.0",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/http-response-object": {
       "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/http-response-object/-/http-response-object-1.1.0.tgz",
+      "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM=",
       "dev": true,
       "license": "MIT"
     },
@@ -3018,11 +3006,13 @@
       }
     },
     "node_modules/human-signals": {
-      "version": "2.1.0",
+      "version": "5.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha1-QmZaKE+a4NreO6QevDfrS4UvOig=",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=10.17.0"
+        "node": ">=16.17.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -3068,6 +3058,9 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3077,6 +3070,8 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "dev": true,
       "license": "ISC"
     },
@@ -3114,6 +3109,8 @@
     },
     "node_modules/is-absolute": {
       "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha1-OV4a6EsR8mrReV5zwXN45IowFXY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3180,6 +3177,8 @@
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3208,6 +3207,8 @@
     },
     "node_modules/is-buffer": {
       "version": "1.1.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true,
       "license": "MIT"
     },
@@ -3225,13 +3226,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha1-KpiAGoSfQ+Kt1kT7trxiKbGaTvQ=",
+      "version": "2.16.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha1-PgdFCoCA684/vwysSU9NKrMk4II=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3309,6 +3310,8 @@
     },
     "node_modules/is-extendable": {
       "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3320,6 +3323,8 @@
     },
     "node_modules/is-extendable/node_modules/is-plain-object": {
       "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3331,6 +3336,8 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3385,6 +3392,8 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3428,6 +3437,8 @@
     },
     "node_modules/is-negated-glob": {
       "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+      "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3445,6 +3456,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-number-object": {
@@ -3505,6 +3526,8 @@
     },
     "node_modules/is-relative": {
       "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha1-obtpNc6MXboei5dUubLcwCDiJg0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3544,13 +3567,13 @@
       }
     },
     "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha1-5r/XqmvvafT0cs6btoHj5XtDGaw=",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3609,6 +3632,8 @@
     },
     "node_modules/is-unc-path": {
       "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha1-1zHoiY7QkKEsNSrS6u1Qla0yLJ0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3633,11 +3658,15 @@
     },
     "node_modules/is-utf8": {
       "version": "0.2.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/is-valid-glob": {
       "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+      "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3692,6 +3721,8 @@
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3732,16 +3763,22 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
       "version": "3.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3757,6 +3794,8 @@
     },
     "node_modules/jackspeak": {
       "version": "4.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha1-J++A8zuTQSA3w76k+O3fgOGTFIM=",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -3825,6 +3864,8 @@
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true,
       "license": "MIT"
     },
@@ -3853,6 +3894,8 @@
     },
     "node_modules/lazystream": {
       "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha1-SUyDEGLx+UCCUexE2xy6KSQqJjg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3863,14 +3906,13 @@
       }
     },
     "node_modules/lead": {
-      "version": "1.0.0",
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lead/-/lead-4.0.0.tgz",
+      "integrity": "sha1-Uxeknv+w5+w6DI+5wbJPtxaquTk=",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "flush-write-stream": "^1.0.2"
-      },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/lie": {
@@ -3942,84 +3984,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/log-symbols/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/log-symbols/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/log-symbols/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/log-symbols/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/log-symbols/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/log-symbols/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/lru-cache": {
-      "version": "11.2.6",
+      "version": "11.5.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha1-AOFmZckMYg+6FKPDaHMql2ST92A=",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4038,6 +4006,8 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha1-oN10voHiqlwvJ+Zc4oNgXuTit/k=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4059,11 +4029,15 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4108,11 +4082,16 @@
       }
     },
     "node_modules/mimic-fn": {
-      "version": "2.1.0",
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha1-YKkFUNXLCyOcymXYk7GlOymHHsw=",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -4124,6 +4103,8 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4145,6 +4126,8 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha1-eTibTrG7LQA6m7qH1JLyvTe9xls=",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4210,22 +4193,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/mocha/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/mocha/node_modules/brace-expansion": {
       "version": "2.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
@@ -4234,51 +4201,6 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/mocha/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/mocha/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/mocha/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/mocha/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mocha/node_modules/glob": {
@@ -4300,16 +4222,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
@@ -4339,43 +4251,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/mocha/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/mocha/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -4417,6 +4292,8 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4424,14 +4301,16 @@
       }
     },
     "node_modules/now-and-later": {
-      "version": "2.0.1",
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/now-and-later/-/now-and-later-3.0.0.tgz",
+      "integrity": "sha1-zcBF3FuJSzV5PPJ2zDIGB3u3MC0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "once": "^1.3.2"
+        "once": "^1.4.0"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10.13.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -4478,6 +4357,8 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4486,6 +4367,8 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha1-jBTKGkJMalYbC7KiL2b1BJqUXT0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4556,6 +4439,8 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4572,14 +4457,16 @@
       }
     },
     "node_modules/onetime": {
-      "version": "5.1.2",
+      "version": "6.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha1-fCTBjtH9LpvKS9JoBqM2E8d9NLQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mimic-fn": "^2.1.0"
+        "mimic-fn": "^4.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4587,6 +4474,8 @@
     },
     "node_modules/ordered-read-streams": {
       "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+      "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4655,6 +4544,8 @@
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha1-TxRxoBCCeob5TP2bByfjbSZ95QU=",
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
@@ -4692,6 +4583,8 @@
     },
     "node_modules/path-dirname": {
       "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true,
       "license": "MIT"
     },
@@ -4707,6 +4600,8 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4715,6 +4610,8 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4753,6 +4650,8 @@
     },
     "node_modules/path-scurry": {
       "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha1-a+DQ7gKhDZ4N56mLrmXhgskGH4U=",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -4781,6 +4680,8 @@
     },
     "node_modules/plugin-error": {
       "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/plugin-error/-/plugin-error-1.0.1.tgz",
+      "integrity": "sha1-dwFr2JGdCsN3/c3QMiMolTyleBw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4791,6 +4692,19 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/plugin-error/node_modules/ansi-colors": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "integrity": "sha1-Y3S03V1HGP884npnGjscrQdxMqk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-wrap": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -4805,11 +4719,15 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/promise": {
       "version": "7.3.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4842,6 +4760,8 @@
     },
     "node_modules/pump": {
       "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4851,6 +4771,8 @@
     },
     "node_modules/pumpify": {
       "version": "1.5.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4861,6 +4783,9 @@
     },
     "node_modules/q": {
       "version": "1.5.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4887,6 +4812,8 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
       "dev": true,
       "funding": [
         {
@@ -4919,6 +4846,8 @@
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha1-kRJegEK7obmIf0k0X2J3Anzovps=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4931,13 +4860,10 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5006,6 +4932,8 @@
     },
     "node_modules/remove-bom-buffer": {
       "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+      "integrity": "sha1-wr8eN3Ug0yT2I4kuM8EMrCwlK1M=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5018,6 +4946,8 @@
     },
     "node_modules/remove-bom-stream": {
       "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+      "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5031,17 +4961,19 @@
     },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/replace-ext": {
-      "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/replace-ext/-/replace-ext-2.0.0.tgz",
-      "integrity": "sha1-lHHCE9IuG8wmcXzW5QiB2I+BKwY=",
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/replace-ext/-/replace-ext-1.0.1.tgz",
+      "integrity": "sha1-LW2ZbQShWFXZZ0Q2Md1fd4JbAWo=",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": ">= 0.10"
       }
     },
     "node_modules/replace-homedir": {
@@ -5101,18 +5033,22 @@
       }
     },
     "node_modules/resolve-options": {
-      "version": "1.1.0",
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/resolve-options/-/resolve-options-2.0.0.tgz",
+      "integrity": "sha1-oaV6mUnbVJ3Qdd4/VVBnXwLx5MU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "value-or-function": "^3.0.0"
+        "value-or-function": "^4.0.0"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10.13.0"
       }
     },
     "node_modules/reusify": {
       "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha1-D+E7lSLhRz9RtVjueW4I8R+bSJ8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5132,6 +5068,8 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
       "dev": true,
       "funding": [
         {
@@ -5172,25 +5110,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-array-concat/node_modules/call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha1-OaZEcAyAvH0MqRAvxtHUOy/X7uc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/safe-array-concat/node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isarray/-/isarray-2.0.5.tgz",
@@ -5199,22 +5118,10 @@
       "license": "MIT"
     },
     "node_modules/safe-buffer": {
-      "version": "5.2.1",
+      "version": "5.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
       "license": "MIT"
     },
     "node_modules/safe-push-apply": {
@@ -5277,7 +5184,9 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.4.4",
+      "version": "1.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha1-2lljdikwe5fnxMso4ICnvDhWDVs=",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5286,6 +5195,8 @@
     },
     "node_modules/semver": {
       "version": "5.7.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5306,9 +5217,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
-      "integrity": "sha1-x5jMBVL/uwiYGRSkKodW4znQ1bE=",
+      "version": "7.0.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha1-BuxAV21M6pbWgBClNFIL/x+UinI=",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -5317,6 +5228,8 @@
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha1-qscjFBmOrtl1z3eyw7a4gGleVEk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5371,6 +5284,8 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5382,6 +5297,8 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5390,6 +5307,8 @@
     },
     "node_modules/shelljs": {
       "version": "0.10.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.10.0.tgz",
+      "integrity": "sha1-47uumbDz8MxdzgW0ajRvriCQ6IM=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5402,6 +5321,8 @@
     },
     "node_modules/shelljs/node_modules/execa": {
       "version": "5.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5424,6 +5345,8 @@
     },
     "node_modules/shelljs/node_modules/get-stream": {
       "version": "6.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5433,8 +5356,43 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/shelljs/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/shelljs/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/shelljs/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/shelljs/node_modules/npm-run-path": {
       "version": "4.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5444,10 +5402,38 @@
         "node": ">=8"
       }
     },
+    "node_modules/shelljs/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/shelljs/node_modules/signal-exit": {
       "version": "3.0.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/shelljs/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
@@ -5527,6 +5513,8 @@
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -5538,6 +5526,8 @@
     },
     "node_modules/source-map": {
       "version": "0.7.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha1-o2WKuH5bZCnIofO6AIPUxhyj7wI=",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -5590,18 +5580,22 @@
     },
     "node_modules/stream-exhaust": {
       "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
+      "integrity": "sha1-rNrI2lnvK8HheiwMz2wyDRIOVV0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/stream-shift": {
       "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha1-hbj6tNcQEPw7qHcugEbMSbijhks=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/streamx": {
-      "version": "2.25.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/streamx/-/streamx-2.25.0.tgz",
-      "integrity": "sha1-zJZ+mTkP2ouRix7q87xDdjfIx68=",
+      "version": "2.28.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha1-A1q1YFe37SIRtR1TLmlz8PmfvxE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5612,16 +5606,13 @@
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -5661,38 +5652,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/string.prototype.trim/node_modules/call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha1-OaZEcAyAvH0MqRAvxtHUOy/X7uc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trim/node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.10",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
@@ -5710,38 +5669,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trimend/node_modules/call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha1-OaZEcAyAvH0MqRAvxtHUOy/X7uc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trimend/node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/string.prototype.trimstart": {
@@ -5776,11 +5703,16 @@
       }
     },
     "node_modules/strip-final-newline": {
-      "version": "2.0.0",
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha1-UolMMT+/8xiDUoCu1g/3Hr8SuP0=",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-json-comments": {
@@ -5794,6 +5726,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -5832,6 +5777,8 @@
     },
     "node_modules/sync-request": {
       "version": "3.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sync-request/-/sync-request-3.0.1.tgz",
+      "integrity": "sha1-yqEjWq+Im6UBB2oYNMQ2gwqC+3M=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5870,17 +5817,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/tar-stream/node_modules/bl": {
-      "version": "1.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bl/-/bl-1.2.3.tgz",
-      "integrity": "sha1-Ho3YAULqyA1xWMnczAR/tiDgNec=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/teex": {
@@ -6017,6 +5953,8 @@
     },
     "node_modules/then-request": {
       "version": "2.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/then-request/-/then-request-2.2.0.tgz",
+      "integrity": "sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6028,13 +5966,10 @@
         "qs": "^6.1.0"
       }
     },
-    "node_modules/then-request/node_modules/caseless": {
-      "version": "0.11.0",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/through2": {
       "version": "2.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6044,6 +5979,8 @@
     },
     "node_modules/through2-filter": {
       "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/through2-filter/-/through2-filter-3.0.0.tgz",
+      "integrity": "sha1-cA54bfI2fCyIzYqlvkz5weeDElQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6073,6 +6010,8 @@
     },
     "node_modules/to-absolute-glob": {
       "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+      "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6105,8 +6044,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/to-buffer/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6116,23 +6078,17 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/to-regex-range/node_modules/is-number": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/to-through": {
-      "version": "2.0.0",
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-through/-/to-through-3.0.0.tgz",
+      "integrity": "sha1-v0lW6spaBHZHSFClNnK+1pBqzlQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "through2": "^2.0.3"
+        "streamx": "^2.12.5"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/tracer": {
@@ -6258,25 +6214,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/typed-array-length/node_modules/call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha1-OaZEcAyAvH0MqRAvxtHUOy/X7uc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/typed-rest-client": {
       "version": "2.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
@@ -6296,11 +6233,15 @@
     },
     "node_modules/typedarray": {
       "version": "0.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "4.9.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha1-CVl5+bzA0J2jJNWNA86Pg3TL5lo=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6332,6 +6273,8 @@
     },
     "node_modules/unc-path-regex": {
       "version": "0.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6380,6 +6323,8 @@
     },
     "node_modules/unique-stream": {
       "version": "2.4.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/unique-stream/-/unique-stream-2.4.0.tgz",
+      "integrity": "sha1-XZlTCVVrW6MkGXo/VB1nWgoFL/Q=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6396,6 +6341,8 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true,
       "license": "MIT"
     },
@@ -6448,7 +6395,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.15.26",
+      "version": "13.15.35",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha1-gc9FXFHxW2nY00C+WRTz+rANv38=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6456,15 +6405,19 @@
       }
     },
     "node_modules/value-or-function": {
-      "version": "3.0.0",
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/value-or-function/-/value-or-function-4.0.0.tgz",
+      "integrity": "sha1-cINraodqAQ3DoriE55AunbBkN40=",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10.13.0"
       }
     },
     "node_modules/vinyl": {
       "version": "2.2.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/vinyl/-/vinyl-2.2.1.tgz",
+      "integrity": "sha1-I8+4u6tezjgDqiwKHrKK98u6GXQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6493,6 +6446,68 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/vinyl-contents/node_modules/bl": {
+      "version": "5.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bl/-/bl-5.1.0.tgz",
+      "integrity": "sha1-GDcV9njHGI7O+f5HXZAglABiQnM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/vinyl-contents/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha1-Ks5XhFnMj74qcKqo9S7mO2p0xsY=",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/vinyl-contents/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha1-VqmzbqllwAxak+8x6xEaDxEFaWc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/vinyl-contents/node_modules/replace-ext": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/replace-ext/-/replace-ext-2.0.0.tgz",
+      "integrity": "sha1-lHHCE9IuG8wmcXzW5QiB2I+BKwY=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/vinyl-contents/node_modules/vinyl": {
       "version": "3.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/vinyl/-/vinyl-3.0.1.tgz",
@@ -6510,66 +6525,99 @@
       }
     },
     "node_modules/vinyl-fs": {
-      "version": "3.0.3",
+      "version": "4.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/vinyl-fs/-/vinyl-fs-4.0.2.tgz",
+      "integrity": "sha1-1GVXZT5KcQnynWJqnPR4aAx/jHA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fs-mkdirp-stream": "^1.0.0",
-        "glob-stream": "^6.1.0",
-        "graceful-fs": "^4.0.0",
+        "fs-mkdirp-stream": "^2.0.1",
+        "glob-stream": "^8.0.3",
+        "graceful-fs": "^4.2.11",
+        "iconv-lite": "^0.6.3",
         "is-valid-glob": "^1.0.0",
-        "lazystream": "^1.0.0",
-        "lead": "^1.0.0",
-        "object.assign": "^4.0.4",
-        "pumpify": "^1.3.5",
-        "readable-stream": "^2.3.3",
-        "remove-bom-buffer": "^3.0.0",
-        "remove-bom-stream": "^1.2.0",
-        "resolve-options": "^1.1.0",
-        "through2": "^2.0.0",
-        "to-through": "^2.0.0",
-        "value-or-function": "^3.0.0",
-        "vinyl": "^2.0.0",
-        "vinyl-sourcemap": "^1.1.0"
+        "lead": "^4.0.0",
+        "normalize-path": "3.0.0",
+        "resolve-options": "^2.0.0",
+        "stream-composer": "^1.0.2",
+        "streamx": "^2.14.0",
+        "to-through": "^3.0.0",
+        "value-or-function": "^4.0.0",
+        "vinyl": "^3.0.1",
+        "vinyl-sourcemap": "^2.0.0"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/vinyl-fs/node_modules/replace-ext": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/replace-ext/-/replace-ext-2.0.0.tgz",
+      "integrity": "sha1-lHHCE9IuG8wmcXzW5QiB2I+BKwY=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/vinyl-fs/node_modules/vinyl": {
+      "version": "3.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/vinyl/-/vinyl-3.0.1.tgz",
+      "integrity": "sha1-X1/4UlW9orXaJeSzvYCz/Ad/tak=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^2.1.2",
+        "remove-trailing-separator": "^1.1.0",
+        "replace-ext": "^2.0.0",
+        "teex": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/vinyl-sourcemap": {
-      "version": "1.1.0",
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/vinyl-sourcemap/-/vinyl-sourcemap-2.0.0.tgz",
+      "integrity": "sha1-Qi9BCg6pfLVM69aY1WoG16IuAnc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "append-buffer": "^1.0.2",
-        "convert-source-map": "^1.5.0",
-        "graceful-fs": "^4.1.6",
-        "normalize-path": "^2.1.1",
-        "now-and-later": "^2.0.0",
-        "remove-bom-buffer": "^3.0.0",
-        "vinyl": "^2.0.0"
+        "convert-source-map": "^2.0.0",
+        "graceful-fs": "^4.2.10",
+        "now-and-later": "^3.0.0",
+        "streamx": "^2.12.5",
+        "vinyl": "^3.0.0",
+        "vinyl-contents": "^2.0.0"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">=10.13.0"
       }
     },
-    "node_modules/vinyl-sourcemap/node_modules/normalize-path": {
-      "version": "2.1.1",
+    "node_modules/vinyl-sourcemap/node_modules/replace-ext": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/replace-ext/-/replace-ext-2.0.0.tgz",
+      "integrity": "sha1-lHHCE9IuG8wmcXzW5QiB2I+BKwY=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/vinyl-sourcemap/node_modules/vinyl": {
+      "version": "3.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/vinyl/-/vinyl-3.0.1.tgz",
+      "integrity": "sha1-X1/4UlW9orXaJeSzvYCz/Ad/tak=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "remove-trailing-separator": "^1.0.1"
+        "clone": "^2.1.2",
+        "remove-trailing-separator": "^1.1.0",
+        "replace-ext": "^2.0.0",
+        "teex": "^1.0.1"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/vinyl/node_modules/replace-ext": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/walkdir": {
@@ -6584,6 +6632,8 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/which/-/which-2.0.2.tgz",
+      "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6692,25 +6742,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/which-typed-array/node_modules/call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha1-OaZEcAyAvH0MqRAvxtHUOy/X7uc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/winreg": {
       "version": "0.0.12",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/winreg/-/winreg-0.0.12.tgz",
@@ -6753,8 +6784,28 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true,
       "license": "ISC"
     },
@@ -6774,6 +6825,8 @@
     },
     "node_modules/xmlbuilder": {
       "version": "11.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha1-vpuuHIoEbnazESdyY0fQrXACvrM=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6782,6 +6835,8 @@
     },
     "node_modules/xtend": {
       "version": "4.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6794,6 +6849,25 @@
       "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
       "dev": true,
       "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yargs/-/yargs-16.2.2.tgz",
+      "integrity": "sha1-xWcx3KDSeIrghm3TyDkH1rq4X30=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
       "engines": {
         "node": ">=10"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/validator": "^5.7.35",
         "@types/xml2js": "^0.4.14",
         "adm-zip": "0.6.0",
-        "azure-pipelines-task-lib": "5.2.8",
+        "azure-pipelines-task-lib": "5.278.0",
         "gulp": "^5.0.1",
         "gulp-cli": "^3.0.0",
         "gulp-mocha": "^10.0.1",
@@ -705,19 +705,18 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
-      "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
+      "version": "5.278.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.278.0.tgz",
+      "integrity": "sha1-ZdWwBh1+xNDN4Q5u9sIcP0mUXFQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/b4a": {

--- a/package.js
+++ b/package.js
@@ -96,7 +96,6 @@ function copyCommonModules(currentExtnRoot, commonDeps, commonSrc, extensionSour
         .then(function () {
             // Copy the task to the layout folder.
             const targetPath = path.join(currentExtnRoot, "Src", "Tasks", task.name);
-            const taskSourcePath = path.join(extensionSourcePath, "Src", "Tasks", task.name);
             shell.mkdir('-p', targetPath);
             shell.rm('-f', path.join(targetPath, '*.csproj'));
             shell.rm('-f', path.join(targetPath, '*.md'));
@@ -130,8 +129,7 @@ function copyCommonModules(currentExtnRoot, commonDeps, commonSrc, extensionSour
                 console.log(`⚒️  Building Node task: ${task.name}`);
 
                 try {
-                    const npmrcPath = path.join(taskSourcePath, ".npmrc");
-                    installDependencies(taskDirPath, task.name, npmrcPath);
+                    installDependencies(taskDirPath, task.name);
                     console.log(`\x1b[A\x1b[K✅ npm ci at ${taskDirPath} completed successfully.`);
                 } catch (err) {
                     console.log(`\x1b[A\x1b[K❌ npm ci at ${taskDirPath} failed. Error: ${err.message}`);
@@ -150,14 +148,20 @@ function copyCommonModules(currentExtnRoot, commonDeps, commonSrc, extensionSour
 
 /**
  * Installs the dependencies for a given task using npm ci, with options to handle engine-strict mode and verbose logging.
+ * Uses the repository-root .npmrc for --userconfig so the install always has feed
+ * credentials: authentication (NpmAuthenticate@0 in CI, or vsts-npm-auth locally) is
+ * applied to the root .npmrc only. The per-task .npmrc files carry the registry URL but
+ * no auth token, so a task install that has to fetch any package not already in the npm
+ * cache would fail with E401. Registry settings are identical across every .npmrc in the
+ * repo, so using the root one changes nothing except adding the credential.
  * @param {string} taskPath - The file system path to the task for which dependencies should be installed.
  * @param {string} taskName - The name of the task, used for determining if engine-strict mode should be disabled based on externals configuration.
- * @param {string} npmrcPath - The path to the .npmrc file for the task.
  */
-function installDependencies(taskPath, taskName, npmrcPath) {
+function installDependencies(taskPath, taskName) {
     console.log(`Installing dependencies for task: ${taskName} at path: ${taskPath}`);
     const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-    const npmArgs = ['ci', '--prefix', taskPath, '--userconfig', `"${npmrcPath}"`];
+    const rootNpmrcPath = path.join(__dirname, ".npmrc");
+    const npmArgs = ['ci', '--prefix', taskPath, '--userconfig', `"${rootNpmrcPath}"`];
 
     // Opt specific tasks out of engine-strict. The outer `npx gulp build` loads
     // the root .npmrc and exports its settings as npm_config_* env vars, which

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/through2": "^2.0.41",
     "@types/validator": "^5.7.35",
     "@types/xml2js": "^0.4.14",
-    "adm-zip": "0.4.11",
+    "adm-zip": "0.6.0",
     "azure-pipelines-task-lib": "5.2.8",
     "gulp": "^5.0.1",
     "gulp-mocha": "^10.0.1",
@@ -41,6 +41,7 @@
     "xml2js": "^0.6.2"
   },
   "overrides": {
+    "adm-zip": "0.6.0",
     "picomatch": "2.3.2",
     "qs": "^6.14.2",
     "serialize-javascript": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/validator": "^5.7.35",
     "@types/xml2js": "^0.4.14",
     "adm-zip": "0.6.0",
-    "azure-pipelines-task-lib": "5.2.8",
+    "azure-pipelines-task-lib": "5.278.0",
     "gulp": "^5.0.1",
     "gulp-mocha": "^10.0.1",
     "gulp-typescript": "^5.0.1",
@@ -41,7 +41,6 @@
     "xml2js": "^0.6.2"
   },
   "overrides": {
-    "adm-zip": "0.6.0",
     "picomatch": "2.3.2",
     "qs": "^6.14.2",
     "serialize-javascript": "^7.0.5",


### PR DESCRIPTION
**Description**: Update the `adm-zip` dependency to `0.6.0` across the entire repository, upgrade `azure-pipelines-task-lib` to `5.278.0`, modernize the Node execution handlers of the affected tasks, and bump the versions of all affected extensions, tasks and libraries.

### 1. adm-zip -> 0.6.0
- Root `package.json`: direct devDependency `adm-zip` `0.4.11` -> `0.6.0`.
- No `adm-zip` `overrides` are needed: `azure-pipelines-task-lib` `5.278.0` declares `adm-zip: ^0.6.0`, and `0.6.0` is the only `0.6.x` on the feed, so every transitive copy resolves to `0.6.0` on its own. The interim overrides added in earlier iterations were removed.

### 2. azure-pipelines-task-lib -> 5.278.0
- Bumped all 8 `azure-pipelines-task-lib` manifest entries to `5.278.0` (preserving the `^` range where it was already used).
- Regenerated all 8 `package-lock.json` files. Every lock now resolves `adm-zip` `0.6.0` and `azure-pipelines-task-lib` `5.278.0` only (no 0.4.x/0.5.x adm-zip remaining; `@types/adm-zip` is unrelated type defs).

### 3. Node execution handler modernization
`adm-zip` `0.6.0` declares `engines.node >=14.0`, so any sub-Node-14 execution handler could fail at runtime once selected. Replaced the old handlers and corrected `minimumAgentVersion`:
- Ansible: `Node10` -> `Node16`
- BitBucket `DownloadArtifactsBitbucket`: `Node` -> `Node16`
- TeamCity `DownloadTeamCityArtifacts`: `Node` -> `Node16`
- Set `minimumAgentVersion` to `2.206.1` (the Node16 handler floor per the azure-pipelines-task-lib agent matrix) on all affected tasks, including the two ExternalTfs tasks that already shipped Node16 but incorrectly declared `2.144.0` (the Node10 floor).
- `task.loc.json` files kept in sync with their `task.json` (version, handler, minimumAgentVersion).

### 4. Version bumps
Rule applied against the master baseline: if a version's Minor is already >= 278, bump Patch by 1; if Minor < 278, set Minor to 278 and Patch to 0.

- **Extensions (vss-extension.json):** Ansible `0.279.12`, BitBucket `15.279.18`, ExternalTfs `16.279.10`, IISWebAppDeploy `1.279.11`, ServiceNow `4.279.11`, TeamCity `15.279.14`
- **Tasks (task.json / task.loc.json):** Ansible `0.279.7`, DownloadArtifactsBitbucket `15.278.1`, DownloadArtifactsTfsGit `16.279.1`, DownloadExternalBuildArtifacts `16.279.1`, DownloadTeamCityArtifacts `15.279.2`
- **Libraries (package.json):** ArtifactEngine `1.278.0`, ArtifactEngineV2 `2.278.0`

> Note: IISWebAppDeploy and ServiceNow have no dependency changes; their extension versions were bumped at explicit request.

### 5. CI build fix: npm authentication for gulp sub-installs
Regenerating the lockfiles introduced packages not present in the root `package-lock.json`, which exposed a latent authentication gap in the `gulp build` step and caused it to fail with `npm error code E401`.

- Root cause: `runNpmInstall` (`gulpfile.js`) and `installDependencies` (`package.js`) ran per-extension / per-task `npm ci` with `--userconfig` pointing at the extension/task-local `.npmrc`, which carries only the registry URL and **no** auth token. Feed authentication (`NpmAuthenticate@0` in CI, `vsts-npm-auth` locally) is applied to the repository-root `.npmrc` only. These sub-installs previously succeeded solely because the earlier authenticated root `npm ci` pre-populated the shared npm cache; once uncached packages had to be fetched from the feed, they failed with E401.
- Fix: point both shared sub-install helpers at the repository-root `.npmrc` (matching the UI-contribution install and `cachePackage`, which already do this), so every extension/task `npm ci` is authenticated without per-extension pipeline wiring. Registry settings are identical across every `.npmrc` in the repo, so this only adds the credential. Verified: the `gulp build` step now passes in the PR validation build.

**Documentation changes required:** (N)

**Added unit tests:** (N) - dependency/version, task-manifest, and build-infrastructure change only.

**Attached related issue:** (N)

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
