### PR TITLE
Fix Ansible task output streaming and large-output failures

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
@@ -183,7 +183,9 @@ export function runCommandOnSameMachine(command: string, options: RemoteCommandO
             settled = true;
             tl.debug('code = ' + code + ', signal = ' + signal);
 
-            if (code && code != 0) {
+            if (signal !== null && signal !== undefined) {
+                reject(tl.loc('RemoteCmdExecutionErr'));
+            } else if (code && code != 0) {
                 reject(tl.loc('RemoteCmdNonZeroExitCode', cmdToRun, code));
             } else if (stdErrWritten === true && options.failOnStdErr === true) {
                 reject(tl.loc('RemoteCmdExecutionErr'));

--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleUtils.ts
@@ -14,10 +14,6 @@ import * as httpClient from 'typed-rest-client/HttpClient';
 var httpObj = new httpClient.HttpClient(tl.getVariable("AZURE_HTTP_USER_AGENT")!);
 const Ssh2Client = ssh.Client;
 
-const CP_EXEC_OPTIONS: cp.ExecOptions = {
-    maxBuffer: 20 * 1024 * 1024
-};
-
 export function _writeLine(str: string): void {
     process.stdout.write(str + os.EOL);
 }
@@ -159,17 +155,40 @@ export function runCommandOnSameMachine(command: string, options: RemoteCommandO
         const cmdToRun = command;
         tl.debug('cmdToRun = ' + cmdToRun);
 
-        cp.exec(cmdToRun, CP_EXEC_OPTIONS, (err, _stdout, stderr) => {
-            if (err) {
-                tl.debug(`code = ${err.code}`);
-                reject(tl.loc('RemoteCmdNonZeroExitCode', cmdToRun, err.code))
+        let stdErrWritten: boolean = false;
+        let settled: boolean = false;
+        const child = cp.spawn(cmdToRun, { shell: true });
+
+        child.stdout.on('data', (data) => {
+            process.stdout.write(data);
+        });
+
+        child.stderr.on('data', (data) => {
+            stdErrWritten = true;
+            process.stderr.write(data);
+        });
+
+        child.on('error', (err) => {
+            if (!settled) {
+                settled = true;
+                reject(tl.loc('RemoteCmdExecutionErr', err));
+            }
+        });
+
+        child.on('close', (code, signal) => {
+            if (settled) {
+                return;
+            }
+
+            settled = true;
+            tl.debug('code = ' + code + ', signal = ' + signal);
+
+            if (code && code != 0) {
+                reject(tl.loc('RemoteCmdNonZeroExitCode', cmdToRun, code));
+            } else if (stdErrWritten === true && options.failOnStdErr === true) {
+                reject(tl.loc('RemoteCmdExecutionErr'));
             } else {
-                tl.debug('code = 0');
-                if (stderr != '' && options.failOnStdErr === true) {
-                    reject(tl.loc('RemoteCmdExecutionErr'));
-                } else {
-                    resolve('0');
-                }
+                resolve('0');
             }
         });
     });

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 279,
-        "Patch": 16
+        "Patch": 17
     },
     "demands": [],
     "minimumAgentVersion": "2.206.1",

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 279,
-        "Patch": 15
+        "Patch": 16
     },
     "demands": [],
     "minimumAgentVersion": "2.206.1",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.15",
+  "version": "0.279.16",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.16",
+  "version": "0.279.17",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Tests/Tasks/Ansible/_suite.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/_suite.ts
@@ -1,6 +1,7 @@
 import assert = require('assert');
 import childProcess = require('child_process');
 import fs = require('fs');
+import os = require('os');
 import path = require('path');
 import { TestGuid } from './mockAnsibleUtils';
 
@@ -69,6 +70,53 @@ function outputContains(runner: any, value: string): boolean {
     return stdout.indexOf(value) >= 0 || stderr.indexOf(value) >= 0;
 }
 
+function quoteShellArg(value: string): string {
+    if (process.platform === 'win32') {
+        return '"' + value.replace(/"/g, '\\"') + '"';
+    }
+
+    return "'" + value.replace(/'/g, "'\\''") + "'";
+}
+
+async function runRealAgentCommand(scriptContents: string): Promise<{ stdout: string; stderr: string; }> {
+    const ansibleUtils = require(path.join(taskFolderPath, 'ansibleUtils.js'));
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ansible-agent-command-'));
+    const scriptPath = path.join(tempDir, 'script.js');
+    fs.writeFileSync(scriptPath, scriptContents, 'utf8');
+
+    const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+    const originalStderrWrite = process.stderr.write.bind(process.stderr);
+    let stdout = '';
+    let stderr = '';
+
+    (process.stdout as any).write = (chunk: any, encoding?: any, callback?: any): boolean => {
+        stdout += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk);
+        const writeCallback = typeof encoding === 'function' ? encoding : callback;
+        if (writeCallback) {
+            writeCallback();
+        }
+        return true;
+    };
+
+    (process.stderr as any).write = (chunk: any, encoding?: any, callback?: any): boolean => {
+        stderr += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk);
+        const writeCallback = typeof encoding === 'function' ? encoding : callback;
+        if (writeCallback) {
+            writeCallback();
+        }
+        return true;
+    };
+
+    try {
+        await ansibleUtils.runCommandOnSameMachine(quoteShellArg(process.execPath) + ' ' + quoteShellArg(scriptPath), { failOnStdErr: false });
+        return { stdout, stderr };
+    } finally {
+        (process.stdout as any).write = originalStdoutWrite;
+        (process.stderr as any).write = originalStderrWrite;
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+}
+
 function ensureTaskMainJs(): void {
     if (fs.existsSync(taskMainPath)) {
         return;
@@ -101,6 +149,23 @@ describe('Ansible Suite', function () {
 
     before(function () {
         ensureTaskMainJs();
+    });
+
+    it('streams real agent command stdout to normal task output', async function () {
+        const result = await runRealAgentCommand("process.stdout.write('visible ansible output');");
+
+        assert(result.stdout.indexOf('visible ansible output') >= 0, 'should stream stdout to normal task output');
+    });
+
+    it('streams real agent command output beyond the old exec buffer limit', async function () {
+        this.timeout(60000);
+
+        const outputSize = 21 * 1024 * 1024;
+        const marker = 'large-output-complete';
+        const result = await runRealAgentCommand("process.stdout.write('x'.repeat(" + outputSize + ")); process.stdout.write('" + marker + "');");
+
+        assert(result.stdout.length >= outputSize + marker.length, 'should capture output larger than the previous exec maxBuffer');
+        assert(result.stdout.indexOf(marker) >= 0, 'should complete after streaming large stdout');
     });
 
     nodeVersions.forEach(function (nodeVersion) {

--- a/Extensions/Ansible/Tests/Tasks/Ansible/_suite.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/_suite.ts
@@ -78,7 +78,7 @@ function quoteShellArg(value: string): string {
     return "'" + value.replace(/'/g, "'\\''") + "'";
 }
 
-async function runRealAgentCommand(scriptContents: string): Promise<{ stdout: string; stderr: string; }> {
+async function runRealAgentCommand(scriptContents: string, failOnStdErr: boolean = false): Promise<{ stdout: string; stderr: string; error?: any; }> {
     const ansibleUtils = require(path.join(taskFolderPath, 'ansibleUtils.js'));
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ansible-agent-command-'));
     const scriptPath = path.join(tempDir, 'script.js');
@@ -88,6 +88,7 @@ async function runRealAgentCommand(scriptContents: string): Promise<{ stdout: st
     const originalStderrWrite = process.stderr.write.bind(process.stderr);
     let stdout = '';
     let stderr = '';
+    let error: any;
 
     (process.stdout as any).write = (chunk: any, encoding?: any, callback?: any): boolean => {
         stdout += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk);
@@ -108,12 +109,35 @@ async function runRealAgentCommand(scriptContents: string): Promise<{ stdout: st
     };
 
     try {
-        await ansibleUtils.runCommandOnSameMachine(quoteShellArg(process.execPath) + ' ' + quoteShellArg(scriptPath), { failOnStdErr: false });
-        return { stdout, stderr };
+        await ansibleUtils.runCommandOnSameMachine(quoteShellArg(process.execPath) + ' ' + quoteShellArg(scriptPath), { failOnStdErr });
+    } catch (err) {
+        error = err;
     } finally {
         (process.stdout as any).write = originalStdoutWrite;
         (process.stderr as any).write = originalStderrWrite;
         fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+
+    return { stdout, stderr, error };
+}
+
+async function runRealAgentCommandTerminatedBySignal(): Promise<void> {
+    const ansibleUtils = require(path.join(taskFolderPath, 'ansibleUtils.js'));
+    const taskLib = require(path.join(taskFolderPath, 'node_modules', 'azure-pipelines-task-lib', 'task.js'));
+    const originalSpawn = childProcess.spawn;
+
+    taskLib.setResourcePath(path.join(taskFolderPath, 'task.json'), true);
+
+    (childProcess as any).spawn = function (): childProcess.ChildProcess {
+        const child = originalSpawn(process.execPath, ['-e', 'setInterval(() => {}, 1000);']);
+        child.on('spawn', () => child.kill('SIGTERM'));
+        return child;
+    };
+
+    try {
+        await ansibleUtils.runCommandOnSameMachine('mock signal command', { failOnStdErr: false });
+    } finally {
+        (childProcess as any).spawn = originalSpawn;
     }
 }
 
@@ -154,7 +178,22 @@ describe('Ansible Suite', function () {
     it('streams real agent command stdout to normal task output', async function () {
         const result = await runRealAgentCommand("process.stdout.write('visible ansible output');");
 
+        assert(!result.error, 'should not fail when stdout is written');
         assert(result.stdout.indexOf('visible ansible output') >= 0, 'should stream stdout to normal task output');
+    });
+
+    it('streams real agent command stderr to normal task output when failOnStdErr is false', async function () {
+        const result = await runRealAgentCommand("process.stderr.write('visible ansible stderr');");
+
+        assert(!result.error, 'should not fail when failOnStdErr is false');
+        assert(result.stderr.indexOf('visible ansible stderr') >= 0, 'should stream stderr to normal task output');
+    });
+
+    it('fails real agent command after streaming stderr when failOnStdErr is true', async function () {
+        const result = await runRealAgentCommand("process.stderr.write('stderr that should fail');", true);
+
+        assert(result.error, 'should fail when failOnStdErr is true and stderr is written');
+        assert(result.stderr.indexOf('stderr that should fail') >= 0, 'should stream stderr before failing');
     });
 
     it('streams real agent command output beyond the old exec buffer limit', async function () {
@@ -164,8 +203,33 @@ describe('Ansible Suite', function () {
         const marker = 'large-output-complete';
         const result = await runRealAgentCommand("process.stdout.write('x'.repeat(" + outputSize + ")); process.stdout.write('" + marker + "');");
 
+        assert(!result.error, 'should not fail when streaming large stdout');
         assert(result.stdout.length >= outputSize + marker.length, 'should capture output larger than the previous exec maxBuffer');
         assert(result.stdout.indexOf(marker) >= 0, 'should complete after streaming large stdout');
+    });
+
+    it('streams real agent command stderr beyond the old exec buffer limit', async function () {
+        this.timeout(60000);
+
+        const outputSize = 21 * 1024 * 1024;
+        const marker = 'large-stderr-complete';
+        const result = await runRealAgentCommand("process.stderr.write('e'.repeat(" + outputSize + ")); process.stderr.write('" + marker + "');");
+
+        assert(!result.error, 'should not fail when failOnStdErr is false and large stderr is written');
+        assert(result.stderr.length >= outputSize + marker.length, 'should capture stderr larger than the previous exec maxBuffer');
+        assert(result.stderr.indexOf(marker) >= 0, 'should complete after streaming large stderr');
+    });
+
+    it('fails real agent command when spawned process is terminated by signal', async function () {
+        let rejected = false;
+
+        try {
+            await runRealAgentCommandTerminatedBySignal();
+        } catch (err) {
+            rejected = true;
+        }
+
+        assert(rejected, 'should reject when the spawned process closes with a signal');
     });
 
     nodeVersions.forEach(function (nodeVersion) {

--- a/Extensions/Ansible/Tests/Tasks/Ansible/_suite.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/_suite.ts
@@ -72,7 +72,7 @@ function outputContains(runner: any, value: string): boolean {
 
 function quoteShellArg(value: string): string {
     if (process.platform === 'win32') {
-        return '"' + value.replace(/"/g, '\\"') + '"';
+        return '"' + value.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
     }
 
     return "'" + value.replace(/'/g, "'\\''") + "'";


### PR DESCRIPTION
## Summary

This change fixes a regression in the Ansible task where `Ansible@0` no longer displayed playbook output in pipeline logs and could fail with `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` when playbook output was large.

The regression affected the local agent-machine execution path introduced in version `0.279.14` and `0.279.15` .

## Problem

The Ansible task previously used `shelljs.exec`, which streamed child process stdout and stderr directly to the task log. After the shelljs removal, the local command path was changed to `child_process.exec`.

`child_process.exec` is not a streaming API. It buffers stdout and stderr and only returns them to the callback after the process exits. In the merged implementation, stdout was not written to normal task output, so users could no longer see `ansible-playbook` output or the play recap in pipeline logs.

Because `exec` buffers output, large or verbose playbook runs could also exceed the configured `maxBuffer`, causing failures such as `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`. Increasing the buffer only reduced the likelihood of failure; it did not remove the buffering problem.

## Fix

The local command execution path now uses `child_process.spawn` with `shell: true` instead of `child_process.exec`.

This restores streaming behavior:

- stdout is written directly to `process.stdout`, so Ansible output is visible in normal pipeline logs again.
- stderr is written directly to `process.stderr`, preserving visibility for warnings/errors.
- `failOnStdErr` behavior is still honored by tracking whether stderr was written and failing after the process exits when requested.
- Since output is streamed instead of buffered, there is no `maxBuffer` ceiling and large playbook output no longer triggers `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`.

**Documentation changes required:** N

**Added unit tests:** Y

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
