### PR TITLE
Add exec options to runCommandOnSameMachine

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
@@ -159,7 +159,7 @@ export function runCommandOnSameMachine(command: string, options: RemoteCommandO
         const cmdToRun = command;
         tl.debug('cmdToRun = ' + cmdToRun);
 
-        cp.exec(cmdToRun, (err, _stdout, stderr) => {
+        cp.exec(cmdToRun, CP_EXEC_OPTIONS, (err, _stdout, stderr) => {
             if (err) {
                 tl.debug(`code = ${err.code}`);
                 reject(tl.loc('RemoteCmdNonZeroExitCode', cmdToRun, err.code))

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 279,
-        "Patch": 14
+        "Patch": 15
     },
     "demands": [],
     "minimumAgentVersion": "2.206.1",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.14",
+  "version": "0.279.15",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",


### PR DESCRIPTION
**Description**: This PR adds missed exec options to `runCommandOnSameMachine`, however it was added in the [commit](https://github.com/microsoft/azure-pipelines-extensions/pull/1485/changes/ba80915ba5caa3855f268692565b58c4753c2abf#diff-7b41a2d599c92f19bb1ec420c4978e8184f73ceb98e2b4ef7c6842fcc4de3089R169)

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [ ] Checked that applied changes work as expected.
