### PR TITLE
Fix the External TFS Git clone retry flow

### DIFF
--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/downloadTfGit.js
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/downloadTfGit.js
@@ -349,7 +349,12 @@ function executeWithRetries(operationName, operation, remainingRetryAttempts) {
         } else {
             tl.debug('RetryingOperation: ' + operationName + ', remainingRetryAttempts: ' + remainingRetryAttempts);
             remainingRetryAttempts = remainingRetryAttempts - 1;
-            setTimeout(() => executeWithRetries(operationName, operation, remainingRetryAttempts), 4 * 1000);
+            setTimeout(() => {
+                executeWithRetries(operationName, operation, remainingRetryAttempts).then(
+                    (result) => deferred.resolve(result),
+                    (retryError) => deferred.reject(retryError)
+                );
+            }, 4 * 1000);
         }
     });
 

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 16,
     "Minor": 279,
-    "Patch": 1
+    "Patch": 2
   },
   "minimumAgentVersion": "2.206.1",
   "instanceNameFormat": "Download Artifacts - External TFS Git",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.22",
+  "version": "16.279.23",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.10",
+  "version": "16.279.22",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/_suite.ts
+++ b/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/_suite.ts
@@ -150,6 +150,9 @@ describe('DownloadArtifactsTfsGit Suite', function () {
                 // `DistributedTask.Tasks.Node.SkipDebugLogsWhenDebugModeOff` and is
                 // therefore environment-dependent (suppressed on hosted agents by default).
                 assert(runner.stdOutContained('[mock-git] clone-attempt 2'), 'should retry after first failure');
+                assert(!runner.stdOutContained('[mock-git] clone-attempt 3'), 'should stop retrying after the clone succeeds');
+                assert(runner.stdOutContained('[mock-git] checkout master'), 'should continue by checking out the branch after the retry succeeds');
+                assert(runner.stdOutContained('[mock-git] checkout 1234567890abcdef1234567890abcdef12345678'), 'should continue by checking out the requested commit after the retry succeeds');
             });
 
             // ---- Failure / validation scenarios ----------------------------
@@ -255,6 +258,7 @@ describe('DownloadArtifactsTfsGit Suite', function () {
                 // GIT_CLONE_RETRY_ATTEMPTS = 4 => 1 initial + 4 retries = 5 attempts.
                 assert(runner.stdOutContained('[mock-git] clone-attempt 5'), 'should attempt clone the maximum number of times');
                 assert(runner.stdOutContained('OperationFailed: gitClone'), 'should emit OperationFailed once retries are exhausted');
+                assert(!runner.stdOutContained('[mock-git] checkout '), 'should not attempt checkout after clone retries are exhausted');
             });
         });
     });


### PR DESCRIPTION
**Description**:

Fixes the External TFS Git clone retry flow. Previously, a successful retry did not resolve the original promise, so execution stopped before branch and commit checkout.

Changes include:
- Propagate recursive retry success and failure to the original promise.
- Verify that retries stop after a successful clone.
- Verify that branch and commit checkout continue after retry recovery.
- Verify that exhausted retries do not attempt checkout.

**Documentation changes required:** N

**Added unit tests:** Y — updated retry tests to validate post-retry checkout and exhausted-retry behavior.

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.