### PR TITLE
Add TeamCity to Typescript check

### DIFF
--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.6",
+  "version": "0.279.7",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.6",
+  "version": "15.279.13",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.5",
+  "version": "16.279.7",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.5",
+  "version": "1.279.8",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.279.7",
+  "version": "4.279.8",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/download.ts
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/download.ts
@@ -1,4 +1,4 @@
-var path = require('path');
+const path = require('path');
 
 import * as tl from 'azure-pipelines-task-lib/task';
 import * as engine from 'artifact-engine/Engine';
@@ -7,11 +7,11 @@ import * as webHandlers from 'artifact-engine/Providers/typed-rest-client/Handle
 
 tl.setResourcePath(path.join(__dirname, 'task.json'));
 
-var taskJson = require('./task.json');
-const area: string = 'DownloadTeamCityArtifacts';
+const taskJson = require('./task.json');
+const area = 'DownloadTeamCityArtifacts';
 
 function getDefaultProps() {
-    var hostType = (tl.getVariable('SYSTEM.HOSTTYPE') || "").toLowerCase();
+    const hostType = (tl.getVariable('SYSTEM.HOSTTYPE') || "").toLowerCase();
     return {
         hostType: hostType,
         definitionName: '[NonEmail:' + (hostType === 'release' ? tl.getVariable('RELEASE.DEFINITIONNAME') : tl.getVariable('BUILD.DEFINITIONNAME')) + ']',
@@ -28,20 +28,21 @@ function getDefaultProps() {
 
 function publishEvent(feature: string, properties: any): void {
     try {
-        var splitVersion = (process.env.AGENT_VERSION || '').split('.');
-        var major = parseInt(splitVersion[0] || '0');
-        var minor = parseInt(splitVersion[1] || '0');
+        const splitVersion = (process.env.AGENT_VERSION || '').split('.');
+        const major = parseInt(splitVersion[0] || '0');
+        const minor = parseInt(splitVersion[1] || '0');
         let telemetry = '';
+
         if (major > 2 || (major == 2 && minor >= 120)) {
             telemetry = `##vso[telemetry.publish area=${area};feature=${feature}]${JSON.stringify(Object.assign(getDefaultProps(), properties))}`;
-        }
-        else {
+        } else {
             if (feature === 'reliability') {
                 let reliabilityData = properties;
                 telemetry = "##vso[task.logissue type=error;code=" + reliabilityData.issueType + ";agentVersion=" + tl.getVariable('Agent.Version') + ";taskId=" + area + "-" + JSON.stringify(taskJson.version) + ";]" + reliabilityData.errorMessage
             }
         }
-        console.log(telemetry);;
+
+        console.log(telemetry);
     }
     catch (err) {
         tl.warning("Failed to log telemetry, error: " + err);
@@ -49,41 +50,42 @@ function publishEvent(feature: string, properties: any): void {
 }
 
 async function main(): Promise<void> {
-    var promise = new Promise<void>(async (resolve, reject) => {
+    const promise = new Promise<void>(async (resolve, reject) => {
         let connection = tl.getInput("connection", true)!;
         let buildId = tl.getInput("version", true);
         let itemPattern = tl.getInput("itemPattern", false);
         let downloadPath = tl.getInput("downloadPath", true)!;
 
-        var endpointUrl = tl.getEndpointUrl(connection, false);
-        var itemsUrl = endpointUrl + "/httpAuth/app/rest/builds/id:" + buildId + "/artifacts/children/";
+        const endpointUrl = tl.getEndpointUrl(connection, false);
+        let itemsUrl = endpointUrl + "/httpAuth/app/rest/builds/id:" + buildId + "/artifacts/children/";
         itemsUrl = itemsUrl.replace(/([^:]\/)\/+/g, "$1");
         console.log(tl.loc("DownloadArtifacts", itemsUrl));
 
-        var templatePath = path.join(__dirname, 'teamcity.handlebars');
-        var username = tl.getEndpointAuthorizationParameter(connection, 'username', false)!;
-        var password = tl.getEndpointAuthorizationParameter(connection, 'password', false)!;
+        const templatePath = path.join(__dirname, 'teamcity.handlebars');
+        const username = tl.getEndpointAuthorizationParameter(connection, 'username', false)!;
+        const password = tl.getEndpointAuthorizationParameter(connection, 'password', false)!;
+
         try {
             tl.setSecret(password);
         } catch {
             tl.warning('Failed to mask password for log redaction.');
         }
-        var teamcityVariables = {
+
+        const teamcityVariables = {
             "endpoint": {
                 "url": endpointUrl
             }
         };
-        var handler = new webHandlers.BasicCredentialHandler(username, password);
-        var webProvider = new providers.WebProvider(itemsUrl, templatePath, teamcityVariables, handler);
-        var fileSystemProvider = new providers.FilesystemProvider(downloadPath);
-        var parallelLimit : number = +tl.getVariable("release.artifact.download.parallellimit")!;
+        const handler = new webHandlers.BasicCredentialHandler(username, password);
+        const webProvider = new providers.WebProvider(itemsUrl, templatePath, teamcityVariables, handler);
+        const fileSystemProvider = new providers.FilesystemProvider(downloadPath);
+        const parallelLimit = Number(tl.getVariable("release.artifact.download.parallellimit"));
 
-        var downloader = new engine.ArtifactEngine();
-        var downloaderOptions = new engine.ArtifactEngineOptions();
+        const downloader = new engine.ArtifactEngine();
+        const downloaderOptions = new engine.ArtifactEngineOptions();
         downloaderOptions.itemPattern = itemPattern ? itemPattern : '**';
-        var debugMode = tl.getVariable('System.Debug');
+        const debugMode = tl.getVariable('System.Debug');
         downloaderOptions.verbose = debugMode ? debugMode.toLowerCase() != 'false' : false;
-        var parallelLimit : number = +tl.getVariable("release.artifact.download.parallellimit")!;
 
         if (parallelLimit) {
             downloaderOptions.parallelProcessingLimit = parallelLimit;

--- a/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
+++ b/Extensions/TeamCity/Src/Tasks/DownloadTeamCityArtifacts/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 15,
     "Minor": 279,
-    "Patch": 1
+    "Patch": 9
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.8",
+  "version": "15.279.9",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/externals.json
+++ b/externals.json
@@ -12,6 +12,7 @@
     "tsc-build-check": [
         "Ansible",
         "DownloadArtifactsTfsGit",
-        "DownloadExternalBuildArtifacts"
+        "DownloadExternalBuildArtifacts",
+        "TeamCity"
     ]
 }


### PR DESCRIPTION
**Description**: Enabled TypeScript build-time type-checking (`tsc-build-check` in `externals.json`) for the `TeamCity` task. Cleaned up `download.ts` to satisfy the check: replaced `var` with `const`/`let`, removed a duplicate `parallelLimit` declaration, and fixed minor formatting (extra semicolon). Bumped the `DownloadTeamCityArtifacts` task version (Patch 1 to 9) and the TeamCity extension version (15.279.8 to 15.279.9).

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [ ] Checked that applied changes work as expected.