### PR TITLE
Update dependencies and refactor Ansible task utilities

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/.npmrc
+++ b/Extensions/Ansible/Src/Tasks/Ansible/.npmrc
@@ -1,1 +1,2 @@
 registry=https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/
+engine-strict=true

--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleCommandLineInterface.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleCommandLineInterface.ts
@@ -1,5 +1,4 @@
 import tl = require("azure-pipelines-task-lib/task");
-// @ts-ignore there is no type definition for shell-quote
 import { quote } from 'shell-quote';
 
 import { ansibleInterface } from './ansibleInterface';

--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
@@ -5,14 +5,14 @@ import querystring = require('querystring');
 import util = require("util");
 
 import tl = require("azure-pipelines-task-lib/task");
-import httpClient = require('vso-node-api/HttpClient');
+import { HttpClient } from 'typed-rest-client/HttpClient';
 import ssh = require('ssh2');
 import shell = require('shelljs');
 import SftpClient = require('ssh2-sftp-client');
 import Q = require("q");
 var uuid = require('uuid/v4');
 
-var httpObj = new httpClient.HttpCallbackClient(tl.getVariable("AZURE_HTTP_USER_AGENT")!);
+var httpObj = new HttpClient(tl.getVariable("AZURE_HTTP_USER_AGENT")!);
 const Ssh2Client = ssh.Client;
 
 export function _writeLine(str: string): void {
@@ -77,7 +77,8 @@ export async function copyFileToRemoteMachine(src: string, dest: string, sftpCon
         }); // ignore logout errors - since there could be spontaneous ECONNRESET errors after logout; see: https://github.com/mscdex/node-imap/issues/695
         await sftpClient.end();
     } catch (err) {
-        tl.debug(`Failed to close SFTP client: ${err}`);
+        tl.debug(`Failed to close SFTP client: ${err}`);
+
     }
 
     return defer.promise;
@@ -219,19 +220,17 @@ export async function beginRequest<T>(request: WebRequest): Promise<WebResponse<
     return await beginRequestInternal(request);
 }
 
