### PR TITLE
Update package dependencies to address vulnerabilities and enhance compatibility

### DIFF
--- a/Extensions/Ansible/Src/vss-extension.json
+++ b/Extensions/Ansible/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-ansible",
   "name": "Ansible",
   "publisher": "ms-vscs-rm",
-  "version": "0.279.43",
+  "version": "0.280.1",
   "public": true,
   "description": "This extension executes an Ansible playbook using a specified inventory via command line interface",
   "_description.comment": "The below format to define extensions is currently in preview and may change in future.",

--- a/Extensions/BitBucket/Src/vss-extension.json
+++ b/Extensions/BitBucket/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-bitbucket",
   "name": "Bitbucket artifacts for Release Management",
   "publisher": "ms-vscs-rm",
-  "version": "15.279.54",
+  "version": "15.280.1",
   "public": true,
   "description": "Tools related to connecting with Bitbucket",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.45",
+  "version": "16.279.46",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.279.46",
+  "version": "16.280.1",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/IISWebAppDeploy/Src/vss-extension.json
+++ b/Extensions/IISWebAppDeploy/Src/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "extensionId": "iiswebapp",
   "name": "IIS Web App Deployment Using WinRM",
-  "version": "1.279.54",
+  "version": "1.280.1",
   "publisher": "ms-vscs-rm",
   "description": "Using WinRM connect to the host Computer, to deploy a Web project using Web Deploy or a SQL DB using sqlpackage.exe.",
   "public": true,

--- a/Extensions/ServiceNow/Src/vss-extension.json
+++ b/Extensions/ServiceNow/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-servicenowchangerequestmanagement",
   "name": "ServiceNow Change Management",
   "publisher": "ms-vscs-rm",
-  "version": "4.279.35",
+  "version": "4.280.1",
   "public": true,
   "description": "Integrate ServiceNow Change Management with Azure Pipelines",
   "categories": [

--- a/Extensions/TeamCity/Src/vss-extension.json
+++ b/Extensions/TeamCity/Src/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "vss-services-teamcity",
   "name": "TeamCity artifacts for Release Management",
   "publisher": "ms-devlabs",
-  "version": "15.279.49",
+  "version": "15.280.1",
   "public": true,
   "description": "Tools related to connecting with TeamCity",
   "_description.comment": "The below format to define artifact extensions is currently in preview and may change in future.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@types/adm-zip": "^0.4.34",
         "@types/gulp": "^4.0.17",
+        "@types/mocha": "^10.0.10",
         "@types/node": "^20.19.41",
         "@types/shelljs": "^0.8.17",
         "@types/through2": "^2.0.41",
@@ -169,6 +170,13 @@
         "@types/vinyl-fs": "*",
         "chokidar": "^3.3.1"
       }
+    },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha1-kfYpBejSPL1mIlMS8jlFSiO+v6A=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.19.43",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "devDependencies": {
         "@types/adm-zip": "^0.4.34",
         "@types/gulp": "^4.0.17",
-        "@types/gulp-mocha": "^0.0.37",
         "@types/node": "^20.19.41",
         "@types/shelljs": "^0.8.17",
         "@types/through2": "^2.0.41",
@@ -21,9 +20,9 @@
         "azure-pipelines-task-lib": "5.278.0",
         "gulp": "^5.0.1",
         "gulp-cli": "^3.0.0",
-        "gulp-mocha": "^10.0.1",
         "gulp-typescript": "^5.0.1",
         "minimatch": "3.1.5",
+        "mocha": "^11.7.5",
         "shelljs": "^0.10.0",
         "sync-request": "3.0.1",
         "tfx-cli": "^0.21.1",
@@ -118,6 +117,17 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha1-p36nQvqyV3UUVDTrHSMoz1ATrDM=",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@types/adm-zip": {
       "version": "0.4.34",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/adm-zip/-/adm-zip-0.4.34.tgz",
@@ -159,24 +169,6 @@
         "@types/vinyl-fs": "*",
         "chokidar": "^3.3.1"
       }
-    },
-    "node_modules/@types/gulp-mocha": {
-      "version": "0.0.37",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/gulp-mocha/-/gulp-mocha-0.0.37.tgz",
-      "integrity": "sha1-OMXFpYALR5cKEemD92AmhtSma1Q=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mocha": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/mocha": {
-      "version": "10.0.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/mocha/-/mocha-10.0.10.tgz",
-      "integrity": "sha1-kfYpBejSPL1mIlMS8jlFSiO+v6A=",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.19.43",
@@ -1281,19 +1273,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/dargs": {
-      "version": "8.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/dargs/-/dargs-8.1.0.tgz",
-      "integrity": "sha1-o0hZ6lCcvORUheWqNW/vcL/McnI=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -1453,9 +1432,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/diff/-/diff-5.2.2.tgz",
-      "integrity": "sha1-CkdCeXKB0Jz6aZt56jLSdyNiO60=",
+      "version": "8.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha1-T1uvMYi5skMRF7li6yC6Mw+t9pY=",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -1504,18 +1483,12 @@
         "node": ">= 10.13.0"
       }
     },
