### PR TITLE
Add support for Node.js 24 in task.json

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -332,6 +332,10 @@
         "Node20_1": {
             "target": "main.js",
             "argumentFormat": ""
+        },
+        "Node24": {
+            "target": "main.js",
+            "argumentFormat": ""
         }
     },
     "messages": {


### PR DESCRIPTION
**Description**: Add `Node24` executor entry to `task.json` so the Ansible task can run on the Node.js 24 agent.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:

- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.

- [ ] Checked that applied changes work as expected.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>