### PR TITLE
Remove deprecated uuid dependency from package.json and package-lock.json

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
@@ -10,7 +10,7 @@ import ssh = require('ssh2');
 import shell = require('shelljs');
 import SftpClient = require('ssh2-sftp-client');
 import Q = require("q");
-var uuid = require('uuid/v4');
+import crypto = require('crypto');
 
 var httpObj = new httpClient.HttpCallbackClient(tl.getVariable("AZURE_HTTP_USER_AGENT")!);
 const Ssh2Client = ssh.Client;
@@ -77,7 +77,8 @@ export async function copyFileToRemoteMachine(src: string, dest: string, sftpCon
         }); // ignore logout errors - since there could be spontaneous ECONNRESET errors after logout; see: https://github.com/mscdex/node-imap/issues/695
         await sftpClient.end();
     } catch (err) {
-        tl.debug(`Failed to close SFTP client: ${err}`);
+        tl.debug(`Failed to close SFTP client: ${err}`);
+
     }
 
     return defer.promise;
@@ -235,7 +236,7 @@ function beginRequestInternal<T>(request: WebRequest): Promise<WebResponse<T>> {
 }
 
 export function getTemporaryInventoryFilePath(): string {
-    return '/tmp/' + uuid() + 'inventory.ini';
+    return '/tmp/' + crypto.randomUUID() + 'inventory.ini';
 }
 
 function toWebResponse<T>(response: http.IncomingMessage | undefined, body: string | undefined): WebResponse<T> {

--- a/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
@@ -14,7 +14,6 @@
         "shelljs": "^0.10.0",
         "ssh2": "1.4.0",
         "ssh2-sftp-client": "^8.1.0",
-        "uuid": "^3.3.2",
         "vso-node-api": "6.0.1-preview"
       },
       "devDependencies": {
@@ -934,16 +933,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     },
     "node_modules/vso-node-api": {
       "version": "6.0.1-preview",

--- a/Extensions/Ansible/Src/Tasks/Ansible/package.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package.json
@@ -11,7 +11,6 @@
     "shelljs": "^0.10.0",
     "ssh2": "1.4.0",
     "ssh2-sftp-client": "^8.1.0",
-    "uuid": "^3.3.2",
     "vso-node-api": "6.0.1-preview"
   },
   "scripts": {


### PR DESCRIPTION
**Description**: Remove the deprecated `uuid` package from `package.json` and `package-lock.json`. The dependency is no longer used in `ansibleUtils.ts`.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:

- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.

- [ ] Checked that applied changes work as expected.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>