### PR TITLE
Add Node executors 20/24 for DownloadArtifactsBitbucket task

### DIFF
--- a/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
+++ b/Extensions/BitBucket/Src/Tasks/DownloadArtifactsBitbucket/task.json
@@ -13,8 +13,8 @@
   "demands": [],
   "version": {
     "Major": 15,
-    "Minor": 277,
-    "Patch": 6
+    "Minor": 278,
+    "Patch": 0
   },
   "minimumAgentVersion": "1.99.0",
   "instanceNameFormat": "Download Artifacts - Bitbucket",
@@ -100,6 +100,14 @@
   ],
   "execution": {
     "Node": {
+      "target": "downloadBitbucket.js",
+      "argumentFormat": ""
+    },
+    "Node20": {
+      "target": "downloadBitbucket.js",
+      "argumentFormat": ""
+    },
+    "Node24": {
       "target": "downloadBitbucket.js",
       "argumentFormat": ""
     }

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.14",
+  "version": "15.279.16",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",


### PR DESCRIPTION
**Description**: Added `Node20` and `Node24` execution handlers to the `DownloadArtifactsBitbucket` task, alongside the existing `Node` handler — all targeting `downloadBitbucket.js`. Bumped the task version to 15.278.0 and the BitBucket extension version to 15.279.7 accordingly.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.