### PR TITLE
Support filesystem-aware artifact matching

### DIFF
--- a/Extensions/ArtifactEngine/Engine/artifactEngine.ts
+++ b/Extensions/ArtifactEngine/Engine/artifactEngine.ts
@@ -157,9 +157,15 @@ export class ArtifactEngine {
     }
 
     private isCaseInsensitiveArtifactMatchingEnabled(destProvider: models.IArtifactProvider): boolean {
-        if (!tl.getPipelineFeature('CaseInsensitiveArtifactMatchingFixEnabled')
-            || !this.isFilesystemCaseInsensitiveDetectionSupported()
-            || !destProvider.isCaseInsensitiveFilesystem) {
+        if (!tl.getPipelineFeature('CaseInsensitiveArtifactMatchingFixEnabled')) {
+            return false;
+        }
+
+        if (process.platform === 'win32') {
+            return true;
+        }
+
+        if (process.platform !== 'darwin' || !destProvider.isCaseInsensitiveFilesystem) {
             return false;
         }
 
@@ -170,10 +176,6 @@ export class ArtifactEngine {
             // Filesystem detection is advisory; preserve case-sensitive matching if it cannot run.
             return false;
         }
-    }
-
-    private isFilesystemCaseInsensitiveDetectionSupported(): boolean {
-        return process.platform === 'win32' || process.platform === 'darwin';
     }
 
     private getRetryIntervalInSeconds(baseRetryInterval: number, retryCount: number): number {

--- a/Extensions/ArtifactEngine/Engine/artifactEngine.ts
+++ b/Extensions/ArtifactEngine/Engine/artifactEngine.ts
@@ -15,6 +15,8 @@ export class ArtifactEngine {
             const workers: Promise<void>[] = [];
             artifactEngineOptions = artifactEngineOptions || new ArtifactEngineOptions();
             this.createPatternList(artifactEngineOptions);
+            this.isCaseInsensitiveArtifactMatching =
+                this.isCaseInsensitiveArtifactMatchingEnabled(destProvider);
             this.artifactItemStore.flush();
             Logger.verbose = artifactEngineOptions.verbose;
             this.logger = new Logger(this.artifactItemStore);
@@ -89,7 +91,7 @@ export class ArtifactEngine {
                 noglobstar: false,
                 dot: true,
                 noext: false,
-                nocase: false,
+                nocase: this.isCaseInsensitiveArtifactMatching,
                 nonull: false,
                 matchBase: false,
                 nocomment: false,
@@ -154,6 +156,26 @@ export class ArtifactEngine {
         }
     }
 
+    private isCaseInsensitiveArtifactMatchingEnabled(destProvider: models.IArtifactProvider): boolean {
+        if (!tl.getPipelineFeature('CaseInsensitiveArtifactMatchingFixEnabled')
+            || !this.isFilesystemCaseInsensitiveDetectionSupported()
+            || !destProvider.isCaseInsensitiveFilesystem) {
+            return false;
+        }
+
+        try {
+            return destProvider.isCaseInsensitiveFilesystem();
+        }
+        catch (error) {
+            // Filesystem detection is advisory; preserve case-sensitive matching if it cannot run.
+            return false;
+        }
+    }
+
+    private isFilesystemCaseInsensitiveDetectionSupported(): boolean {
+        return process.platform === 'win32' || process.platform === 'darwin';
+    }
+
     private getRetryIntervalInSeconds(baseRetryInterval: number, retryCount: number): number {
         let MaxRetryLimitInSeconds = 360;
         var exponentialBackOff = baseRetryInterval * Math.pow(3, (retryCount + 1));
@@ -172,6 +194,7 @@ export class ArtifactEngine {
     private artifactItemStore: ArtifactItemStore = new ArtifactItemStore();
     private logger: Logger;
     private patternList: string[];
+    private isCaseInsensitiveArtifactMatching = false;
 }
 
 tl.setResourcePath(path.join(path.dirname(__dirname), 'lib.json'));

--- a/Extensions/ArtifactEngine/EngineTests/artifactEngineTests.ts
+++ b/Extensions/ArtifactEngine/EngineTests/artifactEngineTests.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 
 import * as engine from '../Engine';
+import * as models from '../Models';
 import * as providers from '../Providers';
 
 describe('Unit Tests', () => {
@@ -133,6 +134,160 @@ describe('Unit Tests', () => {
                     throw err;
                 });
         });
+
+        it('processItems should preserve case-sensitive matching and skip detection when the feature is disabled', async () => {
+            var testProvider = new providers.StubProvider();
+            var destinationProvider: models.IArtifactProvider = testProvider;
+            var downloadOptions = new engine.ArtifactEngineOptions();
+            downloadOptions.itemPattern = 'path1/**\n!PATH1/PATH2/**';
+            var detectionCalled = false;
+            destinationProvider.isCaseInsensitiveFilesystem = () => {
+                detectionCalled = true;
+                return true;
+            };
+
+            await withCaseInsensitiveArtifactMatchingFeature(false, async () => {
+                await new engine.ArtifactEngine()
+                    .processItems(testProvider, destinationProvider, downloadOptions);
+
+                assert.strictEqual(testProvider.getArtifactItemCalledCount, 3);
+                assert.strictEqual(detectionCalled, false);
+            });
+        });
+
+        it('processItems should skip detection and preserve case-sensitive matching on Linux', async () => {
+            var testProvider = new providers.StubProvider();
+            var destinationProvider: models.IArtifactProvider = testProvider;
+            var downloadOptions = new engine.ArtifactEngineOptions();
+            downloadOptions.itemPattern = 'path1/**\n!PATH1/PATH2/**';
+            var detectionCalled = false;
+            destinationProvider.isCaseInsensitiveFilesystem = () => {
+                detectionCalled = true;
+                return true;
+            };
+
+            await withProcessPlatform('linux', async () => {
+                await withCaseInsensitiveArtifactMatchingFeature(true, async () => {
+                    await new engine.ArtifactEngine()
+                        .processItems(testProvider, destinationProvider, downloadOptions);
+
+                    assert.strictEqual(testProvider.getArtifactItemCalledCount, 3);
+                    assert.strictEqual(detectionCalled, false);
+                });
+            });
+        });
+
+        [
+            { target: 'a case-insensitive Windows target', platform: 'win32' as NodeJS.Platform },
+            { target: 'a case-insensitive macOS target', platform: 'darwin' as NodeJS.Platform }
+        ].forEach(({ target, platform }) => {
+            it(`processItems should match case-insensitively when the feature is enabled for ${target}`, async () => {
+                await assertCaseInsensitiveMatching(true, platform);
+            });
+        });
+
+        it('processItems should evaluate destination filesystem detection once for multiple matched items', async () => {
+            var testProvider = new providers.StubProvider();
+            var destinationProvider: models.IArtifactProvider = testProvider;
+            var downloadOptions = new engine.ArtifactEngineOptions();
+            downloadOptions.itemPattern = 'path1/**';
+            var detectionCalledCount = 0;
+            destinationProvider.isCaseInsensitiveFilesystem = () => {
+                detectionCalledCount++;
+                return true;
+            };
+
+            await withProcessPlatform('win32', async () => {
+                await withCaseInsensitiveArtifactMatchingFeature(true, async () => {
+                    await new engine.ArtifactEngine()
+                        .processItems(testProvider, destinationProvider, downloadOptions);
+
+                    assert.strictEqual(testProvider.getArtifactItemCalledCount, 3);
+                    assert.strictEqual(detectionCalledCount, 1);
+                });
+            });
+        });
+
+        [
+            { target: 'a case-sensitive Linux target', platform: 'linux' as NodeJS.Platform },
+            { target: 'a case-sensitive macOS target', platform: 'darwin' as NodeJS.Platform }
+        ].forEach(({ target, platform }) => {
+            it(`processItems should preserve case-sensitive matching when the feature is enabled for ${target}`, async () => {
+                await assertCaseInsensitiveMatching(false, platform);
+            });
+        });
+
+        it('processItems should preserve case-sensitive matching when filesystem detection fails', async () => {
+            await assertCaseInsensitiveMatching(null, 'win32');
+        });
+
+        async function assertCaseInsensitiveMatching(
+            isCaseInsensitive: boolean,
+            platform: NodeJS.Platform): Promise<void> {
+            var testProvider = new providers.StubProvider();
+            var destinationProvider: models.IArtifactProvider = testProvider;
+            var downloadOptions = new engine.ArtifactEngineOptions();
+            downloadOptions.itemPattern = 'path1/**\n!PATH1/PATH2/**';
+            destinationProvider.isCaseInsensitiveFilesystem = () => {
+                if (isCaseInsensitive === null) {
+                    throw new Error('Filesystem case detection is unavailable');
+                }
+
+                return isCaseInsensitive;
+            };
+
+            await withProcessPlatform(platform, async () => {
+                await withCaseInsensitiveArtifactMatchingFeature(true, async () => {
+                    await new engine.ArtifactEngine()
+                        .processItems(testProvider, destinationProvider, downloadOptions);
+
+                    assert.strictEqual(testProvider.getArtifactItemCalledCount, isCaseInsensitive ? 2 : 3);
+                });
+            });
+        }
+
+        async function withProcessPlatform(
+            platform: NodeJS.Platform,
+            operation: () => Promise<void>): Promise<void> {
+            const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+            if (!platformDescriptor) {
+                throw new Error('Unable to save the process platform descriptor');
+            }
+
+            Object.defineProperty(process, 'platform', { value: platform });
+            try {
+                await operation();
+            }
+            finally {
+                Object.defineProperty(process, 'platform', platformDescriptor);
+            }
+        }
+
+        async function withCaseInsensitiveArtifactMatchingFeature(
+            enabled: boolean,
+            operation: () => Promise<void>): Promise<void> {
+            const featureEnvironmentVariable =
+                'DISTRIBUTEDTASK_TASKS_CASEINSENSITIVEARTIFACTMATCHINGFIXENABLED';
+            const originalValue = process.env[featureEnvironmentVariable];
+            if (enabled) {
+                process.env[featureEnvironmentVariable] = 'true';
+            }
+            else {
+                delete process.env[featureEnvironmentVariable];
+            }
+
+            try {
+                await operation();
+            }
+            finally {
+                if (originalValue === undefined) {
+                    delete process.env[featureEnvironmentVariable];
+                }
+                else {
+                    process.env[featureEnvironmentVariable] = originalValue;
+                }
+            }
+        }
 
         it('processItems should call getArtifactItem only for included artifact items prefering exclude over include pattern', (done) => {
             var testProvider = new providers.StubProvider();

--- a/Extensions/ArtifactEngine/EngineTests/artifactEngineTests.ts
+++ b/Extensions/ArtifactEngine/EngineTests/artifactEngineTests.ts
@@ -177,13 +177,30 @@ describe('Unit Tests', () => {
             });
         });
 
-        [
-            { target: 'a case-insensitive Windows target', platform: 'win32' as NodeJS.Platform },
-            { target: 'a case-insensitive macOS target', platform: 'darwin' as NodeJS.Platform }
-        ].forEach(({ target, platform }) => {
-            it(`processItems should match case-insensitively when the feature is enabled for ${target}`, async () => {
-                await assertCaseInsensitiveMatching(true, platform);
+        it('processItems should match case-insensitively and skip detection on Windows', async () => {
+            var testProvider = new providers.StubProvider();
+            var destinationProvider: models.IArtifactProvider = testProvider;
+            var downloadOptions = new engine.ArtifactEngineOptions();
+            downloadOptions.itemPattern = 'path1/**\n!PATH1/PATH2/**';
+            var detectionCalled = false;
+            destinationProvider.isCaseInsensitiveFilesystem = () => {
+                detectionCalled = true;
+                return false;
+            };
+
+            await withProcessPlatform('win32', async () => {
+                await withCaseInsensitiveArtifactMatchingFeature(true, async () => {
+                    await new engine.ArtifactEngine()
+                        .processItems(testProvider, destinationProvider, downloadOptions);
+
+                    assert.strictEqual(testProvider.getArtifactItemCalledCount, 2);
+                    assert.strictEqual(detectionCalled, false);
+                });
             });
+        });
+
+        it('processItems should match case-insensitively for a case-insensitive macOS target', async () => {
+            await assertCaseInsensitiveMatching(true, 'darwin');
         });
 
         it('processItems should evaluate destination filesystem detection once for multiple matched items', async () => {
@@ -197,7 +214,7 @@ describe('Unit Tests', () => {
                 return true;
             };
 
-            await withProcessPlatform('win32', async () => {
+            await withProcessPlatform('darwin', async () => {
                 await withCaseInsensitiveArtifactMatchingFeature(true, async () => {
                     await new engine.ArtifactEngine()
                         .processItems(testProvider, destinationProvider, downloadOptions);
@@ -218,7 +235,7 @@ describe('Unit Tests', () => {
         });
 
         it('processItems should preserve case-sensitive matching when filesystem detection fails', async () => {
-            await assertCaseInsensitiveMatching(null, 'win32');
+            await assertCaseInsensitiveMatching(null, 'darwin');
         });
 
         async function assertCaseInsensitiveMatching(

--- a/Extensions/ArtifactEngine/Models/artifactprovider.ts
+++ b/Extensions/ArtifactEngine/Models/artifactprovider.ts
@@ -7,5 +7,6 @@ export interface IArtifactProvider {
     getArtifactItems(artifactItem: ArtifactItem): Promise<ArtifactItem[]>;
     getArtifactItem(artifactItem: ArtifactItem): Promise<NodeJS.ReadableStream>;
     putArtifactItem(artifactItem: ArtifactItem, stream: NodeJS.ReadableStream): Promise<ArtifactItem>;
+    isCaseInsensitiveFilesystem?(): boolean;
     dispose(): void;
 }

--- a/Extensions/ArtifactEngine/Providers/filesystemCaseSensitivity.ts
+++ b/Extensions/ArtifactEngine/Providers/filesystemCaseSensitivity.ts
@@ -1,0 +1,97 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface FileSystemCaseSensitivityProbe {
+    existsSync(path: string): boolean;
+    readdirSync(path: string): string[];
+    statSync(path: string): { dev: number };
+}
+
+export interface PathOperations {
+    resolve(...paths: string[]): string;
+    dirname(path: string): string;
+    join(...paths: string[]): string;
+}
+
+// Detect case behavior without creating a probe file. Probe only inside the nearest existing
+// destination ancestor. Empty directories may ascend only within the same device.
+export function isFilesystemCaseInsensitive(
+    destinationPath: string,
+    fileSystem: FileSystemCaseSensitivityProbe = fs,
+    pathOperations: PathOperations = path): boolean {
+    if (!destinationPath) {
+        return false;
+    }
+
+    try {
+        let existingPath = pathOperations.resolve(destinationPath);
+
+        while (true) {
+            if (fileSystem.existsSync(existingPath)) {
+                const caseSensitivity = probeDirectoryCaseSensitivity(existingPath, fileSystem, pathOperations);
+                if (caseSensitivity !== null) {
+                    return caseSensitivity;
+                }
+
+                const parentPath = pathOperations.dirname(existingPath);
+                if (parentPath === existingPath) {
+                    return false;
+                }
+
+                if (fileSystem.statSync(existingPath).dev !== fileSystem.statSync(parentPath).dev) {
+                    return false;
+                }
+
+                existingPath = parentPath;
+                continue;
+            }
+
+            const parentPath = pathOperations.dirname(existingPath);
+            if (parentPath === existingPath) {
+                return false;
+            }
+
+            existingPath = parentPath;
+        }
+    }
+    catch (error) {
+        // A false negative only retains the original case-sensitive behavior.
+        return false;
+    }
+}
+
+function probeDirectoryCaseSensitivity(
+    directoryPath: string,
+    fileSystem: FileSystemCaseSensitivityProbe,
+    pathOperations: PathOperations): boolean | null {
+    const entries = fileSystem.readdirSync(directoryPath);
+    for (const entry of entries) {
+        const caseVariant = getCaseVariant(entry);
+        if (!caseVariant) {
+            continue;
+        }
+
+        if (entries.filter((candidate) => candidate.toLowerCase() === entry.toLowerCase()).length !== 1) {
+            return false;
+        }
+
+        return fileSystem.existsSync(pathOperations.join(directoryPath, caseVariant));
+    }
+
+    return null;
+}
+
+function getCaseVariant(pathSegment: string): string | null {
+    for (let index = 0; index < pathSegment.length; index++) {
+        const character = pathSegment.charAt(index);
+        if (character >= 'a' && character <= 'z') {
+            return pathSegment.substring(0, index) + character.toUpperCase() + pathSegment.substring(index + 1);
+        }
+
+        if (character >= 'A' && character <= 'Z') {
+            return pathSegment.substring(0, index) + character.toLowerCase() + pathSegment.substring(index + 1);
+        }
+    }
+
+    return null;
+}

--- a/Extensions/ArtifactEngine/Providers/filesystemProvider.ts
+++ b/Extensions/ArtifactEngine/Providers/filesystemProvider.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as models from '../Models';
 import { Logger } from '../Engine/logger';
 import { ArtifactItemStore } from '../Store/artifactItemStore';
+import { isFilesystemCaseInsensitive } from './filesystemCaseSensitivity';
 
 var tl = require('azure-pipelines-task-lib');
 
@@ -113,6 +114,21 @@ export class FilesystemProvider implements models.IArtifactProvider {
         });
     }
 
+    public isCaseInsensitiveFilesystem(): boolean {
+        if (!this._hasDeterminedFilesystemCaseSensitivity) {
+            try {
+                this._isCaseInsensitiveFilesystem = isFilesystemCaseInsensitive(this._rootLocation);
+            }
+            catch (error) {
+                this._isCaseInsensitiveFilesystem = false;
+            }
+
+            this._hasDeterminedFilesystemCaseSensitivity = true;
+        }
+
+        return this._isCaseInsensitiveFilesystem;
+    }
+
     dispose(): void {
     }
 
@@ -160,4 +176,6 @@ export class FilesystemProvider implements models.IArtifactProvider {
 
     private _rootLocation: string;
     private _rootItemPath: string;
+    private _hasDeterminedFilesystemCaseSensitivity = false;
+    private _isCaseInsensitiveFilesystem = false;
 }

--- a/Extensions/ArtifactEngine/ProvidersTests/filesystemCaseSensitivityTests.ts
+++ b/Extensions/ArtifactEngine/ProvidersTests/filesystemCaseSensitivityTests.ts
@@ -1,0 +1,255 @@
+import * as assert from 'assert';
+import * as path from 'path';
+
+import {
+    FileSystemCaseSensitivityProbe,
+    isFilesystemCaseInsensitive
+} from '../Providers/filesystemCaseSensitivity';
+
+class TestFileSystemProbe implements FileSystemCaseSensitivityProbe {
+    constructor(
+        private readonly existingPaths: string[],
+        private readonly directoryEntries: { [directory: string]: string[] },
+        private readonly isCaseInsensitive: boolean,
+        private readonly deviceIds: { [path: string]: number } = {},
+        private readonly failDirectoryRead: boolean = false) {
+    }
+
+    public enumeratedPaths: string[] = [];
+
+    public existsSync(filePath: string): boolean {
+        return this.existingPaths.some((existingPath) =>
+            this.isCaseInsensitive
+                ? existingPath.toLowerCase() === filePath.toLowerCase()
+                : existingPath === filePath);
+    }
+
+    public readdirSync(directoryPath: string): string[] {
+        this.enumeratedPaths.push(directoryPath);
+        if (this.failDirectoryRead) {
+            throw new Error('Directory cannot be read');
+        }
+
+        const entries = this.directoryEntries[directoryPath];
+        if (!entries) {
+            throw new Error(`Unknown directory: ${directoryPath}`);
+        }
+
+        return entries;
+    }
+
+    public statSync(filePath: string): { dev: number } {
+        const deviceId = this.deviceIds[filePath];
+        if (deviceId === undefined) {
+            throw new Error(`Unknown device: ${filePath}`);
+        }
+
+        return { dev: deviceId };
+    }
+}
+
+class MountBoundaryProbe implements FileSystemCaseSensitivityProbe {
+    public enumeratedPaths: string[] = [];
+
+    public existsSync(filePath: string): boolean {
+        return filePath === '/Volumes/ArtifactCaseSensitive'
+            || filePath === '/Volumes/artifactCaseSensitive'
+            || filePath === '/Volumes/ArtifactCaseSensitive/download';
+    }
+
+    public readdirSync(directoryPath: string): string[] {
+        this.enumeratedPaths.push(directoryPath);
+        if (directoryPath === '/Volumes/ArtifactCaseSensitive') {
+            return ['download'];
+        }
+
+        if (directoryPath === '/Volumes') {
+            return ['ArtifactCaseSensitive'];
+        }
+
+        throw new Error(`Unexpected directory: ${directoryPath}`);
+    }
+
+    public statSync(filePath: string): { dev: number } {
+        throw new Error(`Unexpected stat: ${filePath}`);
+    }
+}
+
+describe('Unit Tests', () => {
+    describe('filesystem case sensitivity tests', () => {
+        it('detects a case-insensitive Windows root destination filesystem', () => {
+            const destinationPath = 'C:\\';
+            const probe = new TestFileSystemProbe(
+                ['C:\\', 'C:\\agent'],
+                { 'C:\\': ['agent'] },
+                true);
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, probe, path.win32),
+                true);
+        });
+
+        it('detects a case-insensitive macOS destination filesystem', () => {
+            const destinationPath = '/Volumes/Build/download';
+            const probe = new TestFileSystemProbe(
+                [destinationPath, destinationPath + '/artifact.txt'],
+                { [destinationPath]: ['artifact.txt'] },
+                true);
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, probe, path.posix),
+                true);
+        });
+
+        it('keeps matching case-sensitive for a Linux destination filesystem', () => {
+            const destinationPath = '/agent/_work/1/s';
+            const probe = new TestFileSystemProbe(
+                [destinationPath, destinationPath + '/artifact.txt'],
+                { [destinationPath]: ['artifact.txt'] },
+                false);
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, probe, path.posix),
+                false);
+        });
+
+        it('keeps matching case-sensitive for a case-sensitive macOS destination filesystem', () => {
+            const destinationPath = '/Volumes/Build/download';
+            const probe = new TestFileSystemProbe(
+                [destinationPath, destinationPath + '/artifact.txt'],
+                { [destinationPath]: ['artifact.txt'] },
+                false);
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, probe, path.posix),
+                false);
+        });
+
+        it('does not use the parent filesystem across a destination mount boundary', () => {
+            const destinationPath = '/Volumes/ArtifactCaseSensitive';
+            const probe = new MountBoundaryProbe();
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, probe, path.posix),
+                false);
+            assert.deepStrictEqual(probe.enumeratedPaths, [destinationPath]);
+        });
+
+        it('ascends from an empty destination directory on the same filesystem', () => {
+            const destinationPath = '/Volumes/Build/download';
+            const parentPath = '/Volumes/Build';
+            const probe = new TestFileSystemProbe(
+                [destinationPath, parentPath, parentPath + '/workspace'],
+                {
+                    [destinationPath]: [],
+                    [parentPath]: ['workspace']
+                },
+                true,
+                {
+                    [destinationPath]: 1,
+                    [parentPath]: 1
+                });
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, probe, path.posix),
+                true);
+            assert.deepStrictEqual(probe.enumeratedPaths, [destinationPath, parentPath]);
+        });
+
+        it('uses the nearest existing ancestor for a nonexistent destination', () => {
+            const destinationPath = '/Volumes/Build/download';
+            const parentPath = '/Volumes/Build';
+            const probe = new TestFileSystemProbe(
+                [parentPath, parentPath + '/workspace'],
+                { [parentPath]: ['workspace'] },
+                true);
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, probe, path.posix),
+                true);
+            assert.deepStrictEqual(probe.enumeratedPaths, [parentPath]);
+        });
+
+        it('does not ascend from an empty mounted destination directory', () => {
+            const destinationPath = '/Volumes/ArtifactCaseSensitive';
+            const parentPath = '/Volumes';
+            const probe = new TestFileSystemProbe(
+                [destinationPath, parentPath, parentPath + '/caseInsensitiveParent'],
+                {
+                    [destinationPath]: [],
+                    [parentPath]: ['caseInsensitiveParent']
+                },
+                true,
+                {
+                    [destinationPath]: 2,
+                    [parentPath]: 1
+                });
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, probe, path.posix),
+                false);
+            assert.deepStrictEqual(probe.enumeratedPaths, [destinationPath]);
+        });
+
+        it('does not leave the destination filesystem for a nonexistent path below an empty mount', () => {
+            const destinationPath = '/Volumes/ArtifactCaseSensitive/download';
+            const mountPath = '/Volumes/ArtifactCaseSensitive';
+            const parentPath = '/Volumes';
+            const probe = new TestFileSystemProbe(
+                [mountPath, parentPath, parentPath + '/caseInsensitiveParent'],
+                {
+                    [mountPath]: [],
+                    [parentPath]: ['caseInsensitiveParent']
+                },
+                true,
+                {
+                    [mountPath]: 2,
+                    [parentPath]: 1
+                });
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, probe, path.posix),
+                false);
+            assert.deepStrictEqual(probe.enumeratedPaths, [mountPath]);
+        });
+
+        it('keeps matching case-sensitive for an empty root destination directory', () => {
+            const probe = new TestFileSystemProbe(
+                ['/'],
+                { '/': [] },
+                true);
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive('/', probe, path.posix),
+                false);
+        });
+
+        it('keeps matching case-sensitive when the destination directory is indeterminate or fails', () => {
+            const destinationPath = '/Volumes/Build/download';
+            const ambiguousProbe = new TestFileSystemProbe(
+                [destinationPath, destinationPath + '/artifact.txt', destinationPath + '/ARTIFACT.txt'],
+                { [destinationPath]: ['artifact.txt', 'ARTIFACT.txt'] },
+                true);
+            const emptyProbe = new TestFileSystemProbe(
+                [destinationPath],
+                { [destinationPath]: [] },
+                true);
+            const failingProbe = new TestFileSystemProbe(
+                [destinationPath],
+                { [destinationPath]: ['artifact.txt'] },
+                true,
+                {},
+                true);
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, emptyProbe, path.posix),
+                false);
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, ambiguousProbe, path.posix),
+                false);
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, failingProbe, path.posix),
+                false);
+        });
+    });
+});

