### PR TITLE
Enhance TypeScript configuration for DownloadArtifactsTfsGit

### DIFF
--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/downloadTfGit.js
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/downloadTfGit.js
@@ -20,6 +20,11 @@ const commitId = tl.getInput(isAdoConnectionType ? "versionAdo" : "version");
 const downloadPath = tl.getInput("downloadPath");
 validateInputs(serviceConnection, repositoryId, projectId, branch, commitId, downloadPath);
 
+/**
+ * @typedef {Object} AuthParameters
+ * @property {Record<string, any>} parameters - An object containing key-value pairs of authorization parameters.
+ */
+
 // @ts-ignore
 shell.rm('-rf', downloadPath);
 const error = shell.error();
@@ -32,9 +37,9 @@ if (error) {
 /**
  * @typedef {Object} ConnectionDetails
  * @property {string} Url - The URL of the TFS server or Azure DevOps organization, obtained from the service connection endpoint.
- * @property {string} Username - The username for authentication, which may be a placeholder value (e.g., "oauth2") for Azure DevOps service connections using access tokens.
- * @property {string} [Password] - The password or token for authentication, which may be an access token for Azure DevOps service connections or a personal access token for TFS service connections.
- * @property {string} [AccessToken] - The access token for authentication, which is only applicable for Azure DevOps service connections using workload identity federation. This property may be undefined for TFS service connections or Azure DevOps service connections that do not use workload identity federation.
+ * @property {string | null} Username - The username for authentication, which may be a placeholder value (e.g., "oauth2") for Azure DevOps service connections using access tokens.
+ * @property {string | null} [Password] - The password or token for authentication, which may be an access token for Azure DevOps service connections or a personal access token for TFS service connections.
+ * @property {string | null} [AccessToken] - The access token for authentication, which is only applicable for Azure DevOps service connections using workload identity federation. This property may be undefined for TFS service connections or Azure DevOps service connections that do not use workload identity federation.
  */
 
 /** @type {ConnectionDetails} */
@@ -186,7 +191,9 @@ function getReposOrTfsScDetails(serviceConnection, hostUrl) {
         throw new Error("The authorization scheme " + auth.scheme + " is not supported for a External Tfs endpoint.");
     }
 
+    /** @type {string | null} */
     let hostUsername = ".";
+    /** @type {string | null} */
     let hostPassword = "";
 
     if (auth.scheme == "Token") {
@@ -213,24 +220,20 @@ function getReposOrTfsScDetails(serviceConnection, hostUrl) {
 
 /**
  * Helper function to get authorization parameters from the service connection authorization object, with case-insensitive key matching.
- * @param {Object} auth - The authorization object obtained from the service connection, which contains the parameters in a 'parameters' property.
+ * @param {AuthParameters} auth - The authorization object obtained from the service connection, which contains the parameters in a 'parameters' property.
  * @param {string} paramName - The name of the parameter to retrieve (e.g., 'username', 'password', 'apitoken').
- * @returns {string} The value of the requested authorization parameter.
+ * @returns {string | null} The value of the requested authorization parameter.
  */
 function getAuthParameter(auth, paramName) {
-    let paramValue = null;
-    // @ts-ignore
-    const parameters = Object.getOwnPropertyNames(auth['parameters']);
-    let keyName;
-    parameters.some(function (key) {
-        if (key.toLowerCase() === paramName.toLowerCase()) {
-            keyName = key;
-            return true;
-        }
+    if (!auth || !auth.parameters || !paramName) {
+        return null;
+    }
+
+    const keyName = Object.keys(auth.parameters).find(function (key) {
+        return key && key.toLowerCase() === paramName.toLowerCase();
     });
-    // @ts-ignore
-    paramValue = auth['parameters'][keyName];
-    return paramValue;
+
+    return keyName ? auth.parameters[keyName] : null;
 }
 
 /**
@@ -244,6 +247,10 @@ function getGitClientPromise(connectionDetails) {
         // Use bearer handler for ADO service connections that works with the access token.
         handler = webApim.getBearerHandler(connectionDetails.AccessToken, true);
     } else {
+        if (!connectionDetails.Username) {
+            throw new Error("Username is not provided for the service connection.");
+        }
+
         if (!connectionDetails.Password) {
             throw new Error("Password is not provided for the service connection.");
         }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 16,
     "Minor": 279,
-    "Patch": 2
+    "Patch": 32
   },
   "minimumAgentVersion": "2.206.1",
   "instanceNameFormat": "Download Artifacts - External TFS Git",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 16,
     "Minor": 279,
-    "Patch": 32
+    "Patch": 45
   },
   "minimumAgentVersion": "2.206.1",
   "instanceNameFormat": "Download Artifacts - External TFS Git",

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/tsconfig.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/tsconfig.json
@@ -24,8 +24,9 @@
         "noUncheckedIndexedAccess": true,
         "noImplicitOverride": true,
         "noPropertyAccessFromIndexSignature": true,
-        "allowUnusedLabels": true,
-        "allowUnreachableCode": true
+        "forceConsistentCasingInFileNames": true,
+        "allowUnusedLabels": false,
+        "allowUnreachableCode": false
     },
     "include": [
         "*.js"

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/tsconfig.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/tsconfig.json
@@ -8,7 +8,24 @@
         "noEmit": true,
         "checkJs": true,
         "useUnknownInCatchVariables": false,
-        "strict": true
+        "strict": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "strictBindCallApply": true,
+        "strictPropertyInitialization": true,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "exactOptionalPropertyTypes": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true,
+        "noUncheckedIndexedAccess": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "allowUnusedLabels": true,
+        "allowUnreachableCode": true
     },
     "include": [
         "*.js"

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.43",
+  "version": "16.279.45",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/_suite.ts
+++ b/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/_suite.ts
@@ -215,7 +215,12 @@ describe('DownloadArtifactsTfsGit Suite', function () {
                 if (runner.succeeded) fail(runner, 'expected task to fail when endpoint authorization is missing');
                 assert(runner.stdOutContained('Failed to get authorization details for service connection'), 'expected error mentioning missing authorization');
             });
-
+            it('fails gracefully when authorization parameters object is missing', async function () {
+                const runner = newRunner('failMissingAuthParameterObject');
+                await runAndDump(runner, nodeVersion);
+                if (runner.succeeded) fail(runner, 'expected task to fail when auth parameters object is missing');
+                assert(runner.stdOutContained('Password is not provided for the service connection'), 'expected null-safe guard to fail with a clear authentication error');
+            });
             it('fails when authorization scheme is not Token/UsernamePassword', async function () {
                 const runner = newRunner('failUnsupportedAuthScheme');
                 await runAndDump(runner, nodeVersion);

--- a/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/_suite.ts
+++ b/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/_suite.ts
@@ -219,6 +219,13 @@ describe('DownloadArtifactsTfsGit Suite', function () {
                 const runner = newRunner('failMissingAuthParameterObject');
                 await runAndDump(runner, nodeVersion);
                 if (runner.succeeded) fail(runner, 'expected task to fail when auth parameters object is missing');
+                // Username is checked before Password in getGitClientPromise, so it surfaces first when both are absent.
+                assert(runner.stdOutContained('Username is not provided for the service connection'), 'expected null-safe guard to fail with a clear authentication error');
+            });
+            it('fails gracefully when password parameter is missing', async function () {
+                const runner = newRunner('failMissingPassword');
+                await runAndDump(runner, nodeVersion);
+                if (runner.succeeded) fail(runner, 'expected task to fail when password parameter is missing');
                 assert(runner.stdOutContained('Password is not provided for the service connection'), 'expected null-safe guard to fail with a clear authentication error');
             });
             it('fails when authorization scheme is not Token/UsernamePassword', async function () {

--- a/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/failMissingAuthParameterObject.ts
+++ b/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/failMissingAuthParameterObject.ts
@@ -1,0 +1,29 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+import {
+    TFS_CONNECTION_ID, PROJECT_ID, REPOSITORY_ID, DOWNLOAD_PATH,
+    BRANCH_REGULAR, COMMIT_ID,
+    registerAllMocks
+} from './mockHelpers';
+
+const taskPath = path.join(__dirname, '..', '..', '..', 'Src', 'Tasks', 'DownloadArtifactsTfsGit', 'downloadTfGit.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('connectionType', 'reposOrTfs');
+tr.setInput('connection', TFS_CONNECTION_ID);
+tr.setInput('project', PROJECT_ID);
+tr.setInput('definition', REPOSITORY_ID);
+tr.setInput('branch', BRANCH_REGULAR);
+tr.setInput('version', COMMIT_ID);
+tr.setInput('downloadPath', DOWNLOAD_PATH);
+
+process.env['ENDPOINT_URL_' + TFS_CONNECTION_ID] = 'https://tfs.example.local/DefaultCollection';
+process.env['ENDPOINT_AUTH_' + TFS_CONNECTION_ID] = JSON.stringify({
+    scheme: 'UsernamePassword'
+});
+process.env['ENDPOINT_AUTH_SCHEME_' + TFS_CONNECTION_ID] = 'UsernamePassword';
+
+registerAllMocks(tr);
+
+tr.run();

--- a/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/failMissingPassword.ts
+++ b/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/failMissingPassword.ts
@@ -1,0 +1,30 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+import {
+    TFS_CONNECTION_ID, PROJECT_ID, REPOSITORY_ID, DOWNLOAD_PATH,
+    BRANCH_REGULAR, COMMIT_ID, TFS_USERNAME,
+    registerAllMocks
+} from './mockHelpers';
+
+const taskPath = path.join(__dirname, '..', '..', '..', 'Src', 'Tasks', 'DownloadArtifactsTfsGit', 'downloadTfGit.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('connectionType', 'reposOrTfs');
+tr.setInput('connection', TFS_CONNECTION_ID);
+tr.setInput('project', PROJECT_ID);
+tr.setInput('definition', REPOSITORY_ID);
+tr.setInput('branch', BRANCH_REGULAR);
+tr.setInput('version', COMMIT_ID);
+tr.setInput('downloadPath', DOWNLOAD_PATH);
+
+process.env['ENDPOINT_URL_' + TFS_CONNECTION_ID] = 'https://tfs.example.local/DefaultCollection';
+process.env['ENDPOINT_AUTH_' + TFS_CONNECTION_ID] = JSON.stringify({
+    scheme: 'UsernamePassword',
+    parameters: { username: TFS_USERNAME }
+});
+process.env['ENDPOINT_AUTH_SCHEME_' + TFS_CONNECTION_ID] = 'UsernamePassword';
+
+registerAllMocks(tr);
+
+tr.run();


### PR DESCRIPTION
**Description**: Tightens the `DownloadArtifactsTfsGit` task's TypeScript checking and hardens its authentication-parameter handling against missing/malformed service connection data.

- Enabled a much stricter `tsconfig.json` for the task (`noImplicitAny`, `strictNullChecks`, `strictFunctionTypes`, `strictBindCallApply`, `strictPropertyInitialization`, `noImplicitThis`, `alwaysStrict`, `noUnusedLocals`, `noUnusedParameters`, `exactOptionalPropertyTypes`, `noImplicitReturns`, `noFallthroughCasesInSwitch`, `noUncheckedIndexedAccess`, `noImplicitOverride`, `noPropertyAccessFromIndexSignature`) to catch a wider class of type errors at build time.
- Made `getAuthParameter` null-safe: it now returns `null` instead of throwing when the endpoint's `auth` object or its `parameters` property is missing, rather than relying on an unchecked `auth['parameters']` lookup.
- Added an explicit guard in `getGitClientPromise` that fails fast with `"Username is not provided for the service connection."` when no username is available (in addition to the existing password guard), so a missing/incomplete auth parameters object produces a clear, actionable error instead of an obscure downstream failure.
- Updated JSDoc typedefs (`ConnectionDetails`, `AuthParameters`) to reflect the new nullable string types.
- Bumped the task/extension version per contribution guidelines.

**Documentation changes required:** N

**Added unit tests:** Y - added `failMissingAuthParameterObject.ts` (auth `parameters` object entirely absent) and `failMissingPassword.ts` (username present, password missing) fixtures, plus corresponding assertions in `_suite.ts` for both Node 16 and Node 20 runners.

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.