### PR TITLE
 Add sprint minor-version guard to extension version verification

### DIFF
--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.10",
+  "version": "16.280.0",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/scripts/VerifyExtensionVersions.ps1
+++ b/scripts/VerifyExtensionVersions.ps1
@@ -37,10 +37,27 @@ Write-Host "Extensions to verify: $($extensionList -join ', ')"
 Write-Host ""
 
 # ---------------------------------------------------------------------------
+# Current Azure DevOps sprint (fetched directly from whatsprintis.it). The
+# extension minor version must not be bumped ahead of the current sprint.
+# https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/taskversionbumping.md
+# ---------------------------------------------------------------------------
+$sprint = $null
+try {
+    $current = Invoke-RestMethod -Uri 'https://whatsprintis.it/?json' -TimeoutSec 10 -ErrorAction Stop
+    $sprint  = [int]$current.sprint
+    Write-Host "Current sprint : $sprint"
+}
+catch {
+    Write-Host "##[warning]Could not fetch the current sprint from whatsprintis.it ($($_.Exception.Message)); skipping the sprint version guard."
+}
+Write-Host ""
+
+# ---------------------------------------------------------------------------
 # Verify each extension by calling BumpExtensionVersion.ps1 -VerifyOnly
 # ---------------------------------------------------------------------------
 $scriptPath = Join-Path $SourceDirectory 'scripts/BumpExtensionVersion.ps1'
 $failures = @()
+$aheadOfSprint = @()  # minor version bumped ahead of the current sprint
 
 foreach ($ext in $extensionList) {
     $manifestPath = Join-Path $SourceDirectory "Extensions/$ext/Src/vss-extension.json"
@@ -50,6 +67,14 @@ foreach ($ext in $extensionList) {
     }
 
     Write-Host "--- Verifying: $ext ---"
+
+    # Sprint guard: the minor version must not be bumped ahead of the current sprint. This is a guardrail to prevent accidentally bumping into a future sprint.
+    $minor = ([version](Get-Content $manifestPath -Raw | ConvertFrom-Json).version).Minor
+    if ($null -ne $sprint -and $minor -gt $sprint) {
+        Write-Host "##[error]$ext`: minor version $minor is ahead of the current sprint ($sprint). Do not bump into a future sprint."
+        $aheadOfSprint += $ext
+    }
+
     $ErrorActionPreference = 'Continue'
     & $scriptPath -ManifestPath $manifestPath -VerifyOnly
     $ErrorActionPreference = 'Stop'
@@ -67,6 +92,14 @@ if ($failures.Count -gt 0) {
     Write-Host "##[error]Version not bumped for: $($failures -join ', ')"
     Write-Host "##[error]Please update the 'version' field in vss-extension.json to exceed the Marketplace version."
     Write-Host "##[error]Run: gulp build --syncVersions $($failures -join ',')"
+}
+
+if ($aheadOfSprint.Count -gt 0) {
+    Write-Host "##[error]Version bumped ahead of the current sprint ($sprint) for: $(($aheadOfSprint | Select-Object -Unique) -join ', ')"
+    Write-Host "##[error]Set the minor version to the current sprint ($sprint) - do not bump into a future sprint."
+}
+
+if ($failures.Count -gt 0 -or $aheadOfSprint.Count -gt 0) {
     exit 1
 }
 

--- a/scripts/VerifyExtensionVersions.ps1
+++ b/scripts/VerifyExtensionVersions.ps1
@@ -44,8 +44,13 @@ Write-Host ""
 $sprint = $null
 try {
     $current = Invoke-RestMethod -Uri 'https://whatsprintis.it/?json' -TimeoutSec 10 -ErrorAction Stop
-    $sprint  = [int]$current.sprint
-    Write-Host "Current sprint : $sprint"
+    if ($current.sprint -and [int]$current.sprint -gt 0) {
+        $sprint = [int]$current.sprint
+        Write-Host "Current sprint : $sprint"
+    }
+    else {
+        Write-Host "##[warning]Unexpected response from whatsprintis.it (no valid sprint number); skipping the sprint version guard."
+    }
 }
 catch {
     Write-Host "##[warning]Could not fetch the current sprint from whatsprintis.it ($($_.Exception.Message)); skipping the sprint version guard."
@@ -68,11 +73,20 @@ foreach ($ext in $extensionList) {
 
     Write-Host "--- Verifying: $ext ---"
 
-    # Sprint guard: the minor version must not be bumped ahead of the current sprint. This is a guardrail to prevent accidentally bumping into a future sprint.
-    $minor = ([version](Get-Content $manifestPath -Raw | ConvertFrom-Json).version).Minor
-    if ($null -ne $sprint -and $minor -gt $sprint) {
-        Write-Host "##[error]$ext`: minor version $minor is ahead of the current sprint ($sprint). Do not bump into a future sprint."
-        $aheadOfSprint += $ext
+    # Sprint guard: the minor version must not be bumped ahead of the current
+    # sprint. This is a guardrail to prevent accidentally bumping into a future
+    # sprint. Skipped when the current sprint could not be determined.
+    if ($null -ne $sprint) {
+        try {
+            $minor = ([version](Get-Content $manifestPath -Raw | ConvertFrom-Json).version).Minor
+            if ($minor -gt $sprint) {
+                Write-Host "##[error]$ext`: minor version $minor is ahead of the current sprint ($sprint). Do not bump into a future sprint."
+                $aheadOfSprint += $ext
+            }
+        }
+        catch {
+            Write-Host "##[warning]$ext`: could not read the manifest version for the sprint guard ($($_.Exception.Message))."
+        }
     }
 
     $ErrorActionPreference = 'Continue'


### PR DESCRIPTION
**Description**: 

Adds a check to verify minor version so the CI PR gate fails when an extension's minor version is bumped ahead of the current Azure DevOps sprint.

What this PR adds:

- Fetches the current sprint number directly from  whatsprintis.it  
- For each verified extension, flags a failure if the manifest's minor version is greater than the current sprint.
- Reports the two failure modes as separate error blocks:
  -  Not bumped vs Marketplace → run  gulp build --syncVersions  (bump up).
  -  Ahead of sprint → manually set the minor to the current sprint
-  The script exits  1  if either check fails.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.
- [ ] Checked that applied changes work as expected.
