### PR TITLE
Remove shelljs dependency and refactor file existence checks to use Node.js fs module

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleRemoteMachineInterface.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleRemoteMachineInterface.ts
@@ -37,7 +37,9 @@ export class ansibleRemoteMachineInterface extends ansibleCommandLineInterface {
             throw tl.loc('PlaybookRootNotDirectory', playbookRoot);
         }
 
-        if (!ansibleUtils.testIfFileExist(path.join(playbookRoot, playbookFile))) {
+        const playbookFilePath = path.join(playbookRoot, playbookFile);
+
+        if (!ansibleUtils.testIfFileExist(playbookFilePath)) {
             throw tl.loc('PlaybookNotPresent', playbookFile, playbookRoot);
         }
 

--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
@@ -187,11 +187,11 @@ export function runCommandOnSameMachine(command: string, options: RemoteCommandO
 }
 
 export function testIfFileExist(filePath: string): boolean {
-    return fs.existsSync(filePath) && fs.lstatSync(filePath).isFile();
+    return fs.existsSync(filePath) && fs.statSync(filePath).isFile();
 }
 
 export function testIfDirectoryExist(directoryPath: string): boolean {
-    return fs.existsSync(directoryPath) && fs.lstatSync(directoryPath).isDirectory();
+    return fs.existsSync(directoryPath) && fs.statSync(directoryPath).isDirectory();
 }
 
 export function getAgentPlatform(): string {
@@ -199,7 +199,7 @@ export function getAgentPlatform(): string {
 }
 
 export function getShellWhich(moduleName: string): string | null {
-    return tl.which(moduleName, true);
+    return tl.which(moduleName, false);
 }
 
 export class WebRequest {

--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
@@ -1,5 +1,6 @@
-const fs = require('fs');
-var os = require('os');
+import cp = require('child_process');
+import fs = require('fs');
+import os = require('os');
 import http = require('http');
 import querystring = require('querystring');
 import util = require("util");
@@ -7,13 +8,16 @@ import util = require("util");
 import tl = require("azure-pipelines-task-lib/task");
 import httpClient = require('vso-node-api/HttpClient');
 import ssh = require('ssh2');
-import shell = require('shelljs');
 import SftpClient = require('ssh2-sftp-client');
 import Q = require("q");
 import crypto = require('crypto');
 
 var httpObj = new httpClient.HttpCallbackClient(tl.getVariable("AZURE_HTTP_USER_AGENT")!);
 const Ssh2Client = ssh.Client;
+
+const CP_EXEC_OPTIONS: cp.ExecOptions = {
+    maxBuffer: 20 * 1024 * 1024
+};
 
 export function _writeLine(str: string): void {
     process.stdout.write(str + os.EOL);
@@ -162,10 +166,14 @@ export function runCommandOnSameMachine(command: string, options: RemoteCommandO
     var cmdToRun = command;
     tl.debug('cmdToRun = ' + cmdToRun);
 
-    shell.exec(cmdToRun, (err, _stdout, stderr) => {
+    cp.exec(cmdToRun, CP_EXEC_OPTIONS, (err, stdout, stderr) => {
+        if (stdout) {
+            tl.debug(stdout);
+        }
+
         if (err) {
-            tl.debug('code = ' + err);
-            defer.reject(tl.loc('RemoteCmdNonZeroExitCode', cmdToRun, err))
+            tl.debug(`code = ${err.code}`);
+            defer.reject(tl.loc('RemoteCmdNonZeroExitCode', cmdToRun, err.code))
         } else {
             tl.debug('code = 0');
             if (stderr != '' && options.failOnStdErr === true) {
@@ -179,11 +187,11 @@ export function runCommandOnSameMachine(command: string, options: RemoteCommandO
 }
 
 export function testIfFileExist(filePath: string): boolean {
-    return shell.test('-f', filePath)
+    return fs.existsSync(filePath) && fs.lstatSync(filePath).isFile();
 }
 
 export function testIfDirectoryExist(directoryPath: string): boolean {
-    return shell.test('-d', directoryPath)
+    return fs.existsSync(directoryPath) && fs.lstatSync(directoryPath).isDirectory();
 }
 
 export function getAgentPlatform(): string {
@@ -191,7 +199,7 @@ export function getAgentPlatform(): string {
 }
 
 export function getShellWhich(moduleName: string): string | null {
-    return shell.which(moduleName);
+    return tl.which(moduleName, true);
 }
 
 export class WebRequest {

--- a/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "azure-pipelines-task-lib": "5.278.0",
         "shell-quote": "^1.9.0",
-        "shelljs": "^0.10.0",
         "ssh2": "1.4.0",
         "ssh2-sftp-client": "^8.1.0",
         "vso-node-api": "6.0.1-preview"

--- a/Extensions/Ansible/Src/Tasks/Ansible/package.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "azure-pipelines-task-lib": "5.278.0",
     "shell-quote": "^1.9.0",
-    "shelljs": "^0.10.0",
     "ssh2": "1.4.0",
     "ssh2-sftp-client": "^8.1.0",
     "vso-node-api": "6.0.1-preview"


### PR DESCRIPTION
**Description**: Remove the `shelljs` dependency and replace its usages with Node.js built-ins:
- `shell.exec` → `child_process.exec`
- `shell.test('-f')` / `shell.test('-d')` → `fs.existsSync` + `fs.lstatSync`
- `shell.which` → `tl.which`

Also converts `require()` calls for `fs` and `os` to TypeScript-style `import =` declarations.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:

- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.

- [ ] Checked that applied changes work as expected.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>