### PR TITLE
Add errors to tl.setResult methods for Ansible task

### DIFF
--- a/Extensions/Ansible/Src/Tasks/Ansible/ansibleTowerInterface.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/ansibleTowerInterface.ts
@@ -42,7 +42,7 @@ export class ansibleTowerInterface extends ansibleInterface {
             if (status === 'successful') {
                 tl.setResult(tl.TaskResult.Succeeded, "");
             } else if (status === 'failed') {
-                tl.setResult(tl.TaskResult.Failed, "");
+                tl.setResult(tl.TaskResult.Failed, tl.loc('AnsibleTowerJobFailed', jobId));
             }
         } catch (error) {
             tl.setResult(tl.TaskResult.Failed, error);

--- a/Extensions/Ansible/Src/Tasks/Ansible/main.ts
+++ b/Extensions/Ansible/Src/Tasks/Ansible/main.ts
@@ -43,7 +43,7 @@ function run() {
         if (ansibleInterface) {
             ansibleInterface.execute();
         } else {
-            tl.setResult(tl.TaskResult.Failed, "");
+            tl.setResult(tl.TaskResult.Failed, tl.loc("AnsibleInterfaceNotInitialized"));
         }
     } catch (error) {
         tl.setResult(tl.TaskResult.Failed, error);

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 279,
-        "Patch": 18
+        "Patch": 28
     },
     "demands": [],
     "minimumAgentVersion": "2.206.1",

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -348,6 +348,7 @@
         "RemoteFileCleanUpFailed": "Failed to delete the script file copied to the Ansible machine. Error: %s.",
         "JobTemplateNotPresent": "Failed to locate job template. Job template with name %s is not present.",
         "Ansible_ConstructorFailed": "Cannot initialize Ansible: %s.",
+        "AnsibleTowerJobFailed": "Ansible Tower job %s failed.",
         "FailedToGetJobDetails": "Failed to get job details. Ansible returns with error code %s and message %s.",
         "CouldnotLaunchJob": "Failed to launch job. Ansible returns with error code %s and message %s.",
         "AgentOnWindowsMachine": "Both agent and Ansible should be on linux machine",

--- a/Extensions/Ansible/Src/Tasks/Ansible/task.json
+++ b/Extensions/Ansible/Src/Tasks/Ansible/task.json
@@ -348,6 +348,7 @@
         "RemoteFileCleanUpFailed": "Failed to delete the script file copied to the Ansible machine. Error: %s.",
         "JobTemplateNotPresent": "Failed to locate job template. Job template with name %s is not present.",
         "Ansible_ConstructorFailed": "Cannot initialize Ansible: %s.",
+        "AnsibleInterfaceNotInitialized": "Failed to initialize the Ansible interface.",
         "AnsibleTowerJobFailed": "Ansible Tower job %s failed.",
         "FailedToGetJobDetails": "Failed to get job details. Ansible returns with error code %s and message %s.",
         "CouldnotLaunchJob": "Failed to launch job. Ansible returns with error code %s and message %s.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.26",
+  "version": "0.279.28",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Tests/Tasks/Ansible/_suite.ts
+++ b/Extensions/Ansible/Tests/Tasks/Ansible/_suite.ts
@@ -467,6 +467,7 @@ describe('Ansible Suite', function () {
                 const runner = newRunner('testTowerFailedJob');
                 await runAndDump(runner, nodeVersion);
                 expectFailure(runner, 'expected tower failed-job status to fail task');
+                assert(outputContains(runner, 'loc_mock_AnsibleTowerJobFailed'), 'should report the failed tower job');
             });
 
             it('fails when tower job status api returns non-200', async function () {


### PR DESCRIPTION
**Description**: Improve Ansible task failure output by replacing empty `tl.setResult` messages with localized error messages. Failed Ansible Tower jobs now include the job ID, and uninitialized interfaces report a clear failure reason.

**Documentation changes required:** N

**Added unit tests:** Y - Updated the Ansible Tower failure test to verify the localized error output.

**Attached related issue:** N - No related issue identified.

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected. Focused Ansible suite passed across Node 16, 20, and 24.
