### PR TITLE
Fix gulp task for syncing TEST version

### DIFF
--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.21",
+  "version": "0.279.22",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.19",
+  "version": "0.279.20",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.15",
+  "version": "0.279.16",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.20",
+  "version": "0.279.21",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.23",
+  "version": "0.279.24",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.22",
+  "version": "0.279.23",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.17",
+  "version": "0.279.18",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.18",
+  "version": "0.279.19",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.24",
+  "version": "0.279.25",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.29",
+  "version": "15.279.30",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.31",
+  "version": "15.279.33",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.33",
+  "version": "15.279.34",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.34",
+  "version": "15.279.35",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.35",
+  "version": "15.279.36",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.36",
+  "version": "15.279.37",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.30",
+  "version": "15.279.31",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.28",
+  "version": "15.279.29",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.12",
+  "version": "16.279.17",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.21",
+  "version": "16.279.23",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.27",
+  "version": "16.279.28",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.25",
+  "version": "16.279.27",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.10",
+  "version": "16.279.12",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.17",
+  "version": "16.279.20",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.20",
+  "version": "16.279.21",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.24",
+  "version": "16.279.25",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.33",
+  "version": "1.279.34",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.36",
+  "version": "1.279.37",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.32",
+  "version": "1.279.33",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.39",
+  "version": "1.279.40",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.35",
+  "version": "1.279.36",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.31",
+  "version": "1.279.32",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.34",
+  "version": "1.279.35",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.37",
+  "version": "1.279.39",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.279.19",
+  "version": "4.279.20",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.279.16",
+  "version": "4.279.17",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.279.21",
+  "version": "4.279.22",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.279.20",
+  "version": "4.279.21",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.279.15",
+  "version": "4.279.16",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.279.18",
+  "version": "4.279.19",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.279.14",
+  "version": "4.279.15",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.279.17",
+  "version": "4.279.18",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.32",
+  "version": "15.279.34",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.31",
+  "version": "15.279.32",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.34",
+  "version": "15.279.35",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.30",
+  "version": "15.279.31",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.26",
+  "version": "15.279.27",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.28",
+  "version": "15.279.29",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.27",
+  "version": "15.279.28",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.29",
+  "version": "15.279.30",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/scripts/BumpExtensionVersion.ps1
+++ b/scripts/BumpExtensionVersion.ps1
@@ -35,10 +35,7 @@ param(
 $ErrorActionPreference = 'Stop'
 
 # ---------------------------------------------------------------------------
-# Obtain Azure CLI token (login is handled by the gulp task before this script runs).
-# The token is minted for the tenant that backs the canary org (Microsoft corp tenant);
-# a token from any other tenant is treated as anonymous by that org's API and returns
-# nothing for the private "-test" extension.
+# Obtain Azure CLI token (login is handled by the gulp task before this script runs)
 # ---------------------------------------------------------------------------
 $azToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --tenant 72f988bf-86f1-41af-91ab-2d7cd011db47 --query accessToken -o tsv 2>$null
 if ($LASTEXITCODE -ne 0 -or -not $azToken) {
@@ -137,43 +134,25 @@ function Get-MarketplaceVersion {
 }
 
 # ---------------------------------------------------------------------------
-# Helper: read a private "-test" extension's version from the canary org where
-# it is installed (Extension Management API).
-# ---------------------------------------------------------------------------
-function Get-CanaryInstalledVersion {
-    param([string]$FullExtensionId, [string]$Token)
-
-    $dot = $FullExtensionId.IndexOf('.')
-    try {
-        $installed = Invoke-RestMethod `
-            -Uri "https://extmgmt.dev.azure.com/canarytest/_apis/extensionmanagement/installedextensions?api-version=7.1-preview.1" `
-            -Method Get `
-            -Headers @{ "Authorization" = "Bearer $Token" }
-
-        $match = $installed.value | Where-Object {
-            $_.publisherId -eq $FullExtensionId.Substring(0, $dot) -and
-            $_.extensionId -eq $FullExtensionId.Substring($dot + 1)
-        } | Select-Object -First 1
-
-        if ($match -and $match.version) {
-            return [version]$match.version
-        }
-    }
-    catch {
-        Write-Warning "Failed to query installed extensions for '$FullExtensionId': $($_.Exception.Message)"
-    }
-
-    return $null
-}
-
-# ---------------------------------------------------------------------------
 # Query both public and test extension versions
 # ---------------------------------------------------------------------------
 $prodId = "$publisher.$extensionId"
 $testId = "$publisher.$extensionId-test"
 
 $prodVersion = Get-MarketplaceVersion -FullExtensionId $prodId -Token $azToken
-$testVersion = Get-CanaryInstalledVersion -FullExtensionId $testId -Token $azToken
+$testVersion = Get-MarketplaceVersion -FullExtensionId $testId -Token $azToken
+
+# Fallback: the Gallery returns a private "-test" extension only to authorized identities;
+# if it did not, read the version from the canarytest org where the extension is installed.
+if (-not $testVersion) {
+    try {
+        $installed = Invoke-RestMethod -Uri "https://extmgmt.dev.azure.com/canarytest/_apis/extensionmanagement/installedextensions?api-version=7.1-preview.1" -Method Get -Headers @{ "Authorization" = "Bearer $azToken" }
+        $dot = $testId.IndexOf('.')
+        $match = $installed.value | Where-Object { $_.publisherId -eq $testId.Substring(0, $dot) -and $_.extensionId -eq $testId.Substring($dot + 1) } | Select-Object -First 1
+        if ($match -and $match.version) { $testVersion = [version]$match.version }
+    }
+    catch { Write-Warning "Failed to query canarytest for '$testId': $($_.Exception.Message)" }
+}
 
 if ($prodVersion) { Write-Host "PROD ver  : $prodVersion  ($prodId)" }
 else              { Write-Host "PROD ver  : not found     ($prodId)" }

--- a/scripts/BumpExtensionVersion.ps1
+++ b/scripts/BumpExtensionVersion.ps1
@@ -145,13 +145,29 @@ $testVersion = Get-MarketplaceVersion -FullExtensionId $testId -Token $azToken
 # Fallback: the Gallery returns a private "-test" extension only to authorized identities;
 # if it did not, read the version from the canarytest org where the extension is installed.
 if (-not $testVersion) {
-    try {
-        $installed = Invoke-RestMethod -Uri "https://extmgmt.dev.azure.com/canarytest/_apis/extensionmanagement/installedextensions?api-version=7.1-preview.1" -Method Get -Headers @{ "Authorization" = "Bearer $azToken" }
-        $dot = $testId.IndexOf('.')
-        $match = $installed.value | Where-Object { $_.publisherId -eq $testId.Substring(0, $dot) -and $_.extensionId -eq $testId.Substring($dot + 1) } | Select-Object -First 1
-        if ($match -and $match.version) { $testVersion = [version]$match.version }
+    $headers = @{
+        "Authorization" = "Bearer $azToken"
     }
-    catch { Write-Warning "Failed to query canarytest for '$testId': $($_.Exception.Message)" }
+
+    try {
+        $installed = Invoke-RestMethod `
+            -Uri "https://extmgmt.dev.azure.com/canarytest/_apis/extensionmanagement/installedextensions?api-version=7.1-preview.1" `
+            -Method Get `
+            -Headers $headers
+
+        $dot = $testId.IndexOf('.')
+        $match = $installed.value | Where-Object {
+            $_.publisherId -eq $testId.Substring(0, $dot) -and
+            $_.extensionId -eq $testId.Substring($dot + 1)
+        } | Select-Object -First 1
+
+        if ($match -and $match.version) {
+            $testVersion = [version]$match.version
+        }
+    }
+    catch {
+        Write-Warning "Failed to query canarytest for '$testId': $($_.Exception.Message)"
+    }
 }
 
 if ($prodVersion) { Write-Host "PROD ver  : $prodVersion  ($prodId)" }

--- a/scripts/BumpExtensionVersion.ps1
+++ b/scripts/BumpExtensionVersion.ps1
@@ -149,7 +149,8 @@ if (-not $testVersion) {
         "Authorization" = "Bearer $azToken"
     }
 
-    try {
+    try 
+    {
         $installed = Invoke-RestMethod `
             -Uri "https://extmgmt.dev.azure.com/canarytest/_apis/extensionmanagement/installedextensions?api-version=7.1-preview.1" `
             -Method Get `

--- a/scripts/BumpExtensionVersion.ps1
+++ b/scripts/BumpExtensionVersion.ps1
@@ -35,9 +35,12 @@ param(
 $ErrorActionPreference = 'Stop'
 
 # ---------------------------------------------------------------------------
-# Obtain Azure CLI token (login is handled by the gulp task before this script runs)
+# Obtain Azure CLI token (login is handled by the gulp task before this script runs).
+# The token is minted for the tenant that backs the canary org (Microsoft corp tenant);
+# a token from any other tenant is treated as anonymous by that org's API and returns
+# nothing for the private "-test" extension.
 # ---------------------------------------------------------------------------
-$azToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv 2>$null
+$azToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --tenant 72f988bf-86f1-41af-91ab-2d7cd011db47 --query accessToken -o tsv 2>$null
 if ($LASTEXITCODE -ne 0 -or -not $azToken) {
     Write-Error "Failed to obtain Azure CLI access token. Ensure you are logged in (az login)."
     exit 1
@@ -128,6 +131,29 @@ function Get-MarketplaceVersion {
     }
     catch {
         Write-Warning "Failed to query Marketplace for '$FullExtensionId': $($_.Exception.Message)"
+    }
+
+    # Private "-test" extensions are not returned by the public Gallery query above.
+    # Read them from the canary org they are installed in (Extension Management API),
+    # using the corp-tenant token acquired earlier.
+    $dot = $FullExtensionId.IndexOf('.')
+    try {
+        $installed = Invoke-RestMethod `
+            -Uri "https://extmgmt.dev.azure.com/canarytest/_apis/extensionmanagement/installedextensions?api-version=7.1-preview.1" `
+            -Method Get `
+            -Headers @{ "Authorization" = "Bearer $Token" }
+
+        $match = $installed.value | Where-Object {
+            $_.publisherId -eq $FullExtensionId.Substring(0, $dot) -and
+            $_.extensionId -eq $FullExtensionId.Substring($dot + 1)
+        } | Select-Object -First 1
+
+        if ($match -and $match.version) {
+            return [version]$match.version
+        }
+    }
+    catch {
+        Write-Warning "Failed to query installed extensions for '$FullExtensionId': $($_.Exception.Message)"
     }
 
     return $null

--- a/scripts/BumpExtensionVersion.ps1
+++ b/scripts/BumpExtensionVersion.ps1
@@ -133,9 +133,16 @@ function Get-MarketplaceVersion {
         Write-Warning "Failed to query Marketplace for '$FullExtensionId': $($_.Exception.Message)"
     }
 
-    # Private "-test" extensions are not returned by the public Gallery query above.
-    # Read them from the canary org they are installed in (Extension Management API),
-    # using the corp-tenant token acquired earlier.
+    return $null
+}
+
+# ---------------------------------------------------------------------------
+# Helper: read a private "-test" extension's version from the canary org where
+# it is installed (Extension Management API).
+# ---------------------------------------------------------------------------
+function Get-CanaryInstalledVersion {
+    param([string]$FullExtensionId, [string]$Token)
+
     $dot = $FullExtensionId.IndexOf('.')
     try {
         $installed = Invoke-RestMethod `
@@ -166,7 +173,7 @@ $prodId = "$publisher.$extensionId"
 $testId = "$publisher.$extensionId-test"
 
 $prodVersion = Get-MarketplaceVersion -FullExtensionId $prodId -Token $azToken
-$testVersion = Get-MarketplaceVersion -FullExtensionId $testId -Token $azToken
+$testVersion = Get-CanaryInstalledVersion -FullExtensionId $testId -Token $azToken
 
 if ($prodVersion) { Write-Host "PROD ver  : $prodVersion  ($prodId)" }
 else              { Write-Host "PROD ver  : not found     ($prodId)" }

--- a/scripts/BumpExtensionVersion.ps1
+++ b/scripts/BumpExtensionVersion.ps1
@@ -37,7 +37,7 @@ $ErrorActionPreference = 'Stop'
 # ---------------------------------------------------------------------------
 # Obtain Azure CLI token (login is handled by the gulp task before this script runs)
 # ---------------------------------------------------------------------------
-$azToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --tenant 72f988bf-86f1-41af-91ab-2d7cd011db47 --query accessToken -o tsv 2>$null
+$azToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv 2>$null
 if ($LASTEXITCODE -ne 0 -or -not $azToken) {
     Write-Error "Failed to obtain Azure CLI access token. Ensure you are logged in (az login)."
     exit 1


### PR DESCRIPTION
**Description**:

Add Installed Extensions API call to BumpExtensionVersion.ps1 script as a fallback to get the private TEST extension version.
The gulp build --syncVersions <Extensions> command returns  "TEST ver: not found." for some users. This could be due to lack of required permissions on the ms-vscs-rm publisher.

<img width="761" height="181" alt="image" src="https://github.com/user-attachments/assets/d3fc4786-bd4c-4b21-af39-21e23a837f24" />


Changes:

- Read the version from the canarytest org's Extension Management API ( extmgmt.dev.azure.com/canarytest/_apis/extensionmanagement/installedextensions ) and match on  publisherId / extensionId . This reuses the same  az login  token master already uses for PROD. Using canarytest org here as the TEST extensions are already installed in this org which will auto update the installed extensions once published to marketplace.
- Bump the manifest version  for the six extensions (Ansible, BitBucket, ExternalTfs, IISWebAppDeploy, ServiceNow, TeamCity)



**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
