### PR TITLE
Refactor gulp tasks to use async/await and improve TypeScript compilation output handling

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@ const cp = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { finished } = require('node:stream/promises');
 const { parseArgs } = require('node:util');
 
 // build/test script
@@ -93,7 +94,7 @@ gulp.task("compilePS", gulp.series("clean", function () {
     }
 }));
 
-gulp.task("compileNode", gulp.series("compilePS", function (cb) {
+gulp.task("compileNode", gulp.series("compilePS", async function () {
     try {
         // Cache all externals in the download directory.
         // Cache all externals in the download directory.
@@ -194,7 +195,7 @@ gulp.task("compileNode", gulp.series("compilePS", function (cb) {
 
     const testFiles = path.join(_extnBuildRoot, "**/Tests/**/*.ts");
 
-    gulp.src([taskFiles, `!${testFiles}`, artifactEngineFiles, artifactEngineV2Files, '!**/node_modules/**'], { base: _extnBuildRoot })
+    const taskCompilation = gulp.src([taskFiles, `!${testFiles}`, artifactEngineFiles, artifactEngineV2Files, '!**/node_modules/**'], { base: _extnBuildRoot })
         .pipe(tasksProject())
         .pipe(gulp.dest(path.join(_buildRoot, "Extensions")))
         .on("error", errorHandler);
@@ -202,7 +203,7 @@ gulp.task("compileNode", gulp.series("compilePS", function (cb) {
     const testProject = gts.createProject(rootTsconfigPath, { typescript: typescript, declaration: true });
     const sanitizerTestFiles = path.join(_extnBuildRoot, "**/ps_modules/Sanitizer/Tests/*.ts");
 
-    gulp.src([testFiles, `!${sanitizerTestFiles}`], { base: _extnBuildRoot })
+    const testCompilation = gulp.src([testFiles, `!${sanitizerTestFiles}`], { base: _extnBuildRoot })
         .pipe(testProject())
         .pipe(gulp.dest(path.join(_buildRoot, "Extensions")))
         .on("error", errorHandler);
@@ -211,8 +212,8 @@ gulp.task("compileNode", gulp.series("compilePS", function (cb) {
     validateArtifactEngineV2TranspileErrors();
 
     // Generate loc files
-    createResjson(cb);
-    cb();
+    createResjson(() => { });
+    await Promise.all([finished(taskCompilation), finished(testCompilation)]);
 }));
 
 function validateArtifactEngineTranspileErrors() {
@@ -668,7 +669,7 @@ gulp.task("tscBuildTasks", function (cb) {
 
             try {
                 pkgm.installDependencies(taskPath, path.basename(taskPath));
-                cp.execFileSync(process.execPath, [tscCliPath, '-p', configPath], { stdio: util.isDebug() ? 'inherit' : 'ignore' });
+                cp.execFileSync(process.execPath, [tscCliPath, '-p', configPath], { stdio: 'inherit' });
             } catch (err) {
                 console.error(`TypeScript compilation failed for ${configPath}: ${err.message}`);
                 console.error(`Execute manually the command:\nnpx tsc -p ${configPath}`);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -167,8 +167,7 @@ gulp.task("compileNode", gulp.series("compilePS", async function () {
             });
     } catch (err) {
         console.log('error:' + err.message);
-        cb(new Error('compileTasks: ' + err.message));
-        return;
+        throw new Error('compileTasks: ' + err.message);
     }
 
     // Compile UIExtensions

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -212,7 +212,10 @@ gulp.task("compileNode", gulp.series("compilePS", async function () {
 
     // Generate loc files
     createResjson(() => { });
-    await Promise.all([finished(taskCompilation), finished(testCompilation)]);
+    await Promise.all([
+        finished(taskCompilation, { readable: false }),
+        finished(testCompilation, { readable: false })
+    ]);
 }));
 
 function validateArtifactEngineTranspileErrors() {

--- a/package-utils.js
+++ b/package-utils.js
@@ -58,9 +58,3 @@ var run = function (cl, inheritStreams, noHeader) {
     return (output || '').toString().trim();
 }
 exports.run = run;
-
-exports.isDebug = function () {
-    let { SYSTEM_DEBUG } = process.env;
-    SYSTEM_DEBUG = SYSTEM_DEBUG || 'false';
-    return SYSTEM_DEBUG.toLowerCase() === 'true' || process.argv.includes('--verbose');
-}

--- a/package.js
+++ b/package.js
@@ -171,12 +171,7 @@ function installDependencies(taskPath, taskName) {
         npmArgs.splice(1, 0, '--no-engine-strict');
     }
 
-    const isDebug = util.isDebug();
-    if (isDebug) {
-        npmArgs.push('--verbose');
-    }
-
-    cp.execFileSync(npmCmd, npmArgs, { stdio: isDebug ? 'inherit' : 'ignore', shell: true });
+    cp.execFileSync(npmCmd, npmArgs, { stdio: 'inherit', shell: true });
 }
 
 module.exports = {


### PR DESCRIPTION
**Description**:
- Wait for the task and test TypeScript compilation streams before completing `compileNode`.
- Stream dependency-install and `tscBuildTasks` output so TypeScript errors are visible in local and CI builds.
- Remove the now-unused debug-output helper.

**Documentation changes required:** (N)

**Added unit tests:** (N)

**Attached related issue:** (N)

**Checklist**:
- [ ] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.