### PR TITLE
Refactor DownloadArtifactsTfsGit: improve input validation, enhance error handling, and add retry logic for PR fetch

### DIFF
--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/downloadTfGit.js
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/downloadTfGit.js
@@ -9,23 +9,9 @@ const auth = require('./auth');
 
 const GIT_CLONE_RETRY_ATTEMPTS = 4;
 
-const connectionType = tl.getInput("connectionType");
-const isAdoConnectionType = connectionType === 'ado';
-
-const serviceConnection = tl.getInput(isAdoConnectionType ? "azureDevOpsServiceConnection" : "connection");
-const repositoryId = tl.getInputRequired(isAdoConnectionType ? "definitionAdo" : "definition");
-const projectId = tl.getInputRequired(isAdoConnectionType ? "projectAdo" : "project");
-const branch = tl.getInputRequired(isAdoConnectionType ? "branchAdo" : "branch");
-const commitId = tl.getInputRequired(isAdoConnectionType ? "versionAdo" : "version");
-const downloadPath = tl.getInputRequired("downloadPath");
-validateInputs(serviceConnection, repositoryId, projectId, branch, commitId, downloadPath);
-
-try {
-    fs.rmSync(downloadPath, { recursive: true, force: true });
-} catch (error) {
-    tl.error(error);
-    process.exit(1);
-}
+let isAdoConnectionType = false;
+/** @type {string} */
+let downloadPath;
 
 /**
  * @typedef {Object} ConnectionDetails
@@ -52,38 +38,50 @@ const gitOptions = {
     debugOutput: !!process.env['SYSTEM_DEBUG']
 };
 
-getServiceConnectionDetails(serviceConnection).then(response => {
-    connectionDetails = response;
-    return getGitClientPromise(connectionDetails);
-}).then(gitClient => {
-    return getRepositoryRemoteUrl(gitClient, repositoryId, projectId);
-}).then(repositoryRemoteUrl => {
-    const gitReadyRepoUrl = prepareGitConsumableRepoUrl(repositoryRemoteUrl, connectionDetails);
-    git = configureGitApiWrapper(connectionDetails);
-    isPullRequest = isPullRequestBranch(branch);
+async function main() {
+    const connectionType = tl.getInput("connectionType");
+    isAdoConnectionType = connectionType === 'ado';
 
-    return executeWithRetries('gitClone', () => {
-        return git
-            .clone(gitReadyRepoUrl, true, downloadPath, gitOptions)
-            .then((/** @type {any} */ result) => {
-            if (isPullRequest) {
-                process.chdir(downloadPath);
-                return git.fetch(['origin', branch], gitOptions);
-            }
-            return result;
-        });
-    }, GIT_CLONE_RETRY_ATTEMPTS);
-}).then(() => {
-    process.chdir(downloadPath);
-    const ref = isPullRequest ? commitId : branch;
-    return git.checkout(ref, gitOptions);
-}).then(() => {
-    if (!isPullRequest) {
-        return git.checkout(commitId);
+    const serviceConnection = tl.getInput(isAdoConnectionType ? "azureDevOpsServiceConnection" : "connection");
+    const repositoryId = tl.getInputRequired(isAdoConnectionType ? "definitionAdo" : "definition");
+    const projectId = tl.getInputRequired(isAdoConnectionType ? "projectAdo" : "project");
+    const branch = tl.getInputRequired(isAdoConnectionType ? "branchAdo" : "branch");
+    const commitId = tl.getInputRequired(isAdoConnectionType ? "versionAdo" : "version");
+    downloadPath = tl.getInputRequired("downloadPath");
+    validateInputs(serviceConnection);
+
+    const originalWorkingDirectory = process.cwd();
+    try {
+        connectionDetails = await getServiceConnectionDetails(serviceConnection);
+        const gitClient = await getGitClientPromise(connectionDetails);
+        const repositoryRemoteUrl = await getRepositoryRemoteUrl(gitClient, repositoryId, projectId);
+        const gitReadyRepoUrl = prepareGitConsumableRepoUrl(repositoryRemoteUrl, connectionDetails);
+        git = configureGitApiWrapper(connectionDetails);
+        isPullRequest = isPullRequestBranch(branch);
+
+        await executeWithRetries('gitClone', () => {
+            process.chdir(originalWorkingDirectory);
+            removeDownloadPath();
+            return git.clone(gitReadyRepoUrl, true, downloadPath, gitOptions);
+        }, GIT_CLONE_RETRY_ATTEMPTS);
+
+        if (isPullRequest) {
+            await executeWithRetries('gitFetch', () => {
+                return git.fetch(['origin', branch], { ...gitOptions, cwd: downloadPath });
+            }, GIT_CLONE_RETRY_ATTEMPTS);
+        }
+
+        const ref = isPullRequest ? commitId : branch;
+        await git.checkout(ref, { ...gitOptions, cwd: downloadPath });
+        if (!isPullRequest) {
+            await git.checkout(commitId, { ...gitOptions, cwd: downloadPath });
+        }
+    } finally {
+        process.chdir(originalWorkingDirectory);
     }
+}
 
-    return null;
-}).catch(error => {
+main().catch(error => {
     tl.error(error);
     tl.setResult(tl.TaskResult.Failed, error);
 });
@@ -92,32 +90,21 @@ getServiceConnectionDetails(serviceConnection).then(response => {
  * Validates the inputs provided to the task, ensuring that all required parameters are present and not empty.
  * If any validation checks fail, an error is thrown with a descriptive message indicating which parameter is missing or invalid.
  * @param {string | undefined} serviceConnection - The name of the service connection in Azure DevOps, which is required to authenticate and access the Git repository.
- * @param {string | undefined} repositoryId - The ID of the Git repository to clone, which is required to identify the specific repository within the project.
- * @param {string | undefined} projectId - The ID of the Azure DevOps project that contains the Git repository, which is required to scope the repository lookup and ensure the correct repository is accessed.
- * @param {string | undefined} branch - The name of the branch to clone, which is required to specify which branch of the repository should be cloned.
- * @param {string | undefined} commitId - The ID of the specific commit to checkout after cloning, which is required to ensure that the correct version of the code is checked out for use in the pipeline.
- * @param {string | undefined} downloadPath - The local file system path where the Git repository should be cloned, which is required to specify where the code should be downloaded on the agent machine.
  * @throws {Error} If any of the required parameters are missing or invalid, an error is thrown with a descriptive message.
  */
-function validateInputs(serviceConnection, repositoryId, projectId, branch, commitId, downloadPath) {
+function validateInputs(serviceConnection) {
     if (!serviceConnection || serviceConnection.trim().length === 0) {
         throw new Error("Service connection is not provided.");
     }
-    if (!repositoryId) {
-        throw new Error("Repository is not provided.");
-    }
-    if (!projectId) {
-        throw new Error("Project is not provided.");
-    }
-    if (!branch) {
-        throw new Error("Branch is not provided.");
-    }
-    if (!commitId) {
-        throw new Error("Commit ID is not provided.");
-    }
-    if (!downloadPath) {
-        throw new Error("Download path is not provided.");
-    }
+}
+
+function removeDownloadPath() {
+    fs.rmSync(downloadPath, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+        retryDelay: 100
+    });
 }
 
 /**

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/downloadTfGit.js
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/downloadTfGit.js
@@ -312,7 +312,15 @@ function isPullRequestBranch(branch) {
  */
 function executeWithRetries(operationName, operation, remainingRetryAttempts) {
     return new Promise((resolve, reject) => {
-        operation().then((/** @type {any} */ result) => {
+        let operationResult;
+        try {
+            // Synchronous throws (e.g. removeDownloadPath's EBUSY/EPERM) must become a rejection here,
+            // otherwise they'd bypass the retry branch below.
+            operationResult = Promise.resolve(operation());
+        } catch (error) {
+            operationResult = Promise.reject(error);
+        }
+        operationResult.then((/** @type {any} */ result) => {
             resolve(result);
         }, (/** @type {string} */ error) => {
             if (remainingRetryAttempts <= 0) {

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 16,
     "Minor": 280,
-    "Patch": 5
+    "Patch": 7
   },
   "minimumAgentVersion": "2.206.1",
   "instanceNameFormat": "Download Artifacts - External TFS Git",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.280.10",
+  "version": "16.280.11",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.280.7",
+  "version": "16.280.10",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/_suite.ts
+++ b/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/_suite.ts
@@ -170,6 +170,17 @@ describe('DownloadArtifactsTfsGit Suite', function () {
                 assert(runner.stdOutContained('[mock-git] checkout 1234567890abcdef1234567890abcdef12345678'), 'should continue by checking out the requested commit after the retry succeeds');
             });
 
+            it('retries clone after removeDownloadPath() throws synchronously (e.g. Windows EBUSY/EPERM)', async function () {
+                const runner = newRunner('successRetryAfterCleanupThrows');
+                await runAndDump(runner, nodeVersion);
+                if (!runner.succeeded) fail(runner, 'expected task to succeed after cleanup retry');
+                assert(runner.stdOutContained('[mock-fs] rmSync-attempt 1'), 'should attempt cleanup once and hit the simulated throw');
+                assert(runner.stdOutContained('[mock-fs] rmSync-attempt 2'), 'should retry cleanup instead of skipping the remaining clone attempts');
+                assert(runner.stdOutContained('[mock-git] clone-attempt 1'), 'should reach git.clone() once cleanup succeeds');
+                assert(!runner.stdOutContained('[mock-git] clone-attempt 2'), 'clone itself should not have needed to retry');
+                assert(runner.stdOutContained('[mock-git] checkout master'), 'should continue to checkout after the retried clone succeeds');
+            });
+
             // ---- Failure / validation scenarios ----------------------------
 
             it('throws when service connection is empty', async function () {
@@ -286,6 +297,17 @@ describe('DownloadArtifactsTfsGit Suite', function () {
                 assert(runner.stdOutContained('[mock-git] clone-attempt 5'), 'should attempt clone the maximum number of times');
                 assert(runner.stdOutContained('OperationFailed: gitClone'), 'should emit OperationFailed once retries are exhausted');
                 assert(!runner.stdOutContained('[mock-git] checkout '), 'should not attempt checkout after clone retries are exhausted');
+            });
+
+            it('fails after exhausting retries when removeDownloadPath() always throws synchronously', async function () {
+                const runner = newRunner('failCleanupAlwaysThrows');
+                await runAndDump(runner, nodeVersion);
+                if (runner.succeeded) fail(runner, 'expected task to fail after cleanup retries exhausted');
+                // GIT_CLONE_RETRY_ATTEMPTS = 4 => 1 initial + 4 retries = 5 cleanup attempts,
+                // and git.clone() should never be reached since cleanup always throws first.
+                assert(runner.stdOutContained('[mock-fs] rmSync-attempt 5'), 'should consume all retry attempts on the synchronous throw instead of failing immediately');
+                assert(!runner.stdOutContained('[mock-git] clone-attempt'), 'should never reach git.clone() since cleanup always throws first');
+                assert(runner.stdOutContained('OperationFailed: gitClone'), 'should emit OperationFailed once retries are exhausted');
             });
         });
     });

--- a/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/_suite.ts
+++ b/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/_suite.ts
@@ -13,6 +13,7 @@
 import assert = require('assert');
 import path = require('path');
 import fs = require('fs');
+import { COMMIT_ID } from './mockHelpers';
 
 // MockTestRunner has no .d.ts in our compile path; use the value via require.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -128,6 +129,16 @@ describe('DownloadArtifactsTfsGit Suite', function () {
                 // For PR path the script does NOT call `git checkout <branch>` separately.
                 const checkoutBranch = runner.stdOutContained('[mock-git] checkout refs/pull/42/merge');
                 assert(!checkoutBranch, 'PR path must not checkout the branch name; only the commit');
+            });
+
+            it('retries a failed PR fetch without recloning', async function () {
+                const runner = newRunner('successPullRequestFetchRetry');
+                await runAndDump(runner, nodeVersion);
+                if (!runner.succeeded) fail(runner, 'expected task to succeed after retrying the PR fetch');
+                assert(runner.stdOutContained('[mock-git] clone-attempt 1'), 'should clone once');
+                assert(!runner.stdOutContained('[mock-git] clone-attempt 2'), 'should not re-clone after fetch fails');
+                assert(runner.stdOutContained('[mock-git] fetch-attempt 2'), 'should retry the PR fetch in the existing checkout');
+                assert(runner.stdOutContained('[mock-git] checkout ' + COMMIT_ID), 'should checkout the requested commit after fetch succeeds');
             });
 
             it('detects PR branches with refs/remotes/origin/pull/ prefix', async function () {

--- a/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/failCleanupAlwaysThrows.ts
+++ b/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/failCleanupAlwaysThrows.ts
@@ -1,0 +1,34 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+import {
+    TFS_CONNECTION_ID, PROJECT_ID, REPOSITORY_ID, DOWNLOAD_PATH,
+    BRANCH_REGULAR, COMMIT_ID,
+    setReposOrTfsEndpoint, registerAllMocks, registerFsMock, compressSetTimeout
+} from './mockHelpers';
+
+// Compress the 4-second retry backoff into ~5ms so the test stays fast.
+compressSetTimeout();
+
+const taskPath = path.join(__dirname, '..', '..', '..', 'Src', 'Tasks', 'DownloadArtifactsTfsGit', 'downloadTfGit.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('connectionType', 'reposOrTfs');
+tr.setInput('connection', TFS_CONNECTION_ID);
+tr.setInput('project', PROJECT_ID);
+tr.setInput('definition', REPOSITORY_ID);
+tr.setInput('branch', BRANCH_REGULAR);
+tr.setInput('version', COMMIT_ID);
+tr.setInput('downloadPath', DOWNLOAD_PATH);
+
+setReposOrTfsEndpoint({ scheme: 'Token' });
+
+// removeDownloadPath()'s fs.rmSync() throws synchronously on every call, so
+// git.clone() is never reached. With GIT_CLONE_RETRY_ATTEMPTS=4 the task
+// should still make 5 cleanup attempts (1 initial + 4 retries) before
+// surfacing "OperationFailed: gitClone" and failing - proving the synchronous
+// throw is consumed by the retry loop instead of skipping it.
+registerFsMock(tr, { rmSyncAlwaysFails: true });
+registerAllMocks(tr);
+
+tr.run();

--- a/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/mockHelpers.ts
+++ b/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/mockHelpers.ts
@@ -106,6 +106,8 @@ export interface GitWrapperMockOptions {
     cloneFailures?: number;
     /** When true, .clone() rejects on every call. */
     cloneAlwaysFails?: boolean;
+    /** Number of times .fetch() should reject before succeeding. */
+    fetchFailures?: number;
     /** Forces .checkout() to reject on its first invocation. */
     checkoutFailsOnce?: boolean;
 }
@@ -167,6 +169,7 @@ function registerGitWrapperMock(tr: tmrm.TaskMockRunner, opts: GitWrapperMockOpt
     const events = require('events');
 
     let cloneAttempts = 0;
+    let fetchAttempts = 0;
     let checkoutAttempts = 0;
 
     class MockGitWrapper extends events.EventEmitter {
@@ -195,9 +198,15 @@ function registerGitWrapperMock(tr: tmrm.TaskMockRunner, opts: GitWrapperMockOpt
         }
 
         public fetch(args: string[], _options: unknown): unknown {
+            fetchAttempts++;
+            console.log('[mock-git] fetch-attempt ' + fetchAttempts);
             console.log('[mock-git] fetch ' + args.join(' '));
             const deferred = Q.defer();
-            process.nextTick(() => deferred.resolve(0));
+            if (fetchAttempts <= (opts.fetchFailures || 0)) {
+                process.nextTick(() => deferred.reject(new Error('Simulated git fetch failure attempt ' + fetchAttempts)));
+            } else {
+                process.nextTick(() => deferred.resolve(0));
+            }
             return deferred.promise;
         }
 

--- a/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/mockHelpers.ts
+++ b/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/mockHelpers.ts
@@ -144,6 +144,31 @@ export function compressSetTimeout(): void {
     };
 }
 
+export interface FsMockOptions {
+    /** Number of leading fs.rmSync() calls that should throw synchronously (simulates Windows EBUSY/EPERM) before succeeding. */
+    rmSyncFailures?: number;
+    /** When true, fs.rmSync() throws synchronously on every call. */
+    rmSyncAlwaysFails?: boolean;
+}
+
+/** Mocks 'fs' so removeDownloadPath()'s fs.rmSync() can be made to throw synchronously, mirroring a locked-file cleanup failure on Windows. */
+export function registerFsMock(tr: tmrm.TaskMockRunner, opts: FsMockOptions = {}): void {
+    const realFs = require('fs');
+    const mockFs: { [key: string]: unknown } = Object.assign({}, realFs);
+    let rmSyncAttempts = 0;
+    mockFs['rmSync'] = (...args: unknown[]) => {
+        rmSyncAttempts++;
+        console.log('[mock-fs] rmSync-attempt ' + rmSyncAttempts);
+        if (opts.rmSyncAlwaysFails || rmSyncAttempts <= (opts.rmSyncFailures || 0)) {
+            const err: NodeJS.ErrnoException = new Error('EBUSY: resource busy or locked, rmdir');
+            err.code = 'EBUSY';
+            throw err;
+        }
+        return realFs.rmSync(...args);
+    };
+    tr.registerMock('fs', mockFs);
+}
+
 function registerShellMock(tr: tmrm.TaskMockRunner): void {
     const realShell = require('shelljs');
     const mockShell: { [key: string]: unknown } = Object.assign({}, realShell);

--- a/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/successPullRequestFetchRetry.ts
+++ b/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/successPullRequestFetchRetry.ts
@@ -1,0 +1,27 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+import {
+    TFS_CONNECTION_ID, PROJECT_ID, REPOSITORY_ID, DOWNLOAD_PATH,
+    BRANCH_PULL_REQUEST, COMMIT_ID,
+    setReposOrTfsEndpoint, registerAllMocks, compressSetTimeout
+} from './mockHelpers';
+
+compressSetTimeout();
+
+const taskPath = path.join(__dirname, '..', '..', '..', 'Src', 'Tasks', 'DownloadArtifactsTfsGit', 'downloadTfGit.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('connectionType', 'reposOrTfs');
+tr.setInput('connection', TFS_CONNECTION_ID);
+tr.setInput('project', PROJECT_ID);
+tr.setInput('definition', REPOSITORY_ID);
+tr.setInput('branch', BRANCH_PULL_REQUEST);
+tr.setInput('version', COMMIT_ID);
+tr.setInput('downloadPath', DOWNLOAD_PATH);
+
+setReposOrTfsEndpoint({ scheme: 'Token' });
+
+registerAllMocks(tr, { gitWrapper: { fetchFailures: 1 } });
+
+tr.run();

--- a/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/successRetryAfterCleanupThrows.ts
+++ b/Extensions/ExternalTfs/Tests/Tasks/DownloadArtifactsTfsGit/successRetryAfterCleanupThrows.ts
@@ -1,0 +1,35 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+import {
+    TFS_CONNECTION_ID, PROJECT_ID, REPOSITORY_ID, DOWNLOAD_PATH,
+    BRANCH_REGULAR, COMMIT_ID,
+    setReposOrTfsEndpoint, registerAllMocks, registerFsMock, compressSetTimeout
+} from './mockHelpers';
+
+// Compress the 4-second retry backoff into ~5ms so the test stays fast even
+// though it exercises the real executeWithRetries() path in downloadTfGit.js.
+compressSetTimeout();
+
+const taskPath = path.join(__dirname, '..', '..', '..', 'Src', 'Tasks', 'DownloadArtifactsTfsGit', 'downloadTfGit.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('connectionType', 'reposOrTfs');
+tr.setInput('connection', TFS_CONNECTION_ID);
+tr.setInput('project', PROJECT_ID);
+tr.setInput('definition', REPOSITORY_ID);
+tr.setInput('branch', BRANCH_REGULAR);
+tr.setInput('version', COMMIT_ID);
+tr.setInput('downloadPath', DOWNLOAD_PATH);
+
+setReposOrTfsEndpoint({ scheme: 'Token' });
+
+// removeDownloadPath()'s fs.rmSync() throws synchronously on the very first
+// call, before git.clone() is ever invoked (simulates a Windows EBUSY/EPERM
+// cleanup failure). executeWithRetries must still count this as a retryable
+// attempt instead of rejecting immediately, so the clone below should succeed
+// on the retry.
+registerFsMock(tr, { rmSyncFailures: 1 });
+registerAllMocks(tr);
+
+tr.run();


### PR DESCRIPTION
**Description**: Refactors `DownloadArtifactsTfsGit` to use an async entry point with guaranteed working-directory restoration. Clone retries now clean the destination before each attempt, while pull-request fetches retry independently without recloning. Git operations use an explicit checkout directory, and download cleanup uses retry-aware `fs.rmSync` options.

This PR updates code based on recommendations from [the PR' comment](https://github.com/microsoft/azure-pipelines-extensions/pull/1525#issuecomment-5581607737)

**Documentation changes required:** N

**Added unit tests:** Y — added coverage verifying that a transient PR fetch failure retries the fetch without recloning.

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.