### PR TITLE
Add support for syncing all publishable extensions in syncVersions command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ In order to build and package extensions you will need to install some dependenc
   - Use `--syncVersions` to automatically bump the `version` field in `vss-extension.json` so it is higher than what is currently published on the Marketplace. This avoids pipeline failures caused by version conflicts.
     - Single extension: `gulp build --syncVersions <ExtensionName>`. For example `gulp build --syncVersions Ansible`
     - Multiple extensions (comma-separated): `gulp build --syncVersions <ExtensionName1>,<ExtensionName2>`. For example `gulp build --syncVersions Ansible,IISWebAppDeploy`
+    - All publishable extensions: `gulp build --syncVersions all`
   - Ensure you run the command with sufficient permissions (e.g. open PowerShell as Administrator), as Azure CLI may need access to protected directories.
   - You may be prompted to log in to Azure (`az login`) because `--syncVersions` requires an access token to query the Marketplace API. The login prompt will open automatically in the browser if your session has expired.
 - `gulp test` will run all pester or mocha tests written for each task, in the Tests folder.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -553,9 +553,17 @@ gulp.task("syncVersions", function (cb) {
 
     // Support comma-separated extension names (e.g. --syncVersions Ansible,IISWebAppDeploy)
     // Note: gulp's CLI replaces commas with spaces, so we split on both.
-    var extensions = String(options.syncVersions).split(/[,\s]+/).map(function (name) {
-        return name.trim();
-    }).filter(Boolean);
+    // Also support --syncVersions all to bump every publishable extension.
+    var requested = String(options.syncVersions).trim();
+    /** @type {string[]} */
+    var extensions = [];
+    if (requested.toLowerCase() === 'all') {
+        extensions = discoverPublishableExtensions();
+    } else {
+        extensions = String(options.syncVersions).split(/[,\s]+/).map(function (name) {
+            return name.trim();
+        }).filter(Boolean);
+    }
 
     if (extensions.length === 0) {
         cb();


### PR DESCRIPTION
**Description**: This PR adds support for `--syncVersions all` when running the repo build flow. Previously, `--syncVersions` only accepted specific extension names or comma-separated extension lists, which required manual enumeration for multi-extension version bumps. The update extends the logic in `gulpfile.js` to detect the `all` case and resolve every publishable extension under `Extensions/` before invoking the version-bump script. The README is also updated to document the new usage.

**Documentation changes required:** Y

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
