### PR TITLE
Fix Artifact Engine V2 folder path assertion

### DIFF
--- a/Extensions/ArtifactEngineV2/ProvidersTests/filesystemProviderTests.ts
+++ b/Extensions/ArtifactEngineV2/ProvidersTests/filesystemProviderTests.ts
@@ -87,7 +87,7 @@ describe('Unit Tests', () => {
             var artifactItem = { fileLength: 0, itemType: models.ItemType.Folder, path: "path1\\folder1", lastModified: null, metadata: null };
 
             localFileProvider.putArtifactItem(artifactItem, null).then((processedItem) => {
-                assert(stub.calledWith(path.join("c:\\drop", "path1\\folder1")));
+                assert(stub.calledWith(path.resolve("c:\\drop", "path1\\folder1")));
                 done();
             }, (err) => {
                 throw err;


### PR DESCRIPTION
**Description**: Align the Artifact Engine V2 folder path assertion with the validated `path.resolve` output on Linux.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) Y (updated existing unit test)

**Attached related issue:** (Y/N) N/A

**Checklist**:
- [x] Version was bumped - not applicable; test-only change.
- [x] Checked that applied changes work as expected.