### PR TITLE
Validate artifact download item paths resolve within the download directory

### DIFF
--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.28",
+  "version": "0.279.32",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.37",
+  "version": "0.279.38",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.32",
+  "version": "0.279.36",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.38",
+  "version": "0.279.39",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.36",
+  "version": "0.279.37",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/ArtifactEngine/Providers/filesystemProvider.ts
+++ b/Extensions/ArtifactEngine/Providers/filesystemProvider.ts
@@ -52,7 +52,23 @@ export class FilesystemProvider implements models.IArtifactProvider {
 
     public putArtifactItem(item: models.ArtifactItem, stream: NodeJS.ReadableStream): Promise<models.ArtifactItem> {
         return new Promise((resolve, reject) => {
-            const outputItemPath = path.join(this._rootLocation, item.path);
+            let outputItemPath: string;
+            if (!tl.getPipelineFeature("EnableArtifactEnginePathValidation")) {
+                outputItemPath = path.join(this._rootLocation, item.path);
+            }
+            else {
+                // Feature on: reject item paths that resolve outside the download root.
+                const resolvedRoot: string = path.resolve(this._rootLocation);
+                const resolvedTarget: string = path.resolve(resolvedRoot, item.path);
+                const relative: string = path.relative(resolvedRoot, resolvedTarget);
+                if (relative === '..'
+                    || relative.startsWith('..' + path.sep)
+                    || path.isAbsolute(relative)) {
+                    reject(new Error(tl.loc("InvalidArtifactPath", item.path)));
+                    return;
+                }
+                outputItemPath = resolvedTarget;
+            }
 
             if (item.itemType === models.ItemType.File) {
                 const folder = path.dirname(outputItemPath);

--- a/Extensions/ArtifactEngine/ProvidersTests/filesystemProviderTests.ts
+++ b/Extensions/ArtifactEngine/ProvidersTests/filesystemProviderTests.ts
@@ -8,21 +8,24 @@ import * as assert from 'assert';
 
 import * as models from '../Models';
 
+var createWriteStreamSpy = sinon.spy((filePath) => {
+    var mockedStream = stream.Writable();
+    mockedStream._write = (data, encoding, callback) => { callback(); };
+    return mockedStream;
+});
+
 libMocker.registerMock('fs', {
     statSync: () => {
         return {
             isDirectory: () => true
         }
     },
-    createWriteStream: (a) => {
-        var mockedStream = stream.Writable();
-        mockedStream._write = (data, encoding, callback) => { callback(); };
-        return mockedStream;
-    },
+    createWriteStream: createWriteStreamSpy,
     existsSync: () => true,
     readFile: (filename, encoding, callback) => {
         callback(undefined, "{}");
-    }
+    },
+    writeFileSync: () => { }
 });
 libMocker.enable({
     warnOnReplace: false,
@@ -41,6 +44,8 @@ describe('Unit Tests', () => {
         let stub;
 
         before(() => {
+            tl.setResourcePath(path.join(__dirname, '..', 'lib.json'));
+            process.env['DISTRIBUTEDTASK_TASKS_ENABLEARTIFACTENGINEPATHVALIDATION'] = 'true';
             stub = sinon.stub(tl, "mkdirP");
 
             localFileProvider = new providers.FilesystemProvider("c:\\drop");
@@ -89,9 +94,158 @@ describe('Unit Tests', () => {
             });
         });
 
+        function makeReadable(content) {
+            const s = new stream.Readable();
+            s._read = () => { };
+            s.push(content);
+            s.push(null);
+            return s;
+        }
+
+        // 1. Parent-relative paths (POSIX separators) are rejected on every platform.
+        it('putArtifactItem should reject parent-relative paths on all platforms', () => {
+            const outOfRootPaths = ['../outside.txt', 'folder/../../outside.txt', 'a/b/../../../outside.txt'];
+
+            return Promise.all(outOfRootPaths.map((itemPath) => {
+                const artifactItem = { fileLength: 0, itemType: models.ItemType.File, path: itemPath, contentType: undefined, lastModified: null, metadata: null };
+                return assert.rejects(
+                    localFileProvider.putArtifactItem(artifactItem, null),
+                    /outside the download directory/);
+            }));
+        });
+
+        // 1. A backslash is a separator only on Windows, so these reject only there.
+        it('putArtifactItem should reject backslash parent-relative paths on win32', function () {
+            if (process.platform !== 'win32') { this.skip(); }
+            const outOfRootPaths = ['..\\outside.txt', 'folder\\..\\..\\outside.txt'];
+
+            return Promise.all(outOfRootPaths.map((itemPath) => {
+                const artifactItem = { fileLength: 0, itemType: models.ItemType.File, path: itemPath, contentType: undefined, lastModified: null, metadata: null };
+                return assert.rejects(
+                    localFileProvider.putArtifactItem(artifactItem, null),
+                    /outside the download directory/);
+            }));
+        });
+
+        // 2. Native absolute item paths point outside the root and must reject.
+        it('putArtifactItem should reject native absolute item paths', function () {
+            const absolutePaths = process.platform === 'win32'
+                ? ['C:\\outside.txt', '\\\\server\\share\\x']
+                : ['/outside.txt'];
+
+            return Promise.all(absolutePaths.map((itemPath) => {
+                const artifactItem = { fileLength: 0, itemType: models.ItemType.File, path: itemPath, contentType: undefined, lastModified: null, metadata: null };
+                return assert.rejects(
+                    localFileProvider.putArtifactItem(artifactItem, null),
+                    /outside the download directory/);
+            }));
+        });
+
+        // 3. A sibling directory that only shares the root's name prefix is still outside the root.
+        it('putArtifactItem should reject a sibling directory sharing the root name prefix', () => {
+            const siblingProvider = new providers.FilesystemProvider("drop");
+            siblingProvider.artifactItemStore = new ArtifactItemStore();
+            const artifactItem = { fileLength: 0, itemType: models.ItemType.File, path: '../drop2/other.txt', contentType: undefined, lastModified: null, metadata: null };
+
+            return assert.rejects(
+                siblingProvider.putArtifactItem(artifactItem, null),
+                /outside the download directory/);
+        });
+
+        // 4. On POSIX a backslash is a legal filename character, so '..\\..\\outside.txt' is a
+        //    SINGLE filename that stays inside the root. This proves the validation relies on
+        //    native path semantics instead of folding '\\' into '/'.
+        it('putArtifactItem should treat a literal-backslash name as one in-root file on POSIX', function () {
+            if (process.platform === 'win32') { this.skip(); }
+
+            const root = '/drop';
+            const posixProvider = new providers.FilesystemProvider(root);
+            posixProvider.artifactItemStore = new ArtifactItemStore();
+            const itemPath = '..\\..\\outside.txt';
+            const expected = path.resolve(root, itemPath);
+            const artifactItem = { fileLength: 0, itemType: models.ItemType.File, path: itemPath, contentType: undefined, lastModified: null, metadata: null };
+
+            return posixProvider.putArtifactItem(artifactItem, makeReadable('stub content')).then((processedItem) => {
+                assert.strictEqual(createWriteStreamSpy.lastCall.args[0], expected, `createWriteStream should receive ${expected}`);
+                assert(expected.startsWith(path.resolve(root)), 'resolved target must stay within the root');
+                assert.strictEqual(processedItem.metadata[models.Constants.DestinationUrlKey], expected);
+            });
+        });
+
+        // 5. Both the File and Folder branches must reject an out-of-root path.
+        it('putArtifactItem should reject an out-of-root path for both File and Folder items', () => {
+            const fileItem = { fileLength: 0, itemType: models.ItemType.File, path: '../outside.txt', contentType: undefined, lastModified: null, metadata: null };
+            const folderItem = { fileLength: 0, itemType: models.ItemType.Folder, path: '../outside', contentType: undefined, lastModified: null, metadata: null };
+
+            return Promise.all([
+                assert.rejects(localFileProvider.putArtifactItem(fileItem, null), /outside the download directory/),
+                assert.rejects(localFileProvider.putArtifactItem(folderItem, null), /outside the download directory/)
+            ]);
+        });
+
+        // 6. Rejection must happen before any filesystem side effect (no mkdirP, no write stream).
+        it('putArtifactItem should not mkdir or open a write stream for rejected paths', async () => {
+            const writeCallsBefore = createWriteStreamSpy.callCount;
+            stub.resetHistory();
+
+            const fileItem = { fileLength: 0, itemType: models.ItemType.File, path: '../outside.txt', contentType: undefined, lastModified: null, metadata: null };
+            await assert.rejects(localFileProvider.putArtifactItem(fileItem, null), /outside the download directory/);
+
+            const folderItem = { fileLength: 0, itemType: models.ItemType.Folder, path: '../outside', contentType: undefined, lastModified: null, metadata: null };
+            await assert.rejects(localFileProvider.putArtifactItem(folderItem, null), /outside the download directory/);
+
+            assert(stub.notCalled, 'mkdirP must not run for rejected paths');
+            assert.strictEqual(createWriteStreamSpy.callCount, writeCallsBefore, 'createWriteStream must not run for rejected paths');
+        });
+
+        // 7. Paths that resolve to the root itself (relative === '') are allowed.
+        it('putArtifactItem should allow folder items that resolve to the root itself', () => {
+            stub.resetHistory();
+            const resolvedRoot = path.resolve("c:\\drop");
+
+            return Promise.all(['', '.'].map((itemPath) => {
+                const artifactItem = { fileLength: 0, itemType: models.ItemType.Folder, path: itemPath, contentType: undefined, lastModified: null, metadata: null };
+                return localFileProvider.putArtifactItem(artifactItem, null).then((processedItem) => {
+                    assert.strictEqual(processedItem, artifactItem);
+                    assert(stub.calledWith(resolvedRoot), `mkdirP should be called with ${resolvedRoot}`);
+                });
+            }));
+        });
+
+        // 8. A valid nested file must be written to the exact validated (resolved) path. This would
+        //    fail against the old bug where the validated path and the written path diverged.
+        it('putArtifactItem should write a nested file to the validated resolved path', () => {
+            const itemPath = 'drop/sub/file.txt';
+            const expected = path.resolve("c:\\drop", itemPath);
+            const artifactItem = { fileLength: 0, itemType: models.ItemType.File, path: itemPath, contentType: undefined, lastModified: null, metadata: null };
+
+            return localFileProvider.putArtifactItem(artifactItem, makeReadable('stub content')).then((processedItem) => {
+                assert.strictEqual(createWriteStreamSpy.lastCall.args[0], expected, `createWriteStream should receive ${expected}`);
+                assert.strictEqual(processedItem.metadata[models.Constants.DestinationUrlKey], expected);
+            });
+        });
+
+        // Feature off: the gate preserves the original path composition (no validation).
+        it('putArtifactItem should preserve original path composition when the feature is disabled', () => {
+            const ffKey = 'DISTRIBUTEDTASK_TASKS_ENABLEARTIFACTENGINEPATHVALIDATION';
+            const previous = process.env[ffKey];
+            delete process.env[ffKey];
+            const restore = () => { if (previous === undefined) { delete process.env[ffKey]; } else { process.env[ffKey] = previous; } };
+
+            const itemPath = '../outside.txt';
+            const artifactItem = { fileLength: 0, itemType: models.ItemType.File, path: itemPath, contentType: undefined, lastModified: null, metadata: null };
+
+            return localFileProvider.putArtifactItem(artifactItem, makeReadable('stub content'))
+                .then((processedItem) => {
+                    assert.strictEqual(processedItem.metadata[models.Constants.DestinationUrlKey], path.join("c:\\drop", itemPath));
+                })
+                .finally(restore);
+        });
+
         after(() => {
             tl.mkdirP.restore();
             libMocker.deregisterAll();
+            delete process.env['DISTRIBUTEDTASK_TASKS_ENABLEARTIFACTENGINEPATHVALIDATION'];
             // Do NOT call libMocker.disable() here. The artifact-engine pipeline
             // started by other tests in this suite is still running asynchronously
             // when this `after` hook fires; its later call to tl.loc() goes

--- a/Extensions/ArtifactEngine/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Extensions/ArtifactEngine/Strings/resources.resjson/de-DE/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "Fehler beim Analysieren des Antworttexts: %s. Erhaltener Fehler: %s",
   "loc.messages.DownloadingTo": "Download von \"%s\" nach \"%s\" wird durchgeführt.",
   "loc.messages.DownloadedTo": "Download von \"%s\" nach \"%s\" wurde durchgeführt.",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "Das Verzeichnis \"%s\" kann nicht gelesen werden. Fehler: %s",
   "loc.messages.RetryingDownload": "Download von \"%s\" wird erneut versucht, Wiederholungsanzahl: %s",
   "loc.messages.SkippingItem": "Die Verarbeitung des Elements \"%s\" wird übersprungen.",

--- a/Extensions/ArtifactEngine/Strings/resources.resjson/en-US/resources.resjson
+++ b/Extensions/ArtifactEngine/Strings/resources.resjson/en-US/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "Failed to parse response body: %s, got error : %s",
   "loc.messages.DownloadingTo": "Downloading %s to %s",
   "loc.messages.DownloadedTo": "Downloaded %s to %s",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "Unable to read directory %s. Error: %s",
   "loc.messages.RetryingDownload": "Retrying download of %s, retry count: %s",
   "loc.messages.SkippingItem": "Skipped processing item %s",

--- a/Extensions/ArtifactEngine/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Extensions/ArtifactEngine/Strings/resources.resjson/es-ES/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "No se pudo analizar el cuerpo de la respuesta: %s. Error: %s",
   "loc.messages.DownloadingTo": "Descargando %s en %s",
   "loc.messages.DownloadedTo": "%s descargado en %s",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "No se puede leer el directorio %s. Error: %s",
   "loc.messages.RetryingDownload": "Reintentando la descarga de %s, número de reintentos: %s",
   "loc.messages.SkippingItem": "Procesamiento de %s omitido",

--- a/Extensions/ArtifactEngine/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Extensions/ArtifactEngine/Strings/resources.resjson/fr-FR/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "Échec d’analyse du corps de la réponse : %s, erreur : %s",
   "loc.messages.DownloadingTo": "Téléchargement de %s à %s",
   "loc.messages.DownloadedTo": "Téléchargé de %s à %s",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "Impossible de lire le répertoire %s. Erreur : %s",
   "loc.messages.RetryingDownload": "Nouvelle tentative de téléchargement de %s, nombre de tentatives : %s",
   "loc.messages.SkippingItem": "Traitement de l’élément ignoré %s",

--- a/Extensions/ArtifactEngine/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Extensions/ArtifactEngine/Strings/resources.resjson/it-IT/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "Non è stato possibile analizzare il corpo della risposta: %s. Errore restituito: %s",
   "loc.messages.DownloadingTo": "Download di %s in %s",
   "loc.messages.DownloadedTo": "%s scaricato in %s",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "Non è possibile leggere la directory %s. Errore: %s",
   "loc.messages.RetryingDownload": "Nuovo tentativo di download di %s. Conteggio dei tentativi: %s",
   "loc.messages.SkippingItem": "Elaborazione dell'elemento %s ignorata",

--- a/Extensions/ArtifactEngine/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Extensions/ArtifactEngine/Strings/resources.resjson/ja-JP/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "応答本文を解析できませんでした: %s、エラー発生: %s",
   "loc.messages.DownloadingTo": "%s を %s へダウンロード中",
   "loc.messages.DownloadedTo": "%s を %s へダウンロード済み",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "ディレクトリ %s を読み取ることができません。エラー: %s",
   "loc.messages.RetryingDownload": "%s のダウンロードを再試行しています。再試行回数: %s",
   "loc.messages.SkippingItem": "項目 %s の処理をスキップしました",

--- a/Extensions/ArtifactEngine/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Extensions/ArtifactEngine/Strings/resources.resjson/ko-KR/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "응답 본문 %s을(를) 구문 분석하지 못했습니다. 오류: %s",
   "loc.messages.DownloadingTo": "%s을(를) %s에 다운로드하는 중",
   "loc.messages.DownloadedTo": "%s을(를) %s에 다운로드함",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "디렉터리 %s을(를) 읽을 수 없습니다. 오류: %s",
   "loc.messages.RetryingDownload": "%s 다운로드를 다시 시도하는 중, 다시 시도 횟수: %s회",
   "loc.messages.SkippingItem": "항목 %s의 처리를 건너뜀",

--- a/Extensions/ArtifactEngine/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Extensions/ArtifactEngine/Strings/resources.resjson/ru-RU/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "Не удалось проанализировать текст ответа: %s. Ошибка: %s",
   "loc.messages.DownloadingTo": "Идет скачивание %s в %s",
   "loc.messages.DownloadedTo": "Скачано %s в %s",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "Не удается считать каталог %s. Ошибка: %s",
   "loc.messages.RetryingDownload": "Повторная попытка скачать %s, всего попыток: %s",
   "loc.messages.SkippingItem": "Пропущена обработка элемента %s",

--- a/Extensions/ArtifactEngine/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Extensions/ArtifactEngine/Strings/resources.resjson/zh-CN/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "未能分析响应正文: %s，显示错误: %s",
   "loc.messages.DownloadingTo": "正在将 %s 下载至 %s",
   "loc.messages.DownloadedTo": "已将 %s 下载至 %s",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "未能读取目录 %s。错误: %s",
   "loc.messages.RetryingDownload": "重新尝试下载 %s，重试计数: %s",
   "loc.messages.SkippingItem": "已跳过处理项目 %s",

--- a/Extensions/ArtifactEngine/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Extensions/ArtifactEngine/Strings/resources.resjson/zh-TW/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "無法剖析回應主體: %s，收到錯誤: %s",
   "loc.messages.DownloadingTo": "正在將 %s 下載到 %s",
   "loc.messages.DownloadedTo": "已將 %s 下載到 %s",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "無法讀取目錄 %s。錯誤: %s",
   "loc.messages.RetryingDownload": "正在重試下載 %s，重試次數: %s",
   "loc.messages.SkippingItem": "已跳過處理項目 %s",

--- a/Extensions/ArtifactEngine/lib.json
+++ b/Extensions/ArtifactEngine/lib.json
@@ -4,6 +4,7 @@
         "FailedToParseResponse": "Failed to parse response body: %s, got error : %s",
         "DownloadingTo": "Downloading %s to %s",
         "DownloadedTo": "Downloaded %s to %s",
+        "InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
         "UnableToReadDirectory": "Unable to read directory %s. Error: %s",
         "RetryingDownload": "Retrying download of %s, retry count: %s",
         "SkippingItem": "Skipped processing item %s",

--- a/Extensions/ArtifactEngine/package-lock.json
+++ b/Extensions/ArtifactEngine/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-engine",
-  "version": "1.278.0",
+  "version": "1.279.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-engine",
-      "version": "1.278.0",
+      "version": "1.279.1",
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.278.0",

--- a/Extensions/ArtifactEngine/package.json
+++ b/Extensions/ArtifactEngine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "1.279.0",
+  "version": "1.279.1",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",

--- a/Extensions/ArtifactEngineV2/Providers/filesystemProvider.ts
+++ b/Extensions/ArtifactEngineV2/Providers/filesystemProvider.ts
@@ -52,7 +52,23 @@ export class FilesystemProvider implements models.IArtifactProvider {
 
     public putArtifactItem(item: models.ArtifactItem, stream: NodeJS.ReadableStream): Promise<models.ArtifactItem> {
         return new Promise((resolve, reject) => {
-            const outputItemPath = path.join(this._rootLocation, item.path);
+            let outputItemPath: string;
+            if (!tl.getPipelineFeature("EnableArtifactEnginePathValidation")) {
+                outputItemPath = path.join(this._rootLocation, item.path);
+            }
+            else {
+                // Feature on: reject item paths that resolve outside the download root.
+                const resolvedRoot: string = path.resolve(this._rootLocation);
+                const resolvedTarget: string = path.resolve(resolvedRoot, item.path);
+                const relative: string = path.relative(resolvedRoot, resolvedTarget);
+                if (relative === '..'
+                    || relative.startsWith('..' + path.sep)
+                    || path.isAbsolute(relative)) {
+                    reject(new Error(tl.loc("InvalidArtifactPath", item.path)));
+                    return;
+                }
+                outputItemPath = resolvedTarget;
+            }
 
             if (item.itemType === models.ItemType.File) {
                 const folder = path.dirname(outputItemPath);

--- a/Extensions/ArtifactEngineV2/ProvidersTests/filesystemProviderTests.ts
+++ b/Extensions/ArtifactEngineV2/ProvidersTests/filesystemProviderTests.ts
@@ -8,21 +8,24 @@ import * as assert from 'assert';
 
 import * as models from '../Models';
 
+var createWriteStreamSpy = sinon.spy((filePath) => {
+    var mockedStream = stream.Writable();
+    mockedStream._write = (data, encoding, callback) => { callback(); };
+    return mockedStream;
+});
+
 libMocker.registerMock('fs', {
     statSync: () => {
         return {
             isDirectory: () => true
         }
     },
-    createWriteStream: (a) => {
-        var mockedStream = stream.Writable();
-        mockedStream._write = (data, encoding, callback) => { callback(); };
-        return mockedStream;
-    },
+    createWriteStream: createWriteStreamSpy,
     existsSync: () => true,
     readFile: (filename, encoding, callback) => {
         callback(undefined, "{}");
-    }
+    },
+    writeFileSync: () => { }
 });
 libMocker.enable({
     warnOnReplace: false,
@@ -41,6 +44,8 @@ describe('Unit Tests', () => {
         let stub;
 
         before(() => {
+            tl.setResourcePath(path.join(__dirname, '..', 'lib.json'));
+            process.env['DISTRIBUTEDTASK_TASKS_ENABLEARTIFACTENGINEPATHVALIDATION'] = 'true';
             stub = sinon.stub(tl, "mkdirP");
 
             localFileProvider = new providers.FilesystemProvider("c:\\drop");
@@ -89,9 +94,158 @@ describe('Unit Tests', () => {
             });
         });
 
+        function makeReadable(content) {
+            const s = new stream.Readable();
+            s._read = () => { };
+            s.push(content);
+            s.push(null);
+            return s;
+        }
+
+        // 1. Parent-relative paths (POSIX separators) are rejected on every platform.
+        it('putArtifactItem should reject parent-relative paths on all platforms', () => {
+            const outOfRootPaths = ['../outside.txt', 'folder/../../outside.txt', 'a/b/../../../outside.txt'];
+
+            return Promise.all(outOfRootPaths.map((itemPath) => {
+                const artifactItem = { fileLength: 0, itemType: models.ItemType.File, path: itemPath, contentType: undefined, lastModified: null, metadata: null };
+                return assert.rejects(
+                    localFileProvider.putArtifactItem(artifactItem, null),
+                    /outside the download directory/);
+            }));
+        });
+
+        // 1. A backslash is a separator only on Windows, so these reject only there.
+        it('putArtifactItem should reject backslash parent-relative paths on win32', function () {
+            if (process.platform !== 'win32') { this.skip(); }
+            const outOfRootPaths = ['..\\outside.txt', 'folder\\..\\..\\outside.txt'];
+
+            return Promise.all(outOfRootPaths.map((itemPath) => {
+                const artifactItem = { fileLength: 0, itemType: models.ItemType.File, path: itemPath, contentType: undefined, lastModified: null, metadata: null };
+                return assert.rejects(
+                    localFileProvider.putArtifactItem(artifactItem, null),
+                    /outside the download directory/);
+            }));
+        });
+
+        // 2. Native absolute item paths point outside the root and must reject.
+        it('putArtifactItem should reject native absolute item paths', function () {
+            const absolutePaths = process.platform === 'win32'
+                ? ['C:\\outside.txt', '\\\\server\\share\\x']
+                : ['/outside.txt'];
+
+            return Promise.all(absolutePaths.map((itemPath) => {
+                const artifactItem = { fileLength: 0, itemType: models.ItemType.File, path: itemPath, contentType: undefined, lastModified: null, metadata: null };
+                return assert.rejects(
+                    localFileProvider.putArtifactItem(artifactItem, null),
+                    /outside the download directory/);
+            }));
+        });
+
+        // 3. A sibling directory that only shares the root's name prefix is still outside the root.
+        it('putArtifactItem should reject a sibling directory sharing the root name prefix', () => {
+            const siblingProvider = new providers.FilesystemProvider("drop");
+            siblingProvider.artifactItemStore = new ArtifactItemStore();
+            const artifactItem = { fileLength: 0, itemType: models.ItemType.File, path: '../drop2/other.txt', contentType: undefined, lastModified: null, metadata: null };
+
+            return assert.rejects(
+                siblingProvider.putArtifactItem(artifactItem, null),
+                /outside the download directory/);
+        });
+
+        // 4. On POSIX a backslash is a legal filename character, so '..\\..\\outside.txt' is a
+        //    SINGLE filename that stays inside the root. This proves the validation relies on
+        //    native path semantics instead of folding '\\' into '/'.
+        it('putArtifactItem should treat a literal-backslash name as one in-root file on POSIX', function () {
+            if (process.platform === 'win32') { this.skip(); }
+
+            const root = '/drop';
+            const posixProvider = new providers.FilesystemProvider(root);
+            posixProvider.artifactItemStore = new ArtifactItemStore();
+            const itemPath = '..\\..\\outside.txt';
+            const expected = path.resolve(root, itemPath);
+            const artifactItem = { fileLength: 0, itemType: models.ItemType.File, path: itemPath, contentType: undefined, lastModified: null, metadata: null };
+
+            return posixProvider.putArtifactItem(artifactItem, makeReadable('stub content')).then((processedItem) => {
+                assert.strictEqual(createWriteStreamSpy.lastCall.args[0], expected, `createWriteStream should receive ${expected}`);
+                assert(expected.startsWith(path.resolve(root)), 'resolved target must stay within the root');
+                assert.strictEqual(processedItem.metadata[models.Constants.DestinationUrlKey], expected);
+            });
+        });
+
+        // 5. Both the File and Folder branches must reject an out-of-root path.
+        it('putArtifactItem should reject an out-of-root path for both File and Folder items', () => {
+            const fileItem = { fileLength: 0, itemType: models.ItemType.File, path: '../outside.txt', contentType: undefined, lastModified: null, metadata: null };
+            const folderItem = { fileLength: 0, itemType: models.ItemType.Folder, path: '../outside', contentType: undefined, lastModified: null, metadata: null };
+
+            return Promise.all([
+                assert.rejects(localFileProvider.putArtifactItem(fileItem, null), /outside the download directory/),
+                assert.rejects(localFileProvider.putArtifactItem(folderItem, null), /outside the download directory/)
+            ]);
+        });
+
+        // 6. Rejection must happen before any filesystem side effect (no mkdirP, no write stream).
+        it('putArtifactItem should not mkdir or open a write stream for rejected paths', async () => {
+            const writeCallsBefore = createWriteStreamSpy.callCount;
+            stub.resetHistory();
+
+            const fileItem = { fileLength: 0, itemType: models.ItemType.File, path: '../outside.txt', contentType: undefined, lastModified: null, metadata: null };
+            await assert.rejects(localFileProvider.putArtifactItem(fileItem, null), /outside the download directory/);
+
+            const folderItem = { fileLength: 0, itemType: models.ItemType.Folder, path: '../outside', contentType: undefined, lastModified: null, metadata: null };
+            await assert.rejects(localFileProvider.putArtifactItem(folderItem, null), /outside the download directory/);
+
+            assert(stub.notCalled, 'mkdirP must not run for rejected paths');
+            assert.strictEqual(createWriteStreamSpy.callCount, writeCallsBefore, 'createWriteStream must not run for rejected paths');
+        });
+
+        // 7. Paths that resolve to the root itself (relative === '') are allowed.
+        it('putArtifactItem should allow folder items that resolve to the root itself', () => {
+            stub.resetHistory();
+            const resolvedRoot = path.resolve("c:\\drop");
+
+            return Promise.all(['', '.'].map((itemPath) => {
+                const artifactItem = { fileLength: 0, itemType: models.ItemType.Folder, path: itemPath, contentType: undefined, lastModified: null, metadata: null };
+                return localFileProvider.putArtifactItem(artifactItem, null).then((processedItem) => {
+                    assert.strictEqual(processedItem, artifactItem);
+                    assert(stub.calledWith(resolvedRoot), `mkdirP should be called with ${resolvedRoot}`);
+                });
+            }));
+        });
+
+        // 8. A valid nested file must be written to the exact validated (resolved) path. This would
+        //    fail against the old bug where the validated path and the written path diverged.
+        it('putArtifactItem should write a nested file to the validated resolved path', () => {
+            const itemPath = 'drop/sub/file.txt';
+            const expected = path.resolve("c:\\drop", itemPath);
+            const artifactItem = { fileLength: 0, itemType: models.ItemType.File, path: itemPath, contentType: undefined, lastModified: null, metadata: null };
+
+            return localFileProvider.putArtifactItem(artifactItem, makeReadable('stub content')).then((processedItem) => {
+                assert.strictEqual(createWriteStreamSpy.lastCall.args[0], expected, `createWriteStream should receive ${expected}`);
+                assert.strictEqual(processedItem.metadata[models.Constants.DestinationUrlKey], expected);
+            });
+        });
+
+        // Feature off: the gate preserves the original path composition (no validation).
+        it('putArtifactItem should preserve original path composition when the feature is disabled', () => {
+            const ffKey = 'DISTRIBUTEDTASK_TASKS_ENABLEARTIFACTENGINEPATHVALIDATION';
+            const previous = process.env[ffKey];
+            delete process.env[ffKey];
+            const restore = () => { if (previous === undefined) { delete process.env[ffKey]; } else { process.env[ffKey] = previous; } };
+
+            const itemPath = '../outside.txt';
+            const artifactItem = { fileLength: 0, itemType: models.ItemType.File, path: itemPath, contentType: undefined, lastModified: null, metadata: null };
+
+            return localFileProvider.putArtifactItem(artifactItem, makeReadable('stub content'))
+                .then((processedItem) => {
+                    assert.strictEqual(processedItem.metadata[models.Constants.DestinationUrlKey], path.join("c:\\drop", itemPath));
+                })
+                .finally(restore);
+        });
+
         after(() => {
             tl.mkdirP.restore();
             libMocker.deregisterAll();
+            delete process.env['DISTRIBUTEDTASK_TASKS_ENABLEARTIFACTENGINEPATHVALIDATION'];
             // Do NOT call libMocker.disable() here. The artifact-engine pipeline
             // started by other tests in this suite is still running asynchronously
             // when this `after` hook fires; its later call to tl.loc() goes

--- a/Extensions/ArtifactEngineV2/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Extensions/ArtifactEngineV2/Strings/resources.resjson/de-DE/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "Fehler beim Analysieren des Antworttexts: %s. Erhaltener Fehler: %s",
   "loc.messages.DownloadingTo": "Download von \"%s\" nach \"%s\" wird durchgeführt.",
   "loc.messages.DownloadedTo": "Download von \"%s\" nach \"%s\" wurde durchgeführt.",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "Das Verzeichnis \"%s\" kann nicht gelesen werden. Fehler: %s",
   "loc.messages.RetryingDownload": "Download von \"%s\" wird erneut versucht, Wiederholungsanzahl: %s",
   "loc.messages.SkippingItem": "Die Verarbeitung des Elements \"%s\" wird übersprungen.",

--- a/Extensions/ArtifactEngineV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Extensions/ArtifactEngineV2/Strings/resources.resjson/en-US/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "Failed to parse response body: %s, got error : %s",
   "loc.messages.DownloadingTo": "Downloading %s to %s",
   "loc.messages.DownloadedTo": "Downloaded %s to %s",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "Unable to read directory %s. Error: %s",
   "loc.messages.RetryingDownload": "Retrying download of %s, retry count: %s",
   "loc.messages.SkippingItem": "Skipped processing item %s",

--- a/Extensions/ArtifactEngineV2/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Extensions/ArtifactEngineV2/Strings/resources.resjson/es-ES/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "No se pudo analizar el cuerpo de la respuesta: %s. Error: %s",
   "loc.messages.DownloadingTo": "Descargando %s en %s",
   "loc.messages.DownloadedTo": "%s descargado en %s",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "No se puede leer el directorio %s. Error: %s",
   "loc.messages.RetryingDownload": "Reintentando la descarga de %s, número de reintentos: %s",
   "loc.messages.SkippingItem": "Procesamiento de %s omitido",

--- a/Extensions/ArtifactEngineV2/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Extensions/ArtifactEngineV2/Strings/resources.resjson/fr-FR/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "Échec d’analyse du corps de la réponse : %s, erreur : %s",
   "loc.messages.DownloadingTo": "Téléchargement de %s à %s",
   "loc.messages.DownloadedTo": "Téléchargé de %s à %s",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "Impossible de lire le répertoire %s. Erreur : %s",
   "loc.messages.RetryingDownload": "Nouvelle tentative de téléchargement de %s, nombre de tentatives : %s",
   "loc.messages.SkippingItem": "Traitement de l’élément ignoré %s",

--- a/Extensions/ArtifactEngineV2/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Extensions/ArtifactEngineV2/Strings/resources.resjson/it-IT/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "Non è stato possibile analizzare il corpo della risposta: %s. Errore restituito: %s",
   "loc.messages.DownloadingTo": "Download di %s in %s",
   "loc.messages.DownloadedTo": "%s scaricato in %s",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "Non è possibile leggere la directory %s. Errore: %s",
   "loc.messages.RetryingDownload": "Nuovo tentativo di download di %s. Conteggio dei tentativi: %s",
   "loc.messages.SkippingItem": "Elaborazione dell'elemento %s ignorata",

--- a/Extensions/ArtifactEngineV2/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Extensions/ArtifactEngineV2/Strings/resources.resjson/ja-JP/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "応答本文を解析できませんでした: %s、エラー発生: %s",
   "loc.messages.DownloadingTo": "%s を %s へダウンロード中",
   "loc.messages.DownloadedTo": "%s を %s へダウンロード済み",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "ディレクトリ %s を読み取ることができません。エラー: %s",
   "loc.messages.RetryingDownload": "%s のダウンロードを再試行しています。再試行回数: %s",
   "loc.messages.SkippingItem": "項目 %s の処理をスキップしました",

--- a/Extensions/ArtifactEngineV2/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Extensions/ArtifactEngineV2/Strings/resources.resjson/ko-KR/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "응답 본문 %s을(를) 구문 분석하지 못했습니다. 오류: %s",
   "loc.messages.DownloadingTo": "%s을(를) %s에 다운로드하는 중",
   "loc.messages.DownloadedTo": "%s을(를) %s에 다운로드함",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "디렉터리 %s을(를) 읽을 수 없습니다. 오류: %s",
   "loc.messages.RetryingDownload": "%s 다운로드를 다시 시도하는 중, 다시 시도 횟수: %s회",
   "loc.messages.SkippingItem": "항목 %s의 처리를 건너뜀",

--- a/Extensions/ArtifactEngineV2/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Extensions/ArtifactEngineV2/Strings/resources.resjson/ru-RU/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "Не удалось проанализировать текст ответа: %s. Ошибка: %s",
   "loc.messages.DownloadingTo": "Идет скачивание %s в %s",
   "loc.messages.DownloadedTo": "Скачано %s в %s",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "Не удается считать каталог %s. Ошибка: %s",
   "loc.messages.RetryingDownload": "Повторная попытка скачать %s, всего попыток: %s",
   "loc.messages.SkippingItem": "Пропущена обработка элемента %s",

--- a/Extensions/ArtifactEngineV2/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Extensions/ArtifactEngineV2/Strings/resources.resjson/zh-CN/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "未能分析响应正文: %s，显示错误: %s",
   "loc.messages.DownloadingTo": "正在将 %s 下载至 %s",
   "loc.messages.DownloadedTo": "已将 %s 下载至 %s",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "未能读取目录 %s。错误: %s",
   "loc.messages.RetryingDownload": "重新尝试下载 %s，重试计数: %s",
   "loc.messages.SkippingItem": "已跳过处理项目 %s",

--- a/Extensions/ArtifactEngineV2/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Extensions/ArtifactEngineV2/Strings/resources.resjson/zh-TW/resources.resjson
@@ -3,6 +3,7 @@
   "loc.messages.FailedToParseResponse": "無法剖析回應主體: %s，收到錯誤: %s",
   "loc.messages.DownloadingTo": "正在將 %s 下載到 %s",
   "loc.messages.DownloadedTo": "已將 %s 下載到 %s",
+  "loc.messages.InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
   "loc.messages.UnableToReadDirectory": "無法讀取目錄 %s。錯誤: %s",
   "loc.messages.RetryingDownload": "正在重試下載 %s，重試次數: %s",
   "loc.messages.SkippingItem": "已跳過處理項目 %s",

--- a/Extensions/ArtifactEngineV2/lib.json
+++ b/Extensions/ArtifactEngineV2/lib.json
@@ -4,6 +4,7 @@
         "FailedToParseResponse": "Failed to parse response body: %s, got error : %s",
         "DownloadingTo": "Downloading %s to %s",
         "DownloadedTo": "Downloaded %s to %s",
+        "InvalidArtifactPath": "Artifact path %s resolves outside the download directory.",
         "UnableToReadDirectory": "Unable to read directory %s. Error: %s",
         "RetryingDownload": "Retrying download of %s, retry count: %s",
         "SkippingItem": "Skipped processing item %s",

--- a/Extensions/ArtifactEngineV2/package-lock.json
+++ b/Extensions/ArtifactEngineV2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-engine",
-  "version": "2.278.0",
+  "version": "2.279.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-engine",
-      "version": "2.278.0",
+      "version": "2.279.1",
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.278.0",

--- a/Extensions/ArtifactEngineV2/package.json
+++ b/Extensions/ArtifactEngineV2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "2.279.0",
+  "version": "2.279.1",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.42",
+  "version": "15.279.46",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.51",
+  "version": "15.279.52",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.52",
+  "version": "15.279.53",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.53",
+  "version": "15.279.54",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.50",
+  "version": "15.279.51",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.46",
+  "version": "15.279.49",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.39",
+  "version": "16.279.41",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.30",
+  "version": "16.279.35",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.41",
+  "version": "16.279.42",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.35",
+  "version": "16.279.38",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.42",
+  "version": "16.279.43",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.41",
+  "version": "1.279.46",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.53",
+  "version": "1.279.54",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.52",
+  "version": "1.279.53",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.51",
+  "version": "1.279.52",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.46",
+  "version": "1.279.50",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.50",
+  "version": "1.279.51",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.279.32",
+  "version": "4.279.33",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.279.23",
+  "version": "4.279.28",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.279.34",
+  "version": "4.279.35",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.279.33",
+  "version": "4.279.34",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.279.28",
+  "version": "4.279.31",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.41",
+  "version": "15.279.45",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.47",
+  "version": "15.279.48",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.48",
+  "version": "15.279.49",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.45",
+  "version": "15.279.46",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.37",
+  "version": "15.279.41",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.46",
+  "version": "15.279.47",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.36",
+  "version": "15.279.37",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ In order to build and package extensions you will need to install some dependenc
 - Run `npm install -g tfx-cli`
 - Run `npm install -g vsts-npm-auth`
 - Run `vsts-npm-auth -config .npmrc` to setup authentication for npm (might be needed if you need to install packages for certain tasks within an extension))
+   - Sometimes `-force` parameter needs to be used
 
 ### How to Build
 


### PR DESCRIPTION
### What
Adds input validation in the Artifact Engine filesystem provider (v1 and v2). Each downloaded item path is now resolved against the configured download root and rejected if it resolves outside that directory. Paths that resolve within the root — including nested paths and the root itself — are unaffected.

### Why
Makes artifact download path handling more robust and predictable across platforms by relying on native `path.resolve` / `path.relative` semantics (correct separator handling on Windows vs POSIX) instead of manual string manipulation.

### Changes
- `FilesystemProvider` in ArtifactEngine (v1) and ArtifactEngineV2 (v2): validate the resolved output path before creating directories or writing the file.
- Unit tests covering nested paths, the root itself, and paths that resolve outside the root.
- Version bump: `artifact-engine` 1.279.1 / 2.279.1.
- TeamCity extension version bump (repo policy: publishable extensions are versioned when shared Artifact Engine code changes).

### Testing
- `filesystemProviderTests` pass for both majors (11 passing, 1 platform-specific pending).
