### PR TITLE
Add Node executors 20/24 for DownloadTeamCityArtifacts  task

### DIFF
--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 15,
     "Minor": 279,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",
@@ -102,6 +102,14 @@
   "instanceNameFormat": "Download Artifacts - TeamCity",
   "execution": {
     "Node": {
+      "target": "download.js",
+      "argumentFormat": ""
+    },
+    "Node20": {
+      "target": "download.js",
+      "argumentFormat": ""
+    },
+    "Node24": {
       "target": "download.js",
       "argumentFormat": ""
     }

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.7",
+  "version": "15.279.8",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",


### PR DESCRIPTION
**Description**: Added `Node20` and `Node24` execution handlers to the `DownloadTeamCityArtifacts` task, alongside the existing `Node` handler — all targeting `download.js`. Bumped the task version to 15.279.1 and the Teamcity  extension version to 15.279.8 accordingly.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.