### PR TITLE
Add test for printing agent machine playbook output to task output

### DIFF
--- a/Extensions/Ansible/Tests/Tasks/Ansible/_suite.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/_suite.ts
@@ -182,6 +182,14 @@ describe('Ansible Suite', function () {
         assert(result.stdout.indexOf('visible ansible output') >= 0, 'should stream stdout to normal task output');
     });
 
+    it('prints agent machine playbook output to normal task output', async function () {
+        const playbookOutput = 'PLAY [localhost] ***\\nTASK [Gathering Facts] ***\\nok: [localhost]\\nPLAY RECAP ***************\\n';
+        const result = await runRealAgentCommand("process.stdout.write(" + JSON.stringify(playbookOutput) + ");");
+
+        assert(!result.error, 'should not fail when playbook output is written');
+        assert(result.stdout.indexOf(playbookOutput) >= 0, 'should print playbook output to normal task output');
+    });
+
     it('streams real agent command stderr to normal task output when failOnStdErr is false', async function () {
         const result = await runRealAgentCommand("process.stderr.write('visible ansible stderr');");
 


### PR DESCRIPTION
Description: Added a regression test verifying that multiline Ansible playbook output from runCommandOnSameMachine is printed to normal task output. This protects against future changes that swallow child-process stdout.

Documentation changes required: (N) No documentation changes are required.

Added unit tests: (Y) Added a unit test covering multiline playbook stdout.

Attached related issue: AB#2451099

Checklist:

- [ ] Version was bumped - not required for a test-only change.
- [ ] Checked that applied changes work as expected.