-function beginRequestInternal<T>(request: WebRequest): Promise<WebResponse<T>> {
+async function beginRequestInternal<T>(request: WebRequest): Promise<WebResponse<T>> {
     tl.debug(util.format("[%s]%s", request.method, request.uri));
 
-    return new Promise<WebResponse<T>>((resolve, reject) => {
-        httpObj.send(request.method, request.uri, request.body, request.headers, (error, response, body) => {
-            if (error) {
-                reject(error);
-            } else {
-                var httpResponse = toWebResponse<T>(response, body);
-                resolve(httpResponse);
-            }
-        });
-    });
+    try {
+        const response = await httpObj.request(request.method, request.uri, request.body, request.headers);
+        const body = await response.readBody();
+        var httpResponse = toWebResponse<T>(response.message, body);
+        return httpResponse;
+    } catch (error) {
+        throw error;
+    }
 }
 
 export function getTemporaryInventoryFilePath(): string {

--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
@@ -73,7 +73,7 @@ export async function copyFileToRemoteMachine(src: string, dest: string, sftpCon
 
     try {
         sftpClient.on('error', (err) => {
-            tl.debug(`sftpClient: Ignoring error diconnecting: ${err}`);
+            tl.debug(`sftpClient: Ignoring error disconnecting: ${err}`);
         }); // ignore logout errors - since there could be spontaneous ECONNRESET errors after logout; see: https://github.com/mscdex/node-imap/issues/695
         await sftpClient.end();
     } catch (err) {

--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
@@ -10,7 +10,7 @@ import ssh = require('ssh2');
 import shell = require('shelljs');
 import SftpClient = require('ssh2-sftp-client');
 import Q = require("q");
-var uuid = require('uuid/v4');
+import uuid = require('uuid');
 
 var httpObj = new HttpClient(tl.getVariable("AZURE_HTTP_USER_AGENT")!);
 const Ssh2Client = ssh.Client;
@@ -234,7 +234,7 @@ async function beginRequestInternal<T>(request: WebRequest): Promise<WebResponse
 }
 
 export function getTemporaryInventoryFilePath(): string {
-    return '/tmp/' + uuid() + 'inventory.ini';
+    return '/tmp/' + uuid.v4() + 'inventory.ini';
 }
 
 function toWebResponse<T>(response: http.IncomingMessage | undefined, body: string | undefined): WebResponse<T> {

--- a/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
@@ -9,16 +9,18 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "azure-pipelines-task-lib": "5.2.8",
+        "azure-devops-node-api": "^15.1.2",
+        "azure-pipelines-task-lib": "^5.278.0",
         "shell-quote": "^1.9.0",
         "shelljs": "^0.10.0",
         "ssh2": "1.4.0",
         "ssh2-sftp-client": "^8.1.0",
-        "uuid": "^3.3.2",
-        "vso-node-api": "6.0.1-preview"
+        "typed-rest-client": "^2.3.0",
+        "uuid": "^14.0.1"
       },
       "devDependencies": {
         "@types/q": "^1.5.8",
+        "@types/shell-quote": "^1.7.5",
         "@types/ssh2-sftp-client": "^9.0.6"
       }
     },
@@ -74,6 +76,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/shell-quote": {
+      "version": "1.7.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/shell-quote/-/shell-quote-1.7.5.tgz",
+      "integrity": "sha1-bbRwR0LTB81tYE4STjrWzV7ZQ/M=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/ssh2": {
       "version": "1.15.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/ssh2/-/ssh2-1.15.5.tgz",
@@ -124,19 +133,47 @@
         "safer-buffer": "~2.1.0"
       }
     },
-    "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
-      "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
+    "node_modules/azure-devops-node-api": {
+      "version": "15.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-15.1.2.tgz",
+      "integrity": "sha1-XboWjAyR+xOgQOIZlRBBULjAOHU=",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "tunnel": "0.0.6",
+        "typed-rest-client": "2.1.0"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/azure-devops-node-api/node_modules/typed-rest-client": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/azure-pipelines-task-lib": {
+      "version": "5.278.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.278.0.tgz",
+      "integrity": "sha1-ZdWwBh1+xNDN4Q5u9sIcP0mUXFQ=",
+      "license": "MIT",
+      "dependencies": {
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/balanced-match": {
@@ -189,6 +226,35 @@
       "optional": true,
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha1-S1QowiK+mF15w9gmV0edvgtZstY=",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha1-I43pNdKippKSjFOMfM+pEGf9Bio=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/concat-map": {
@@ -256,11 +322,65 @@
         }
       }
     },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha1-HTf1dm87v/Tuljjocah2jBc7gdo=",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha1-165mfh3INIL4tw/Q9u78UNow9Yo=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/err-code": {
       "version": "2.0.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha1-I8Lzt1b/38YI0w4nyalBAkgH5/k=",
       "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha1-mD6y+aZyTpMD9hrd8BHHLgngsPo=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -342,6 +462,52 @@
         }
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha1-dD8OO2lkqTpUke0b/6rgVNf5jQE=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha1-FQs/J0OGnvPoUewMSdFbHRTQDuE=",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
@@ -364,6 +530,42 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha1-ifVrghe9vIgCvSmd9tfxCB1+UaE=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha1-/JxqeDoISVHQuXH+EBjegTcHozg=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -442,6 +644,21 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "license": "ISC"
     },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU=",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha1-oN10voHiqlwvJ+Zc4oNgXuTit/k=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -500,6 +717,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
@@ -547,6 +770,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha1-g3UmXiG8IND6WCwi4bE0hdbgAhM=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/onetime": {
@@ -607,6 +842,22 @@
       "engines": {
         "node": ">=0.6.0",
         "teleport": ">=0.2.0"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha1-doUhMqWO1cfA72fkRBubtdYGGzs=",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -775,6 +1026,78 @@
         "node": ">=18"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha1-6gLGLgXcS+pn1EQvD7ce4ZL44Ks=",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha1-wuC1oUpUCuvuO7xsP4ZmzJtQkSc=",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha1-1rtrN5Asb+9RdOX1M/q0xzKib0I=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha1-Ed2hnVNo5Azp7CvcH7DsvAeQ7Oo=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -883,9 +1206,9 @@
       }
     },
     "node_modules/tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