-    "node_modules/easy-transform-stream": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/easy-transform-stream/-/easy-transform-stream-1.0.1.tgz",
-      "integrity": "sha1-+v/dGDmgPRTXbmlL0uYxVVGmohU=",
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s=",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2492,78 +2465,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/gulp-mocha": {
-      "version": "10.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/gulp-mocha/-/gulp-mocha-10.0.1.tgz",
-      "integrity": "sha1-uNmVn0J4tjtAZKPXCS0r/nY+vJs=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dargs": "^8.1.0",
-        "execa": "^8.0.1",
-        "gulp-plugin-extras": "^0.3.0",
-        "mocha": "^10.2.0",
-        "supports-color": "^9.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      },
-      "peerDependencies": {
-        "gulp": ">=4"
-      },
-      "peerDependenciesMeta": {
-        "gulp": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/gulp-mocha/node_modules/supports-color": {
-      "version": "9.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-color/-/supports-color-9.4.0.tgz",
-      "integrity": "sha1-F7/PaGKI9THbPeoyFVEGIcy1WVQ=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/gulp-plugin-extras": {
-      "version": "0.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/gulp-plugin-extras/-/gulp-plugin-extras-0.3.0.tgz",
-      "integrity": "sha1-rSwV631xU6dVVsWe6B2EaT7EIzA=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/vinyl": "^2.0.9",
-        "chalk": "^5.3.0",
-        "easy-transform-stream": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/gulp-plugin-extras/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha1-sSOLbiPqM3r3HH+KKV21rwwViuo=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/gulp-typescript": {
       "version": "5.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/gulp-typescript/-/gulp-typescript-5.0.1.tgz",
@@ -3484,6 +3385,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha1-0jE2LlOgf/Kw4Op/7QSRYf/RYoM=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -4147,31 +4058,32 @@
       }
     },
     "node_modules/mocha": {
-      "version": "10.8.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mocha/-/mocha-10.8.2.tgz",
-      "integrity": "sha1-jYNC0BbtQRsSpCnrcxuCX5Ya+5Y=",
+      "version": "11.8.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mocha/-/mocha-11.8.0.tgz",
+      "integrity": "sha1-kWPMWWAOwmRw9rBA4wqlGsyXPtI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-colors": "^4.1.3",
         "browser-stdout": "^1.3.1",
-        "chokidar": "^3.5.3",
+        "chokidar": "^4.0.1",
         "debug": "^4.3.5",
-        "diff": "^5.2.0",
+        "diff": "^7.0.0",
         "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
-        "glob": "^8.1.0",
+        "glob": "^10.4.5",
         "he": "^1.2.0",
+        "is-path-inside": "^3.0.3",
         "js-yaml": "^4.1.0",
         "log-symbols": "^4.1.0",
-        "minimatch": "^5.1.6",
+        "minimatch": "^9.0.5",
         "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
         "serialize-javascript": "^6.0.2",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
-        "workerpool": "^6.5.1",
-        "yargs": "^16.2.0",
-        "yargs-parser": "^20.2.9",
+        "workerpool": "^9.2.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1",
         "yargs-unparser": "^2.0.0"
       },
       "bin": {
@@ -4179,17 +4091,69 @@
         "mocha": "bin/mocha.js"
       },
       "engines": {
-        "node": ">= 14.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/mocha/node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha1-N2ETQOsiQ+cMxgTK011jJw1IeBs=",
+    "node_modules/mocha/node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha1-s3Znt7wYHBaHgiWbq0JHT79StVA=",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mocha/node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha1-FPja7G2B5yIdKjV+Zoyrc728p5Q=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha1-JHyOe3ChpDsQzhTAIm/L9Y6IFdU=",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/mocha/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha1-wETV3MUhoHZBNHJZehrLHxA8QEE=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
@@ -4202,38 +4166,206 @@
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/mocha/node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha1-04j2Vlk+9wjuPjRkD9+5mp/Rwz4=",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+    "node_modules/mocha/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha1-e+N6TAPJruHs/oYqSiOyxwwgXTA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/mocha/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha1-DASwddsCy/5g3I5s8vVIaxo2CKo=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/mocha/node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mocha/node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/mocha/node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mocha/node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/mocha/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha1-hAyIA7DYBH9P8M+WMXazLU7z7XI=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha1-jsA1WRnNMzjChCiiPU8k7MX+c4w=",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mocha/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha1-iDOp2Jq0rN5hiJQr0cU7Y5DtWoo=",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/mocha/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha1-QQ/IoXtw5ZgBPfJXwkRrfzOD8Rk=",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha1-EpPvFdsAmLOUVA6Pn3RPn9qN7ks=",
+      "version": "9.0.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha1-mwy5/LeAh/b9fqur4lEcTT1gV04=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha1-eWCmaIiFlKByCxKpEdGnQqufEdI=",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha1-64WAFDX78qfuWPGeCSGwaPxplI0=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/mocha/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha1-0iomlSKDamJ6+NBLXD/Sx/o+MuM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/mocha/node_modules/supports-color": {
@@ -4250,6 +4382,71 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/mocha/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha1-VtwiNo7lcPrOG0mBmXXZuaXq0hQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/mocha/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha1-FPja7G2B5yIdKjV+Zoyrc728p5Q=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha1-d53/5ryv7FlqcXLpgyiaWIZH+qo=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mocha/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha1-kJa87r+ZDSG7MfqVFuDt4pSnfTU=",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ms": {
@@ -4663,6 +4860,13 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s=",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
@@ -5216,9 +5420,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
-      "integrity": "sha1-BuxAV21M6pbWgBClNFIL/x+UinI=",
+      "version": "7.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
+      "integrity": "sha1-nkYsXG3sXbyLVdkMUqStav+YW58=",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -5628,6 +5832,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.11",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
@@ -5689,6 +5909,20 @@
       }
     },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
@@ -6373,14 +6607,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "11.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha1-9tgdLhxl0Adi5eKbFsXS2ZXiCK0=",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8flags": {
@@ -6777,13 +7014,32 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "6.5.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/workerpool/-/workerpool-6.5.1.tgz",
-      "integrity": "sha1-Bg9zs50Mr5fG22TaAEzQG0wJlUQ=",
+      "version": "9.3.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/workerpool/-/workerpool-9.3.4.tgz",
+      "integrity": "sha1-9skjlbIUGv144qiJ6AyzOP6fykE=",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "gulp-cli": "^3.0.0",
     "tfx-cli": "^0.21.1",
     "@types/gulp": "^4.0.17",
-    "@types/gulp-mocha": "^0.0.37",
     "@types/node": "^20.19.41",
     "@types/shelljs": "^0.8.17",
     "@types/through2": "^2.0.41",
@@ -30,9 +29,9 @@
     "adm-zip": "0.6.0",
     "azure-pipelines-task-lib": "5.278.0",
     "gulp": "^5.0.1",
-    "gulp-mocha": "^10.0.1",
     "gulp-typescript": "^5.0.1",
     "minimatch": "3.1.5",
+    "mocha": "^11.7.5",
     "shelljs": "^0.10.0",
     "sync-request": "3.0.1",
     "through2": "^2.0.1",
@@ -41,17 +40,12 @@
     "xml2js": "^0.6.2"
   },
   "overrides": {
-    "picomatch": "2.3.2",
-    "qs": "^6.14.2",
-    "serialize-javascript": "^7.0.5",
-    "mocha@5.2.0": {
-      "minimatch": "3.1.5"
+    "tfx-cli": {
+      "uuid": "11.1.1"
     },
-    "mkdirp@0.5.1": {
-      "minimist": "0.2.4"
-    },
-    "gulp-typescript": {
-      "braces": "3.0.3"
+    "mocha": {
+      "diff": "8.0.4",
+      "serialize-javascript": "7.1.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gulp-cli": "^3.0.0",
     "tfx-cli": "^0.21.1",
     "@types/gulp": "^4.0.17",
+    "@types/mocha": "^10.0.10",
     "@types/node": "^20.19.41",
     "@types/shelljs": "^0.8.17",
     "@types/through2": "^2.0.41",


### PR DESCRIPTION
**Description**:
- Replaced `gulp-mocha` with `mocha` 11.7.5 and updated the Mocha type definitions.
- Updated root dependency resolutions to address vulnerable transitive packages, including `uuid`.
- Bumped extension versions for Ansible, BitBucket, ExternalTfs, IIS Web App Deploy, ServiceNow, and TeamCity.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [ ] Checked that applied changes work as expected.
