### PR TITLE
Fix ArtifactEngine filesystem provider tests on Linux

### DIFF
--- a/Extensions/ArtifactEngine/ProvidersTests/filesystemProviderTests.ts
+++ b/Extensions/ArtifactEngine/ProvidersTests/filesystemProviderTests.ts
@@ -77,7 +77,7 @@ describe('Unit Tests', () => {
             s.push(null);
 
             localFileProvider.putArtifactItem(artifactItem, s).then((processedItem) => {
-                assert.strictEqual(processedItem.metadata[models.Constants.DestinationUrlKey], path.join("c:\\drop", "path1\\file1"));
+                assert.strictEqual(processedItem.metadata[models.Constants.DestinationUrlKey], path.resolve("c:\\drop", "path1\\file1"));
                 done();
             }, (err) => {
                 throw err;
@@ -103,7 +103,7 @@ describe('Unit Tests', () => {
             var artifactItem = { fileLength: 0, itemType: models.ItemType.Folder, path: "path1\\folder1", lastModified: null, metadata: null };
 
             localFileProvider.putArtifactItem(artifactItem, null).then((processedItem) => {
-                assert(stub.calledWith(path.join("c:\\drop", "path1\\folder1")));
+                assert(stub.calledWith(path.resolve("c:\\drop", "path1\\folder1")));
                 done();
             }, (err) => {
                 throw err;


### PR DESCRIPTION
**Description**: Correct ArtifactEngine filesystem-provider test expectations so enabled path validation uses the same `path.resolve` semantics as production on Linux agents.

**Documentation changes required:** N - test-only correction; no user-facing behavior changes.

**Added unit tests:** Y - updated two existing filesystem provider unit-test assertions.

**Attached related issue:** N - fixes CI build 32014712.

**Checklist**:
- [x] Version was bumped - N/A: test-only change.
- [x] Checked that applied changes work as expected.