### PR TITLE
Users/v nairin/additional l0tests teamcity ext

### DIFF
--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.14",
+  "version": "15.279.16",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.17",
+  "version": "15.279.20",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.16",
+  "version": "15.279.17",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Tests/Tasks/DownloadTeamCityArtifacts/_suite.ts
+++ b/Extensions/TeamCity/Tests/Tasks/DownloadTeamCityArtifacts/_suite.ts
@@ -87,6 +87,24 @@ describe('DownloadTeamCityArtifacts Suite', function () {
             'should propagate the parallellimit variable into downloaderOptions');
     });
 
+    it('succeeds when itemPattern matches nothing (zero artifacts)', async function () {
+        const runner = newRunner('successItemPatternMatchesNothing');
+        await runAndDump(runner, NODE_VERSION);
+        if (!runner.succeeded) fail(runner, 'expected task to succeed even when pattern matches nothing');
+
+        assert(runner.stdOutContained('[mock-artifact-engine] processItems itemPattern=nonexistent/**'),
+            'should pass the no-match pattern through to processItems unchanged');
+    });
+
+    it('collapses double-slash when endpoint URL has trailing slash', async function () {
+        const runner = newRunner('successTrailingSlashUrl');
+        await runAndDump(runner, NODE_VERSION);
+        if (!runner.succeeded) fail(runner, 'expected task to succeed with trailing-slash endpoint');
+
+        assert(runner.stdOutContained('[mock-web-provider] ctor url=https://teamcity.example.com/httpAuth/app/rest/builds/id:42/artifacts/children/'),
+            'should collapse the double slash — URL must NOT contain //httpAuth');
+    });
+
     // -- Failure scenarios ------------------------------------------------------
 
     it('fails when TeamCity returns 404 build-not-found', async function () {
@@ -117,6 +135,21 @@ describe('DownloadTeamCityArtifacts Suite', function () {
             'should mark the task Failed (not crash or complete Succeeded)');
         assert(runner.stdOutContained('401 - Unauthorized'),
             'should propagate the actual 401 error message from artifact-engine, not a different failure path');
+    });
+
+    it('fails when TeamCity returns 500 internal server error', async function () {
+        const runner = newRunner('fail500ServerError');
+        await runAndDump(runner, NODE_VERSION);
+        if (runner.succeeded) fail(runner, 'expected task to fail with 500');
+
+        assert(runner.stdOutContained('[mock-artifact-engine] processItems'),
+            'should invoke processItems before failing');
+        assert(runner.stdOutContained('##vso[task.issue type=error'),
+            'should surface the backend error via tl.error / task.issue');
+        assert(runner.stdOutContained('##vso[task.complete result=Failed'),
+            'should mark the task Failed');
+        assert(runner.stdOutContained('500 - Internal Server Error'),
+            'should propagate the actual 500 error message from artifact-engine');
     });
 
     it('fails when required "connection" input is missing', async function () {

--- a/Extensions/TeamCity/Tests/Tasks/DownloadTeamCityArtifacts/_suite.ts
+++ b/Extensions/TeamCity/Tests/Tasks/DownloadTeamCityArtifacts/_suite.ts
@@ -27,11 +27,11 @@ function fail(runner: any, msg: string): never {
     throw new Error(msg);
 }
 
-// TeamCity task.json declares only "Node" (legacy handler). All modern agents run
-// Node 20+ per the repo engines requirement.
-const NODE_VERSION = 20;
+// TeamCity task.json declares Node16, Node20, and Node24 execution handlers.
+const NODE_VERSIONS = [16, 20, 24];
 
-describe('DownloadTeamCityArtifacts Suite', function () {
+NODE_VERSIONS.forEach(function (NODE_VERSION) {
+describe(`DownloadTeamCityArtifacts Suite (Node ${NODE_VERSION})`, function () {
     this.timeout(120000);
 
     // -- Success scenarios ------------------------------------------------------
@@ -94,6 +94,8 @@ describe('DownloadTeamCityArtifacts Suite', function () {
 
         assert(runner.stdOutContained('[mock-artifact-engine] processItems itemPattern=nonexistent/**'),
             'should pass the no-match pattern through to processItems unchanged');
+        assert(runner.stdOutContained('[mock-artifact-engine] processItems downloadedCount=0'),
+            'should download zero items when pattern matches nothing in the available item list');
     });
 
     it('collapses double-slash when endpoint URL has trailing slash', async function () {
@@ -185,3 +187,4 @@ describe('DownloadTeamCityArtifacts Suite', function () {
             'should mark the task Failed');
     });
 });
+}); // end NODE_VERSIONS.forEach

--- a/Extensions/TeamCity/Tests/Tasks/DownloadTeamCityArtifacts/fail500ServerError.ts
+++ b/Extensions/TeamCity/Tests/Tasks/DownloadTeamCityArtifacts/fail500ServerError.ts
@@ -1,0 +1,16 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs } from './mockHelpers';
+
+const taskPath = path.join(__dirname, '../../../Src/Tasks/DownloadTeamCityArtifacts/download.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth();
+registerAllMocks(tr, {
+    downloadFailStatusCode: 500,
+    downloadFailMessage: 'Failed request: (statusCode) 500 - Internal Server Error'
+});
+
+tr.run();

--- a/Extensions/TeamCity/Tests/Tasks/DownloadTeamCityArtifacts/mockHelpers.ts
+++ b/Extensions/TeamCity/Tests/Tasks/DownloadTeamCityArtifacts/mockHelpers.ts
@@ -20,6 +20,9 @@ export interface ScenarioOptions {
     downloadFailStatusCode?: number;
     // Custom error message on the rejection. Defaults to "Failed request".
     downloadFailMessage?: string;
+    // Fake artifact list available on the server. When provided, processItems filters
+    // this list against itemPattern and logs the downloadedCount.
+    availableItems?: string[];
 }
 
 // -- Input helpers -------------------------------------------------------------
@@ -80,6 +83,27 @@ function registerArtifactEngineMocks(tr: tmrm.TaskMockRunner, options: ScenarioO
         public parallelProcessingLimit: number = 4;
     }
 
+    // Simple glob matcher for test patterns (handles **, *, and prefix/suffix matching).
+    function simpleGlobMatch(pattern: string, item: string): boolean {
+        if (pattern === '**') return true;
+        // e.g. "nonexistent/**" → prefix match
+        if (pattern.endsWith('/**')) {
+            const prefix = pattern.slice(0, -3);
+            return item.startsWith(prefix + '/') || item === prefix;
+        }
+        // e.g. "**/*.zip" → suffix match
+        if (pattern.startsWith('**/')) {
+            const suffix = pattern.slice(3);
+            if (suffix.startsWith('*')) {
+                // e.g. "**/*.zip" → extension match
+                const ext = suffix.slice(1);
+                return item.endsWith(ext);
+            }
+            return item.endsWith(suffix) || item === suffix;
+        }
+        return item === pattern;
+    }
+
     class MockArtifactEngine {
         public processItems(webProvider: any, fsProvider: any, opts: MockArtifactEngineOptions): Promise<void> {
             console.log('[mock-artifact-engine] processItems itemPattern=' + opts.itemPattern);
@@ -87,6 +111,13 @@ function registerArtifactEngineMocks(tr: tmrm.TaskMockRunner, options: ScenarioO
             console.log('[mock-artifact-engine] processItems verbose=' + opts.verbose);
             console.log('[mock-artifact-engine] webProviderUrl=' + (webProvider && webProvider.url));
             console.log('[mock-artifact-engine] fsProviderPath=' + (fsProvider && fsProvider.rootPath));
+
+            if (options.availableItems) {
+                const matched = options.availableItems.filter(function (item) {
+                    return simpleGlobMatch(opts.itemPattern, item);
+                });
+                console.log('[mock-artifact-engine] processItems downloadedCount=' + matched.length);
+            }
 
             if (options.downloadFailStatusCode) {
                 const err: any = new Error(options.downloadFailMessage || 'Failed request');

--- a/Extensions/TeamCity/Tests/Tasks/DownloadTeamCityArtifacts/successItemPatternMatchesNothing.ts
+++ b/Extensions/TeamCity/Tests/Tasks/DownloadTeamCityArtifacts/successItemPatternMatchesNothing.ts
@@ -1,0 +1,14 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { registerAllMocks, setEndpointAuth, setRequiredInputs } from './mockHelpers';
+
+const taskPath = path.join(__dirname, '../../../Src/Tasks/DownloadTeamCityArtifacts/download.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+// Pattern that matches nothing — task should still succeed.
+setRequiredInputs(tr, { itemPattern: 'nonexistent/**' });
+setEndpointAuth();
+registerAllMocks(tr);
+
+tr.run();

--- a/Extensions/TeamCity/Tests/Tasks/DownloadTeamCityArtifacts/successItemPatternMatchesNothing.ts
+++ b/Extensions/TeamCity/Tests/Tasks/DownloadTeamCityArtifacts/successItemPatternMatchesNothing.ts
@@ -9,6 +9,6 @@ const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 // Pattern that matches nothing — task should still succeed.
 setRequiredInputs(tr, { itemPattern: 'nonexistent/**' });
 setEndpointAuth();
-registerAllMocks(tr);
+registerAllMocks(tr, { availableItems: ['src/main.ts', 'lib/utils.js', 'docs/readme.md'] });
 
 tr.run();

--- a/Extensions/TeamCity/Tests/Tasks/DownloadTeamCityArtifacts/successTrailingSlashUrl.ts
+++ b/Extensions/TeamCity/Tests/Tasks/DownloadTeamCityArtifacts/successTrailingSlashUrl.ts
@@ -1,0 +1,17 @@
+import path = require('path');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+
+import { CONNECTION_ID, registerAllMocks, setEndpointAuth, setRequiredInputs } from './mockHelpers';
+
+const taskPath = path.join(__dirname, '../../../Src/Tasks/DownloadTeamCityArtifacts/download.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+setRequiredInputs(tr);
+setEndpointAuth();
+
+// Override the endpoint URL to include a trailing slash
+process.env['ENDPOINT_URL_' + CONNECTION_ID] = 'https://teamcity.example.com/';
+
+registerAllMocks(tr);
+
+tr.run();


### PR DESCRIPTION
Additional L0 tests for TeamCity DownloadTeamCityArtifacts task

Adds 3 new L0 test scenarios for the DownloadTeamCityArtifacts task, requested during review of [#1454](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html):

1. successItemPatternMatchesNothing — Task succeeds when itemPattern (nonexistent/**) matches zero artifacts. Mock now accepts an [availableItems](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) list, filters against [itemPattern](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and asserts downloadedCount=0.
2. fail500ServerError — Generic 500 server error propagates cleanly. Asserts ##vso[task.issue type=error], ##vso[task.complete result=Failed], and "500 - Internal Server Error" message.
3. successTrailingSlashUrl — When endpoint URL has a trailing slash (https://teamcity.example.com/), the regex in download.ts collapses the double-slash so the final URL is .../httpAuth/... (not ...//httpAuth/...).

Files changed:

- New: [successItemPatternMatchesNothing.ts](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

- New: [fail500ServerError.ts](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

- New: [successTrailingSlashUrl.ts](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

- Modified: [_suite.ts](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — added 3 [it()](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) blocks, tests now run on Node 16/20/24 via [forEach](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) loop

- Modified: [mockHelpers.ts](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — added [availableItems](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) option to [ScenarioOptions](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with [simpleGlobMatch](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) filtering and downloadedCount logging

- Modified: [vss-extension.json](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — version bump to 15.279.20

Testing:

All 39 L0 tests passing (13 scenarios × 3 Node versions: 16, 20, 24).