+      "version": "0.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw=",
       "license": "MIT",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -896,6 +1219,22 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "license": "Unlicense"
+    },
+    "node_modules/typed-rest-client": {
+      "version": "2.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.3.0.tgz",
+      "integrity": "sha1-YBK4gubNvRsOC2BAf31OP6VJih0=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.14.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.13.8"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
     },
     "node_modules/typedarray": {
       "version": "0.0.6",
@@ -929,24 +1268,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "14.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha1-ill1s+A4kCv9FpoQtSAvXsDPP68=",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
-    "node_modules/vso-node-api": {
-      "version": "6.0.1-preview",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/vso-node-api/-/vso-node-api-6.0.1-preview.tgz",
-      "integrity": "sha1-RBprv5s8aNpiTbAeo1y6jwpMLKs=",
-      "license": "MIT",
-      "dependencies": {
-        "q": "^1.0.1",
-        "tunnel": "0.0.4",
-        "underscore": "^1.8.3"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/which": {

--- a/Extensions/Ansible/Src/Tasks/Ansible/package.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package.json
@@ -6,13 +6,14 @@
   "author": "Microsoft",
   "license": "ISC",
   "dependencies": {
-    "azure-pipelines-task-lib": "5.2.8",
+    "azure-devops-node-api": "^15.1.2",
+    "azure-pipelines-task-lib": "^5.278.0",
     "shell-quote": "^1.9.0",
     "shelljs": "^0.10.0",
     "ssh2": "1.4.0",
     "ssh2-sftp-client": "^8.1.0",
-    "uuid": "^3.3.2",
-    "vso-node-api": "6.0.1-preview"
+    "typed-rest-client": "^2.3.0",
+    "uuid": "^14.0.1"
   },
   "overrides": {
     "adm-zip": "0.6.0"
@@ -22,6 +23,7 @@
   },
   "devDependencies": {
     "@types/q": "^1.5.8",
+    "@types/shell-quote": "^1.7.5",
     "@types/ssh2-sftp-client": "^9.0.6"
   }
 }

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.10",
+  "version": "0.279.11",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.9",
+  "version": "0.279.10",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",


### PR DESCRIPTION
**Description**:
- Removed the `vso-node-api` package and replaced its `HttpClient` usage in `ansibleUtils.ts` with `typed-rest-client`'s `HttpClient`, rewriting `beginRequestInternal` to use async/await (`request()` + `readBody()`) instead of the old callback-based `send()`. This code path backs all Ansible Tower job template/status/event requests made from `ansibleTowerInterface.ts`.
- Added `typed-rest-client` (`^2.3.0`) and `azure-devops-node-api` (`^15.1.2`) as new dependencies.
- Updated `azure-pipelines-task-lib` to `^5.278.0` and upgraded `uuid` from `^3.3.2` to `^14.0.1`.
- Added `@types/shell-quote` (`^1.7.5`) as a dev dependency and removed the now-unneeded `// @ts-ignore` comment above the `shell-quote` import in `ansibleCommandLineInterface.ts`.
- Enabled `engine-strict=true` in `.npmrc`.
- Bumped the extension version in `vss-extension.json` from `0.279.9` to `0.279.10`.

**Documentation changes required:** N

**Added unit tests:** N - no new tests were added; the existing Ansible Tower test suite (`Tests/Tasks/Ansible/testTower*.ts`) continues to exercise `beginRequest` via the existing mocks in `mockAnsibleUtils.ts`.

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - extension version bumped in `vss-extension.json` (`0.279.9` → `0.279.10`); note `task.json` version was left unchanged.
- [x] Checked that applied changes work as expected.
