### PR TITLE
Add type definitions for shell-quote to package.json and package-lock.json

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleCommandLineInterface.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleCommandLineInterface.ts
@@ -1,5 +1,4 @@
 import tl = require("azure-pipelines-task-lib/task");
-// @ts-ignore there is no type definition for shell-quote
 import { quote } from 'shell-quote';
 
 import { ansibleInterface } from './ansibleInterface';

--- a/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@types/q": "^1.5.8",
+        "@types/shell-quote": "^1.7.5",
         "@types/ssh2-sftp-client": "^9.0.6"
       }
     },
@@ -71,6 +72,13 @@
       "version": "1.5.8",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/q/-/q-1.5.8.tgz",
       "integrity": "sha1-lfbGoI8q2Gi6Iw6tHS1/e+PbODc=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/shell-quote": {
+      "version": "1.7.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/shell-quote/-/shell-quote-1.7.5.tgz",
+      "integrity": "sha1-bbRwR0LTB81tYE4STjrWzV7ZQ/M=",
       "dev": true,
       "license": "MIT"
     },

--- a/Extensions/Ansible/Src/Tasks/Ansible/package.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@types/q": "^1.5.8",
+    "@types/shell-quote": "^1.7.5",
     "@types/ssh2-sftp-client": "^9.0.6"
   }
 }

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 279,
-        "Patch": 7
+        "Patch": 13
     },
     "demands": [],
     "minimumAgentVersion": "2.206.1",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.12",
+  "version": "0.279.13",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",


### PR DESCRIPTION
**Description**:
Add `@types/shell-quote` as a dev dependency so the `shell-quote` import in `ansibleCommandLineInterface.ts` has proper TypeScript type definitions, removing the need for the `@ts-ignore` comment.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.
- [ ] Checked that applied changes work as expected.
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>