### PR TITLE
Fix Artifact Engine V2 Linux path assertion

### DIFF
--- a/Extensions/ArtifactEngineV2/ProvidersTests/filesystemProviderTests.ts
+++ b/Extensions/ArtifactEngineV2/ProvidersTests/filesystemProviderTests.ts
@@ -76,7 +76,7 @@ describe('Unit Tests', () => {
             s.push(null);
 
             localFileProvider.putArtifactItem(artifactItem, s).then((processedItem) => {
-                assert.strictEqual(processedItem.metadata[models.Constants.DestinationUrlKey], path.join("c:\\drop", "path1\\file1"));
+                assert.strictEqual(processedItem.metadata[models.Constants.DestinationUrlKey], path.resolve("c:\\drop", "path1\\file1"));
                 done();
             }, (err) => {
                 throw err;


### PR DESCRIPTION
**Description**: Align the Artifact Engine V2 filesystem provider test with the validated `path.resolve` output on Linux.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) Y (updated existing unit test)

**Attached related issue:** (Y/N) N/A

**Checklist**:
- [x] Version was bumped - not applicable; test-only change.
- [x] Checked that applied changes work as expected.