### PR TITLE
Fix Windows artifact path matching

### DIFF
--- a/Extensions/ArtifactEngineV2/Engine/artifactEngine.ts
+++ b/Extensions/ArtifactEngineV2/Engine/artifactEngine.ts
@@ -83,13 +83,15 @@ export class ArtifactEngine {
         retryCount = retryCount ? retryCount : 0;
         if (item.itemType === models.ItemType.File) {
             var pathToMatch = item.path.replace(/\\/g, '/');
+            var isCaseInsensitiveArtifactMatchingFixEnabled =
+                tl.getPipelineFeature('CaseInsensitiveArtifactMatchingFixEnabled');
             var matchOptions = {
                 debug: false,
                 nobrace: true,
                 noglobstar: false,
                 dot: true,
                 noext: false,
-                nocase: false,
+                nocase: process.platform === 'win32' && isCaseInsensitiveArtifactMatchingFixEnabled,
                 nonull: false,
                 matchBase: false,
                 nocomment: false,

--- a/Extensions/ArtifactEngineV2/EngineTests/artifactEngineTests.ts
+++ b/Extensions/ArtifactEngineV2/EngineTests/artifactEngineTests.ts
@@ -134,6 +134,44 @@ describe('Unit Tests', () => {
                 });
         });
 
+        it('processItems should preserve case-sensitive matching when the feature is disabled', (done) => {
+            var testProvider = new providers.StubProvider();
+            var downloadOptions = new engine.ArtifactEngineOptions();
+            downloadOptions.itemPattern = 'path1/**\n!PATH1/PATH2/**';
+
+            new engine.ArtifactEngine()
+                .processItems(testProvider, testProvider, downloadOptions)
+                .then(() => {
+                    assert.strictEqual(testProvider.getArtifactItemCalledCount, 3);
+                    done();
+                }, (err) => {
+                    throw err;
+                });
+        });
+
+        runWindowsBasedTest('processItems should match case-insensitively when the feature is enabled', async () => {
+            var testProvider = new providers.StubProvider();
+            var downloadOptions = new engine.ArtifactEngineOptions();
+            downloadOptions.itemPattern = 'path1/**\n!PATH1/PATH2/**';
+            const featureEnvironmentVariable =
+                'DISTRIBUTEDTASK_TASKS_CASEINSENSITIVEARTIFACTMATCHINGFIXENABLED';
+            var originalValue = process.env[featureEnvironmentVariable];
+            process.env[featureEnvironmentVariable] = 'true';
+
+            try {
+                await new engine.ArtifactEngine().processItems(testProvider, testProvider, downloadOptions);
+                assert.strictEqual(testProvider.getArtifactItemCalledCount, 2);
+            }
+            finally {
+                if (originalValue === undefined) {
+                    delete process.env[featureEnvironmentVariable];
+                }
+                else {
+                    process.env[featureEnvironmentVariable] = originalValue;
+                }
+            }
+        });
+
         it('processItems should call getArtifactItem only for included artifact items prefering exclude over include pattern', (done) => {
             var testProvider = new providers.StubProvider();
             var downloadOptions = new engine.ArtifactEngineOptions();

--- a/Extensions/ArtifactEngineV2/package-lock.json
+++ b/Extensions/ArtifactEngineV2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-engine",
-  "version": "2.279.1",
+  "version": "2.279.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-engine",
-      "version": "2.279.1",
+      "version": "2.279.2",
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.278.0",

--- a/Extensions/ArtifactEngineV2/package.json
+++ b/Extensions/ArtifactEngineV2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "2.279.1",
+  "version": "2.279.2",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Context
Align Windows artifact exclusion matching with Windows path behavior.

### Description
Adds controlled, Windows-only case-insensitive artifact matching to ArtifactEngineV2 when enabled through Feature Availability.

### Risk Assessment
Low. The existing behavior remains active unless the flag is enabled, and non-Windows behavior is unchanged.

### Unit Tests Added or Updated
Yes.

### Additional Testing Performed
Ran the ArtifactEngineV2 build and regression suite.

### Change Behind Feature Flag
Yes. `DistributedTask.Tasks.CaseInsensitiveArtifactMatchingFixEnabled`.

### Tech Design / Approach
Read the runtime pipeline feature only when constructing artifact minimatch options. Enable `nocase` only on Windows and only when the flag is true.

### Documentation Changes Required
No.

### Logging Added/Updated
No. No new path or pattern logging is added.

### Telemetry Added/Updated
No. Rollout monitoring uses aggregate task reliability signals.

### Rollback Scenario and Process
Yes. Disable `DistributedTask.Tasks.CaseInsensitiveArtifactMatchingFixEnabled`.

### Dependency Impact Assessed and Regression Tested
Yes. ArtifactEngineV2 version is bumped to `2.279.2`; tests cover default-off and Windows-enabled behavior.