--- a/Extensions/ArtifactEngine/ProvidersTests/filesystemProviderTests.ts
+++ b/Extensions/ArtifactEngine/ProvidersTests/filesystemProviderTests.ts
@@ -35,6 +35,7 @@ libMocker.enable({
 
 import * as providers from '../Providers';
 import { ArtifactItemStore } from '../Store/artifactItemStore';
+import * as filesystemCaseSensitivity from '../Providers/filesystemCaseSensitivity';
 var tl = require("azure-pipelines-task-lib");
 
 describe('Unit Tests', () => {
@@ -81,6 +82,21 @@ describe('Unit Tests', () => {
             }, (err) => {
                 throw err;
             });
+        });
+
+        it('isCaseInsensitiveFilesystem should detect only the destination root once', () => {
+            const caseDetectionStub = sinon.stub(filesystemCaseSensitivity, 'isFilesystemCaseInsensitive').returns(true);
+            const provider = new providers.FilesystemProvider('c:\\drop');
+
+            try {
+                assert.strictEqual(provider.isCaseInsensitiveFilesystem(), true);
+                assert.strictEqual(provider.isCaseInsensitiveFilesystem(), true);
+                assert.strictEqual(caseDetectionStub.calledOnce, true);
+                assert.deepStrictEqual(caseDetectionStub.firstCall.args, ['c:\\drop']);
+            }
+            finally {
+                caseDetectionStub.restore();
+            }
         });
 
         it('putArtifactItem should also create empty folders', (done) => {

--- a/Extensions/ArtifactEngine/package-lock.json
+++ b/Extensions/ArtifactEngine/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-engine",
-  "version": "1.279.1",
+  "version": "1.280.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-engine",
-      "version": "1.279.1",
+      "version": "1.280.0",
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.278.0",

--- a/Extensions/ArtifactEngine/package.json
+++ b/Extensions/ArtifactEngine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "1.279.1",
+  "version": "1.280.0",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",

--- a/Extensions/ArtifactEngineV2/Engine/artifactEngine.ts
+++ b/Extensions/ArtifactEngineV2/Engine/artifactEngine.ts
@@ -157,9 +157,15 @@ export class ArtifactEngine {
     }
 
     private isCaseInsensitiveArtifactMatchingEnabled(destProvider: models.IArtifactProvider): boolean {
-        if (!tl.getPipelineFeature('CaseInsensitiveArtifactMatchingFixEnabled')
-            || !this.isFilesystemCaseInsensitiveDetectionSupported()
-            || !destProvider.isCaseInsensitiveFilesystem) {
+        if (!tl.getPipelineFeature('CaseInsensitiveArtifactMatchingFixEnabled')) {
+            return false;
+        }
+
+        if (process.platform === 'win32') {
+            return true;
+        }
+
+        if (process.platform !== 'darwin' || !destProvider.isCaseInsensitiveFilesystem) {
             return false;
         }
 
@@ -170,10 +176,6 @@ export class ArtifactEngine {
             // Filesystem detection is advisory; preserve case-sensitive matching if it cannot run.
             return false;
         }
-    }
-
-    private isFilesystemCaseInsensitiveDetectionSupported(): boolean {
-        return process.platform === 'win32' || process.platform === 'darwin';
     }
 
     private getRetryIntervalInSeconds(baseRetryInterval: number, retryCount: number): number {

--- a/Extensions/ArtifactEngineV2/Engine/artifactEngine.ts
+++ b/Extensions/ArtifactEngineV2/Engine/artifactEngine.ts
@@ -15,6 +15,8 @@ export class ArtifactEngine {
             const workers: Promise<void>[] = [];
             artifactEngineOptions = artifactEngineOptions || new ArtifactEngineOptions();
             this.createPatternList(artifactEngineOptions);
+            this.isCaseInsensitiveArtifactMatching =
+                this.isCaseInsensitiveArtifactMatchingEnabled(destProvider);
             this.artifactItemStore.flush();
             Logger.verbose = artifactEngineOptions.verbose;
             this.logger = new Logger(this.artifactItemStore);
@@ -83,15 +85,13 @@ export class ArtifactEngine {
         retryCount = retryCount ? retryCount : 0;
         if (item.itemType === models.ItemType.File) {
             var pathToMatch = item.path.replace(/\\/g, '/');
-            var isCaseInsensitiveArtifactMatchingFixEnabled =
-                tl.getPipelineFeature('CaseInsensitiveArtifactMatchingFixEnabled');
             var matchOptions = {
                 debug: false,
                 nobrace: true,
                 noglobstar: false,
                 dot: true,
                 noext: false,
-                nocase: process.platform === 'win32' && isCaseInsensitiveArtifactMatchingFixEnabled,
+                nocase: this.isCaseInsensitiveArtifactMatching,
                 nonull: false,
                 matchBase: false,
                 nocomment: false,
@@ -156,6 +156,26 @@ export class ArtifactEngine {
         }
     }
 
+    private isCaseInsensitiveArtifactMatchingEnabled(destProvider: models.IArtifactProvider): boolean {
+        if (!tl.getPipelineFeature('CaseInsensitiveArtifactMatchingFixEnabled')
+            || !this.isFilesystemCaseInsensitiveDetectionSupported()
+            || !destProvider.isCaseInsensitiveFilesystem) {
+            return false;
+        }
+
+        try {
+            return destProvider.isCaseInsensitiveFilesystem();
+        }
+        catch (error) {
+            // Filesystem detection is advisory; preserve case-sensitive matching if it cannot run.
+            return false;
+        }
+    }
+
+    private isFilesystemCaseInsensitiveDetectionSupported(): boolean {
+        return process.platform === 'win32' || process.platform === 'darwin';
+    }
+
     private getRetryIntervalInSeconds(baseRetryInterval: number, retryCount: number): number {
         let MaxRetryLimitInSeconds = 360;
         var exponentialBackOff = baseRetryInterval * Math.pow(3, (retryCount + 1));
@@ -174,6 +194,7 @@ export class ArtifactEngine {
     private artifactItemStore: ArtifactItemStore = new ArtifactItemStore();
     private logger: Logger;
     private patternList: string[];
+    private isCaseInsensitiveArtifactMatching = false;
 }
 
 tl.setResourcePath(path.join(path.dirname(__dirname), 'lib.json'));

--- a/Extensions/ArtifactEngineV2/EngineTests/artifactEngineTests.ts
+++ b/Extensions/ArtifactEngineV2/EngineTests/artifactEngineTests.ts
@@ -177,13 +177,30 @@ describe('Unit Tests', () => {
             });
         });
 
-        [
-            { target: 'a case-insensitive Windows target', platform: 'win32' as NodeJS.Platform },
-            { target: 'a case-insensitive macOS target', platform: 'darwin' as NodeJS.Platform }
-        ].forEach(({ target, platform }) => {
-            it(`processItems should match case-insensitively when the feature is enabled for ${target}`, async () => {
-                await assertCaseInsensitiveMatching(true, platform);
+        it('processItems should match case-insensitively and skip detection on Windows', async () => {
+            var testProvider = new providers.StubProvider();
+            var destinationProvider: models.IArtifactProvider = testProvider;
+            var downloadOptions = new engine.ArtifactEngineOptions();
+            downloadOptions.itemPattern = 'path1/**\n!PATH1/PATH2/**';
+            var detectionCalled = false;
+            destinationProvider.isCaseInsensitiveFilesystem = () => {
+                detectionCalled = true;
+                return false;
+            };
+
+            await withProcessPlatform('win32', async () => {
+                await withCaseInsensitiveArtifactMatchingFeature(true, async () => {
+                    await new engine.ArtifactEngine()
+                        .processItems(testProvider, destinationProvider, downloadOptions);
+
+                    assert.strictEqual(testProvider.getArtifactItemCalledCount, 2);
+                    assert.strictEqual(detectionCalled, false);
+                });
             });
+        });
+
+        it('processItems should match case-insensitively for a case-insensitive macOS target', async () => {
+            await assertCaseInsensitiveMatching(true, 'darwin');
         });
 
         it('processItems should evaluate destination filesystem detection once for multiple matched items', async () => {
@@ -197,7 +214,7 @@ describe('Unit Tests', () => {
                 return true;
             };
 
-            await withProcessPlatform('win32', async () => {
+            await withProcessPlatform('darwin', async () => {
                 await withCaseInsensitiveArtifactMatchingFeature(true, async () => {
                     await new engine.ArtifactEngine()
                         .processItems(testProvider, destinationProvider, downloadOptions);
@@ -218,7 +235,7 @@ describe('Unit Tests', () => {
         });
 
         it('processItems should preserve case-sensitive matching when filesystem detection fails', async () => {
-            await assertCaseInsensitiveMatching(null, 'win32');
+            await assertCaseInsensitiveMatching(null, 'darwin');
         });
 
         async function assertCaseInsensitiveMatching(

--- a/Extensions/ArtifactEngineV2/EngineTests/artifactEngineTests.ts
+++ b/Extensions/ArtifactEngineV2/EngineTests/artifactEngineTests.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 
 import * as engine from '../Engine';
+import * as models from '../Models';
 import * as providers from '../Providers';
 
 describe('Unit Tests', () => {
@@ -134,33 +135,149 @@ describe('Unit Tests', () => {
                 });
         });
 
-        it('processItems should preserve case-sensitive matching when the feature is disabled', (done) => {
+        it('processItems should preserve case-sensitive matching and skip detection when the feature is disabled', async () => {
             var testProvider = new providers.StubProvider();
+            var destinationProvider: models.IArtifactProvider = testProvider;
             var downloadOptions = new engine.ArtifactEngineOptions();
             downloadOptions.itemPattern = 'path1/**\n!PATH1/PATH2/**';
+            var detectionCalled = false;
+            destinationProvider.isCaseInsensitiveFilesystem = () => {
+                detectionCalled = true;
+                return true;
+            };
 
-            new engine.ArtifactEngine()
-                .processItems(testProvider, testProvider, downloadOptions)
-                .then(() => {
-                    assert.strictEqual(testProvider.getArtifactItemCalledCount, 3);
-                    done();
-                }, (err) => {
-                    throw err;
-                });
+            await withCaseInsensitiveArtifactMatchingFeature(false, async () => {
+                await new engine.ArtifactEngine()
+                    .processItems(testProvider, destinationProvider, downloadOptions);
+
+                assert.strictEqual(testProvider.getArtifactItemCalledCount, 3);
+                assert.strictEqual(detectionCalled, false);
+            });
         });
 
-        runWindowsBasedTest('processItems should match case-insensitively when the feature is enabled', async () => {
+        it('processItems should skip detection and preserve case-sensitive matching on Linux', async () => {
             var testProvider = new providers.StubProvider();
+            var destinationProvider: models.IArtifactProvider = testProvider;
             var downloadOptions = new engine.ArtifactEngineOptions();
             downloadOptions.itemPattern = 'path1/**\n!PATH1/PATH2/**';
+            var detectionCalled = false;
+            destinationProvider.isCaseInsensitiveFilesystem = () => {
+                detectionCalled = true;
+                return true;
+            };
+
+            await withProcessPlatform('linux', async () => {
+                await withCaseInsensitiveArtifactMatchingFeature(true, async () => {
+                    await new engine.ArtifactEngine()
+                        .processItems(testProvider, destinationProvider, downloadOptions);
+
+                    assert.strictEqual(testProvider.getArtifactItemCalledCount, 3);
+                    assert.strictEqual(detectionCalled, false);
+                });
+            });
+        });
+
+        [
+            { target: 'a case-insensitive Windows target', platform: 'win32' as NodeJS.Platform },
+            { target: 'a case-insensitive macOS target', platform: 'darwin' as NodeJS.Platform }
+        ].forEach(({ target, platform }) => {
+            it(`processItems should match case-insensitively when the feature is enabled for ${target}`, async () => {
+                await assertCaseInsensitiveMatching(true, platform);
+            });
+        });
+
+        it('processItems should evaluate destination filesystem detection once for multiple matched items', async () => {
+            var testProvider = new providers.StubProvider();
+            var destinationProvider: models.IArtifactProvider = testProvider;
+            var downloadOptions = new engine.ArtifactEngineOptions();
+            downloadOptions.itemPattern = 'path1/**';
+            var detectionCalledCount = 0;
+            destinationProvider.isCaseInsensitiveFilesystem = () => {
+                detectionCalledCount++;
+                return true;
+            };
+
+            await withProcessPlatform('win32', async () => {
+                await withCaseInsensitiveArtifactMatchingFeature(true, async () => {
+                    await new engine.ArtifactEngine()
+                        .processItems(testProvider, destinationProvider, downloadOptions);
+
+                    assert.strictEqual(testProvider.getArtifactItemCalledCount, 3);
+                    assert.strictEqual(detectionCalledCount, 1);
+                });
+            });
+        });
+
+        [
+            { target: 'a case-sensitive Linux target', platform: 'linux' as NodeJS.Platform },
+            { target: 'a case-sensitive macOS target', platform: 'darwin' as NodeJS.Platform }
+        ].forEach(({ target, platform }) => {
+            it(`processItems should preserve case-sensitive matching when the feature is enabled for ${target}`, async () => {
+                await assertCaseInsensitiveMatching(false, platform);
+            });
+        });
+
+        it('processItems should preserve case-sensitive matching when filesystem detection fails', async () => {
+            await assertCaseInsensitiveMatching(null, 'win32');
+        });
+
+        async function assertCaseInsensitiveMatching(
+            isCaseInsensitive: boolean,
+            platform: NodeJS.Platform): Promise<void> {
+            var testProvider = new providers.StubProvider();
+            var destinationProvider: models.IArtifactProvider = testProvider;
+            var downloadOptions = new engine.ArtifactEngineOptions();
+            downloadOptions.itemPattern = 'path1/**\n!PATH1/PATH2/**';
+            destinationProvider.isCaseInsensitiveFilesystem = () => {
+                if (isCaseInsensitive === null) {
+                    throw new Error('Filesystem case detection is unavailable');
+                }
+
+                return isCaseInsensitive;
+            };
+
+            await withProcessPlatform(platform, async () => {
+                await withCaseInsensitiveArtifactMatchingFeature(true, async () => {
+                    await new engine.ArtifactEngine()
+                        .processItems(testProvider, destinationProvider, downloadOptions);
+
+                    assert.strictEqual(testProvider.getArtifactItemCalledCount, isCaseInsensitive ? 2 : 3);
+                });
+            });
+        }
+
+        async function withProcessPlatform(
+            platform: NodeJS.Platform,
+            operation: () => Promise<void>): Promise<void> {
+            const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+            if (!platformDescriptor) {
+                throw new Error('Unable to save the process platform descriptor');
+            }
+
+            Object.defineProperty(process, 'platform', { value: platform });
+            try {
+                await operation();
+            }
+            finally {
+                Object.defineProperty(process, 'platform', platformDescriptor);
+            }
+        }
+
+        async function withCaseInsensitiveArtifactMatchingFeature(
+            enabled: boolean,
+            operation: () => Promise<void>): Promise<void> {
             const featureEnvironmentVariable =
                 'DISTRIBUTEDTASK_TASKS_CASEINSENSITIVEARTIFACTMATCHINGFIXENABLED';
-            var originalValue = process.env[featureEnvironmentVariable];
-            process.env[featureEnvironmentVariable] = 'true';
+            const originalValue = process.env[featureEnvironmentVariable];
+            if (enabled) {
+                process.env[featureEnvironmentVariable] = 'true';
+            }
+            else {
+                delete process.env[featureEnvironmentVariable];
+            }
 
             try {
-                await new engine.ArtifactEngine().processItems(testProvider, testProvider, downloadOptions);
-                assert.strictEqual(testProvider.getArtifactItemCalledCount, 2);
+                await operation();
             }
             finally {
                 if (originalValue === undefined) {
@@ -170,7 +287,7 @@ describe('Unit Tests', () => {
                     process.env[featureEnvironmentVariable] = originalValue;
                 }
             }
-        });
+        }
 
         it('processItems should call getArtifactItem only for included artifact items prefering exclude over include pattern', (done) => {
             var testProvider = new providers.StubProvider();

--- a/Extensions/ArtifactEngineV2/Models/artifactprovider.ts
+++ b/Extensions/ArtifactEngineV2/Models/artifactprovider.ts
@@ -7,5 +7,6 @@ export interface IArtifactProvider {
     getArtifactItems(artifactItem: ArtifactItem): Promise<ArtifactItem[]>;
     getArtifactItem(artifactItem: ArtifactItem): Promise<NodeJS.ReadableStream>;
     putArtifactItem(artifactItem: ArtifactItem, stream: NodeJS.ReadableStream): Promise<ArtifactItem>;
+    isCaseInsensitiveFilesystem?(): boolean;
     dispose(): void;
 }

--- a/Extensions/ArtifactEngineV2/Providers/filesystemCaseSensitivity.ts
+++ b/Extensions/ArtifactEngineV2/Providers/filesystemCaseSensitivity.ts
@@ -1,0 +1,97 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface FileSystemCaseSensitivityProbe {
+    existsSync(path: string): boolean;
+    readdirSync(path: string): string[];
+    statSync(path: string): { dev: number };
+}
+
+export interface PathOperations {
+    resolve(...paths: string[]): string;
+    dirname(path: string): string;
+    join(...paths: string[]): string;
+}
+
+// Detect case behavior without creating a probe file. Probe only inside the nearest existing
+// destination ancestor. Empty directories may ascend only within the same device.
+export function isFilesystemCaseInsensitive(
+    destinationPath: string,
+    fileSystem: FileSystemCaseSensitivityProbe = fs,
+    pathOperations: PathOperations = path): boolean {
+    if (!destinationPath) {
+        return false;
+    }
+
+    try {
+        let existingPath = pathOperations.resolve(destinationPath);
+
+        while (true) {
+            if (fileSystem.existsSync(existingPath)) {
+                const caseSensitivity = probeDirectoryCaseSensitivity(existingPath, fileSystem, pathOperations);
+                if (caseSensitivity !== null) {
+                    return caseSensitivity;
+                }
+
+                const parentPath = pathOperations.dirname(existingPath);
+                if (parentPath === existingPath) {
+                    return false;
+                }
+
+                if (fileSystem.statSync(existingPath).dev !== fileSystem.statSync(parentPath).dev) {
+                    return false;
+                }
+
+                existingPath = parentPath;
+                continue;
+            }
+
+            const parentPath = pathOperations.dirname(existingPath);
+            if (parentPath === existingPath) {
+                return false;
+            }
+
+            existingPath = parentPath;
+        }
+    }
+    catch (error) {
+        // A false negative only retains the original case-sensitive behavior.
+        return false;
+    }
+}
+
+function probeDirectoryCaseSensitivity(
+    directoryPath: string,
+    fileSystem: FileSystemCaseSensitivityProbe,
+    pathOperations: PathOperations): boolean | null {
+    const entries = fileSystem.readdirSync(directoryPath);
+    for (const entry of entries) {
+        const caseVariant = getCaseVariant(entry);
+        if (!caseVariant) {
+            continue;
+        }
+
+        if (entries.filter((candidate) => candidate.toLowerCase() === entry.toLowerCase()).length !== 1) {
+            return false;
+        }
+
+        return fileSystem.existsSync(pathOperations.join(directoryPath, caseVariant));
+    }
+
+    return null;
+}
+
+function getCaseVariant(pathSegment: string): string | null {
+    for (let index = 0; index < pathSegment.length; index++) {
+        const character = pathSegment.charAt(index);
+        if (character >= 'a' && character <= 'z') {
+            return pathSegment.substring(0, index) + character.toUpperCase() + pathSegment.substring(index + 1);
+        }
+
+        if (character >= 'A' && character <= 'Z') {
+            return pathSegment.substring(0, index) + character.toLowerCase() + pathSegment.substring(index + 1);
+        }
+    }
+
+    return null;
+}

--- a/Extensions/ArtifactEngineV2/Providers/filesystemProvider.ts
+++ b/Extensions/ArtifactEngineV2/Providers/filesystemProvider.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as models from '../Models';
 import { Logger } from '../Engine/logger';
 import { ArtifactItemStore } from '../Store/artifactItemStore';
+import { isFilesystemCaseInsensitive } from './filesystemCaseSensitivity';
 
 var tl = require('azure-pipelines-task-lib');
 
@@ -113,6 +114,21 @@ export class FilesystemProvider implements models.IArtifactProvider {
         });
     }
 
+    public isCaseInsensitiveFilesystem(): boolean {
+        if (!this._hasDeterminedFilesystemCaseSensitivity) {
+            try {
+                this._isCaseInsensitiveFilesystem = isFilesystemCaseInsensitive(this._rootLocation);
+            }
+            catch (error) {
+                this._isCaseInsensitiveFilesystem = false;
+            }
+
+            this._hasDeterminedFilesystemCaseSensitivity = true;
+        }
+
+        return this._isCaseInsensitiveFilesystem;
+    }
+
     dispose(): void {
     }
 
@@ -160,4 +176,6 @@ export class FilesystemProvider implements models.IArtifactProvider {
 
     private _rootLocation: string;
     private _rootItemPath: string;
+    private _hasDeterminedFilesystemCaseSensitivity = false;
+    private _isCaseInsensitiveFilesystem = false;
 }

--- a/Extensions/ArtifactEngineV2/ProvidersTests/filesystemCaseSensitivityTests.ts
+++ b/Extensions/ArtifactEngineV2/ProvidersTests/filesystemCaseSensitivityTests.ts
@@ -1,0 +1,255 @@
+import * as assert from 'assert';
+import * as path from 'path';
+
+import {
+    FileSystemCaseSensitivityProbe,
+    isFilesystemCaseInsensitive
+} from '../Providers/filesystemCaseSensitivity';
+
+class TestFileSystemProbe implements FileSystemCaseSensitivityProbe {
+    constructor(
+        private readonly existingPaths: string[],
+        private readonly directoryEntries: { [directory: string]: string[] },
+        private readonly isCaseInsensitive: boolean,
+        private readonly deviceIds: { [path: string]: number } = {},
+        private readonly failDirectoryRead: boolean = false) {
+    }
+
+    public enumeratedPaths: string[] = [];
+
+    public existsSync(filePath: string): boolean {
+        return this.existingPaths.some((existingPath) =>
+            this.isCaseInsensitive
+                ? existingPath.toLowerCase() === filePath.toLowerCase()
+                : existingPath === filePath);
+    }
+
+    public readdirSync(directoryPath: string): string[] {
+        this.enumeratedPaths.push(directoryPath);
+        if (this.failDirectoryRead) {
+            throw new Error('Directory cannot be read');
+        }
+
+        const entries = this.directoryEntries[directoryPath];
+        if (!entries) {
+            throw new Error(`Unknown directory: ${directoryPath}`);
+        }
+
+        return entries;
+    }
+
+    public statSync(filePath: string): { dev: number } {
+        const deviceId = this.deviceIds[filePath];
+        if (deviceId === undefined) {
+            throw new Error(`Unknown device: ${filePath}`);
+        }
+
+        return { dev: deviceId };
+    }
+}
+
+class MountBoundaryProbe implements FileSystemCaseSensitivityProbe {
+    public enumeratedPaths: string[] = [];
+
+    public existsSync(filePath: string): boolean {
+        return filePath === '/Volumes/ArtifactCaseSensitive'
+            || filePath === '/Volumes/artifactCaseSensitive'
+            || filePath === '/Volumes/ArtifactCaseSensitive/download';
+    }
+
+    public readdirSync(directoryPath: string): string[] {
+        this.enumeratedPaths.push(directoryPath);
+        if (directoryPath === '/Volumes/ArtifactCaseSensitive') {
+            return ['download'];
+        }
+
+        if (directoryPath === '/Volumes') {
+            return ['ArtifactCaseSensitive'];
+        }
+
+        throw new Error(`Unexpected directory: ${directoryPath}`);
+    }
+
+    public statSync(filePath: string): { dev: number } {
+        throw new Error(`Unexpected stat: ${filePath}`);
+    }
+}
+
+describe('Unit Tests', () => {
+    describe('filesystem case sensitivity tests', () => {
+        it('detects a case-insensitive Windows root destination filesystem', () => {
+            const destinationPath = 'C:\\';
+            const probe = new TestFileSystemProbe(
+                ['C:\\', 'C:\\agent'],
+                { 'C:\\': ['agent'] },
+                true);
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, probe, path.win32),
+                true);
+        });
+
+        it('detects a case-insensitive macOS destination filesystem', () => {
+            const destinationPath = '/Volumes/Build/download';
+            const probe = new TestFileSystemProbe(
+                [destinationPath, destinationPath + '/artifact.txt'],
+                { [destinationPath]: ['artifact.txt'] },
+                true);
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, probe, path.posix),
+                true);
+        });
+
+        it('keeps matching case-sensitive for a Linux destination filesystem', () => {
+            const destinationPath = '/agent/_work/1/s';
+            const probe = new TestFileSystemProbe(
+                [destinationPath, destinationPath + '/artifact.txt'],
+                { [destinationPath]: ['artifact.txt'] },
+                false);
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, probe, path.posix),
+                false);
+        });
+
+        it('keeps matching case-sensitive for a case-sensitive macOS destination filesystem', () => {
+            const destinationPath = '/Volumes/Build/download';
+            const probe = new TestFileSystemProbe(
+                [destinationPath, destinationPath + '/artifact.txt'],
+                { [destinationPath]: ['artifact.txt'] },
+                false);
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, probe, path.posix),
+                false);
+        });
+
+        it('does not use the parent filesystem across a destination mount boundary', () => {
+            const destinationPath = '/Volumes/ArtifactCaseSensitive';
+            const probe = new MountBoundaryProbe();
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, probe, path.posix),
+                false);
+            assert.deepStrictEqual(probe.enumeratedPaths, [destinationPath]);
+        });
+
+        it('ascends from an empty destination directory on the same filesystem', () => {
+            const destinationPath = '/Volumes/Build/download';
+            const parentPath = '/Volumes/Build';
+            const probe = new TestFileSystemProbe(
+                [destinationPath, parentPath, parentPath + '/workspace'],
+                {
+                    [destinationPath]: [],
+                    [parentPath]: ['workspace']
+                },
+                true,
+                {
+                    [destinationPath]: 1,
+                    [parentPath]: 1
+                });
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, probe, path.posix),
+                true);
+            assert.deepStrictEqual(probe.enumeratedPaths, [destinationPath, parentPath]);
+        });
+
+        it('uses the nearest existing ancestor for a nonexistent destination', () => {
+            const destinationPath = '/Volumes/Build/download';
+            const parentPath = '/Volumes/Build';
+            const probe = new TestFileSystemProbe(
+                [parentPath, parentPath + '/workspace'],
+                { [parentPath]: ['workspace'] },
+                true);
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, probe, path.posix),
+                true);
+            assert.deepStrictEqual(probe.enumeratedPaths, [parentPath]);
+        });
+
+        it('does not ascend from an empty mounted destination directory', () => {
+            const destinationPath = '/Volumes/ArtifactCaseSensitive';
+            const parentPath = '/Volumes';
+            const probe = new TestFileSystemProbe(
+                [destinationPath, parentPath, parentPath + '/caseInsensitiveParent'],
+                {
+                    [destinationPath]: [],
+                    [parentPath]: ['caseInsensitiveParent']
+                },
+                true,
+                {
+                    [destinationPath]: 2,
+                    [parentPath]: 1
+                });
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, probe, path.posix),
+                false);
+            assert.deepStrictEqual(probe.enumeratedPaths, [destinationPath]);
+        });
+
+        it('does not leave the destination filesystem for a nonexistent path below an empty mount', () => {
+            const destinationPath = '/Volumes/ArtifactCaseSensitive/download';
+            const mountPath = '/Volumes/ArtifactCaseSensitive';
+            const parentPath = '/Volumes';
+            const probe = new TestFileSystemProbe(
+                [mountPath, parentPath, parentPath + '/caseInsensitiveParent'],
+                {
+                    [mountPath]: [],
+                    [parentPath]: ['caseInsensitiveParent']
+                },
+                true,
+                {
+                    [mountPath]: 2,
+                    [parentPath]: 1
+                });
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, probe, path.posix),
+                false);
+            assert.deepStrictEqual(probe.enumeratedPaths, [mountPath]);
+        });
+
+        it('keeps matching case-sensitive for an empty root destination directory', () => {
+            const probe = new TestFileSystemProbe(
+                ['/'],
+                { '/': [] },
+                true);
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive('/', probe, path.posix),
+                false);
+        });
+
+        it('keeps matching case-sensitive when the destination directory is indeterminate or fails', () => {
+            const destinationPath = '/Volumes/Build/download';
+            const ambiguousProbe = new TestFileSystemProbe(
+                [destinationPath, destinationPath + '/artifact.txt', destinationPath + '/ARTIFACT.txt'],
+                { [destinationPath]: ['artifact.txt', 'ARTIFACT.txt'] },
+                true);
+            const emptyProbe = new TestFileSystemProbe(
+                [destinationPath],
+                { [destinationPath]: [] },
+                true);
+            const failingProbe = new TestFileSystemProbe(
+                [destinationPath],
+                { [destinationPath]: ['artifact.txt'] },
+                true,
+                {},
+                true);
+
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, emptyProbe, path.posix),
+                false);
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, ambiguousProbe, path.posix),
+                false);
+            assert.strictEqual(
+                isFilesystemCaseInsensitive(destinationPath, failingProbe, path.posix),
+                false);
+        });
+    });
+});

--- a/Extensions/ArtifactEngineV2/ProvidersTests/filesystemProviderTests.ts
+++ b/Extensions/ArtifactEngineV2/ProvidersTests/filesystemProviderTests.ts
@@ -35,6 +35,7 @@ libMocker.enable({
 
 import * as providers from '../Providers';
 import { ArtifactItemStore } from '../Store/artifactItemStore';
+import * as filesystemCaseSensitivity from '../Providers/filesystemCaseSensitivity';
 var tl = require("azure-pipelines-task-lib");
 
 describe('Unit Tests', () => {
@@ -81,6 +82,20 @@ describe('Unit Tests', () => {
             }, (err) => {
                 throw err;
             });
+        });
+
+        it('isCaseInsensitiveFilesystem should detect only the destination root once', () => {
+            const caseDetectionStub = sinon.stub(filesystemCaseSensitivity, 'isFilesystemCaseInsensitive').returns(true);
+            const provider = new providers.FilesystemProvider('c:\\drop');
+
+            try {
+                assert.strictEqual(provider.isCaseInsensitiveFilesystem(), true);
+                assert.strictEqual(provider.isCaseInsensitiveFilesystem(), true);
+                assert.strictEqual(caseDetectionStub.calledOnceWithExactly('c:\\drop'), true);
+            }
+            finally {
+                caseDetectionStub.restore();
+            }
         });
 
         it('putArtifactItem should also create empty folders', (done) => {

--- a/Extensions/ArtifactEngineV2/package-lock.json
+++ b/Extensions/ArtifactEngineV2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "artifact-engine",
-  "version": "2.279.2",
+  "version": "2.280.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "artifact-engine",
-      "version": "2.279.2",
+      "version": "2.280.0",
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.278.0",

--- a/Extensions/ArtifactEngineV2/package.json
+++ b/Extensions/ArtifactEngineV2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifact-engine",
-  "version": "2.279.2",
+  "version": "2.280.0",
   "description": "Artifact Engine to download artifacts from jenkins, teamcity, vsts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
 **Description**: Update ArtifactEngine 1.x and V2 to detect the destination filesystem's case behavior. When the existing `CaseInsensitiveArtifactMatchingFixEnabled` Tasks flag is enabled, matching is case-insensitive on case-insensitive Windows and macOS filesystems. Flag-off behavior, Linux, case-sensitive macOS volumes, and detection failures remain case-sensitive.
 
 ArtifactEngine 1.x remains a separate implementation because it has an independent package lifecycle and is still consumed by the TeamCity and External TFS tasks. 
 
 **Documentation changes required:** N - this is an internal matching correction behind an existing dynamic feature flag.
 
 **Added unit tests:** Y - added coverage for feature/platform gating, case-sensitive and case-insensitive filesystems, mount boundaries, empty and missing destinations, detection caching, and failure fallback.
 
 **Attached related issue:** N
 
 **Checklist**:
 - [x] Version was bumped - ArtifactEngine 1.x to `1.280.0` and ArtifactEngineV2 to `2.280.0`.
 - [x] Checked that applied changes work as expected - ArtifactEngine 1.x: 89 passing; focused ArtifactEngineV2 suites: 43 passing.
