### PR TITLE
Add support for Node24 in DownloadArtifactsTfsGit and DownloadExternalBuildArtifacts tasks

### DIFF
--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/downloadTfGit.js
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/downloadTfGit.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const url = require('url');
 
 const tl = require('azure-pipelines-task-lib/task');
 const webApim = require('azure-devops-node-api/WebApi');
@@ -267,13 +266,14 @@ function getRepositoryRemoteUrl(gitClient, repositoryId, projectId) {
  * @returns {string} The Git repository URL with authentication details included, if available.
  */
 function prepareGitConsumableRepoUrl(repoUrl, connectionDetails) {
-    const parsedRepoUrl = url.parse(repoUrl);
+    const parsedRepoUrl = new URL(repoUrl);
 
     if (connectionDetails.Username && connectionDetails.Password) {
-        parsedRepoUrl.auth = connectionDetails.Username + ':' + connectionDetails.Password;
+        parsedRepoUrl.username = connectionDetails.Username;
+        parsedRepoUrl.password = connectionDetails.Password;
     }
 
-    return url.format(parsedRepoUrl);
+    return parsedRepoUrl.toString();
 }
 
 /**

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package-lock.json
@@ -7,7 +7,7 @@
       "name": "DownloadArtifactsTfsGit",
       "dependencies": {
         "@azure/msal-node": "^2.7.0",
-        "azure-devops-node-api": "14.1.0",
+        "azure-devops-node-api": "^17.0.0",
         "azure-pipelines-task-lib": "^5.278.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.272.1"
       },
@@ -321,13 +321,13 @@
       }
     },
     "node_modules/azure-devops-node-api": {
-      "version": "14.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-14.1.0.tgz",
-      "integrity": "sha1-7FOT3p+hRjmd6qtpBOQdoD7c4YA=",
+      "version": "17.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-17.0.0.tgz",
+      "integrity": "sha1-WTgKfVSxPVYJtvy0g9ZjsKEvqbE=",
       "license": "MIT",
       "dependencies": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "2.1.0"
+        "typed-rest-client": "3.1.0"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -630,9 +630,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha1-HE8sSDcydZfOadLKGQp/3RcjOME=",
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -816,9 +816,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
+      "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1378,12 +1378,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha1-/VVCbXEEA93MxF4PnqsW23cn7Ok=",
+      "version": "6.15.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha1-doUhMqWO1cfA72fkRBubtdYGGzs=",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1539,14 +1540,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha1-w/z/nE2pMnhIczNeyXZfqU/2a8k=",
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha1-6gLGLgXcS+pn1EQvD7ce4ZL44Ks=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1558,13 +1559,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha1-EMtZhCYxFdO3oOM2WR4pCoMK+K0=",
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha1-wuC1oUpUCuvuO7xsP4ZmzJtQkSc=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1668,19 +1669,19 @@
       }
     },
     "node_modules/typed-rest-client": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
-      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.0.tgz",
+      "integrity": "sha1-Fgau0uxZ51Fp5gTZD6PTwPY3QtM=",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",
         "js-md4": "^0.3.2",
-        "qs": "^6.10.3",
+        "qs": "6.15.3",
         "tunnel": "0.0.6",
-        "underscore": "^1.12.1"
+        "underscore": "^1.13.8"
       },
       "engines": {
-        "node": ">= 16.0.0"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/underscore": {

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/package.json
@@ -3,7 +3,7 @@
   "main": "download.js",
   "dependencies": {
     "@azure/msal-node": "^2.7.0",
-    "azure-devops-node-api": "14.1.0",
+    "azure-devops-node-api": "^17.0.0",
     "azure-pipelines-task-lib": "^5.278.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.272.1"
   },

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadArtifactsTfsGit/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 16,
     "Minor": 280,
-    "Patch": 7
+    "Patch": 12
   },
   "minimumAgentVersion": "2.206.1",
   "instanceNameFormat": "Download Artifacts - External TFS Git",
@@ -235,6 +235,10 @@
       "argumentFormat": ""
     },
     "Node20": {
+      "target": "downloadTfGit.js",
+      "argumentFormat": ""
+    },
+    "Node24": {
       "target": "downloadTfGit.js",
       "argumentFormat": ""
     }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/download.ts
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/download.ts
@@ -6,7 +6,7 @@ import * as tl from 'azure-pipelines-task-lib/task';
 
 import * as engine from "artifact-engine/Engine";
 import * as providers from "artifact-engine/Providers";
-import * as webHandlers from "artifact-engine/Providers/typed-rest-client/Handlers";
+import * as webHandlers from "typed-rest-client/Handlers";
 
 tl.setResourcePath(path.join(__dirname, 'task.json'));
 

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package-lock.json
@@ -7,10 +7,11 @@
       "name": "DownloadExternalBuildArtifacts",
       "dependencies": {
         "@azure/msal-node": "^3.7.3",
-        "artifact-engine": "^1.271.1",
-        "azure-devops-node-api": "14.1.0",
+        "artifact-engine": "^2.280.0",
+        "azure-devops-node-api": "17.0.0",
         "azure-pipelines-task-lib": "^5.278.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.267.0"
+        "azure-pipelines-tasks-azure-arm-rest": "^3.267.0",
+        "typed-rest-client": "3.1.2"
       },
       "devDependencies": {
         "typescript": "5.1.6"
@@ -313,15 +314,14 @@
       }
     },
     "node_modules/artifact-engine": {
-      "version": "1.273.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/artifact-engine/-/artifact-engine-1.273.0.tgz",
-      "integrity": "sha1-HY+J8JFzStgYLxuPDqmezu4lEmo=",
+      "version": "2.280.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/artifact-engine/-/artifact-engine-2.280.0.tgz",
+      "integrity": "sha1-vjvD//3Aa1tRoNsQOh3QA4yozyQ=",
       "license": "MIT",
       "dependencies": {
-        "azure-pipelines-task-lib": "^5.2.8",
+        "azure-pipelines-task-lib": "^5.278.0",
         "handlebars": "4.7.9",
-        "minimatch": "3.1.5",
-        "tunnel": "0.0.4"
+        "typed-rest-client": "^3.0.0"
       }
     },
     "node_modules/async-mutex": {
@@ -334,25 +334,48 @@
       }
     },
     "node_modules/azure-devops-node-api": {
-      "version": "14.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-14.1.0.tgz",
-      "integrity": "sha1-7FOT3p+hRjmd6qtpBOQdoD7c4YA=",
+      "version": "17.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-17.0.0.tgz",
+      "integrity": "sha1-WTgKfVSxPVYJtvy0g9ZjsKEvqbE=",
       "license": "MIT",
       "dependencies": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "2.1.0"
+        "typed-rest-client": "3.1.0"
       },
       "engines": {
         "node": ">= 16.0.0"
       }
     },
-    "node_modules/azure-devops-node-api/node_modules/tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw=",
-      "license": "MIT",
+    "node_modules/azure-devops-node-api/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha1-doUhMqWO1cfA72fkRBubtdYGGzs=",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
       "engines": {
-        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/azure-devops-node-api/node_modules/typed-rest-client": {
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.0.tgz",
+      "integrity": "sha1-Fgau0uxZ51Fp5gTZD6PTwPY3QtM=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "6.15.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.13.8"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/azure-pipelines-task-lib": {
@@ -436,15 +459,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/typed-rest-client": {
@@ -1454,12 +1468,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha1-/VVCbXEEA93MxF4PnqsW23cn7Ok=",
+      "version": "6.16.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha1-wixyOiipIPOqzc6Cifq9Q+zLef0=",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1615,14 +1630,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha1-w/z/nE2pMnhIczNeyXZfqU/2a8k=",
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha1-6gLGLgXcS+pn1EQvD7ce4ZL44Ks=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1744,37 +1759,28 @@
       "license": "0BSD"
     },
     "node_modules/tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
-    "node_modules/typed-rest-client": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
-      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
-      "license": "MIT",
-      "dependencies": {
-        "des.js": "^1.1.0",
-        "js-md4": "^0.3.2",
-        "qs": "^6.10.3",
-        "tunnel": "0.0.6",
-        "underscore": "^1.12.1"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      }
-    },
-    "node_modules/typed-rest-client/node_modules/tunnel": {
       "version": "0.0.6",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw=",
       "license": "MIT",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "3.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.2.tgz",
+      "integrity": "sha512-fX2taQCAMhjzILtYoxz8Twc88QKfmhYo56bxs8q5v1Fh0qIw1QkBC/+MSKQXREOnY8Xa9c/kLNehUw0gbCZVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.16.0",
+        "tunnel": "0.0.6",
+        "underscore": "^1.13.8"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/typescript": {

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/package.json
@@ -3,10 +3,11 @@
   "main": "download.js",
   "dependencies": {
     "@azure/msal-node": "^3.7.3",
-    "artifact-engine": "^1.271.1",
-    "azure-devops-node-api": "14.1.0",
+    "artifact-engine": "^2.280.0",
+    "azure-devops-node-api": "17.0.0",
     "azure-pipelines-task-lib": "^5.278.0",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.267.0"
+    "azure-pipelines-tasks-azure-arm-rest": "^3.267.0",
+    "typed-rest-client": "3.1.2"
   },
   "devDependencies": {
     "typescript": "5.1.6"

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 16,
     "Minor": 279,
-    "Patch": 2
+    "Patch": 12
   },
   "demands": [],
   "minimumAgentVersion": "2.206.1",
@@ -197,6 +197,10 @@
       "argumentFormat": ""
     },
     "Node20_1": {
+      "target": "download.js",
+      "argumentFormat": ""
+    },
+    "Node24": {
       "target": "download.js",
       "argumentFormat": ""
     }

--- a/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.loc.json
+++ b/Extensions/ExternalTfs/Src/Tasks/DownloadExternalBuildArtifacts/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 16,
     "Minor": 279,
-    "Patch": 2
+    "Patch": 12
   },
   "demands": [],
   "minimumAgentVersion": "2.206.1",
@@ -197,6 +197,10 @@
       "argumentFormat": ""
     },
     "Node20_1": {
+      "target": "download.js",
+      "argumentFormat": ""
+    },
+    "Node24": {
       "target": "download.js",
       "argumentFormat": ""
     }

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.280.12",
+  "version": "16.280.13",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.280.11",
+  "version": "16.280.12",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Src/vss-extension.json
+++ b/Extensions/ExternalTfs/Src/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "vss-services-externaltfs",
-  "version": "16.280.13",
+  "version": "16.280.14",
   "name": "TFS artifacts for Release Management",
   "publisher": "ms-vscs-rm",
   "description": "Deploy external TFS/ Azure DevOps artifacts using Release Management",

--- a/Extensions/ExternalTfs/Tests/Tasks/DownloadExternalBuildArtifacts/mockHelpers.ts
+++ b/Extensions/ExternalTfs/Tests/Tasks/DownloadExternalBuildArtifacts/mockHelpers.ts
@@ -4,7 +4,7 @@
 //   azure-devops-node-api/WebApi           -> WebApi + getBasicHandler
 //   artifact-engine/Engine                 -> ArtifactEngine, ArtifactEngineOptions
 //   artifact-engine/Providers              -> FilesystemProvider, WebProvider
-//   artifact-engine/Providers/typed-rest-client/Handlers
+//   typed-rest-client/Handlers
 //                                          -> BasicCredentialHandler, PersonalAccessTokenCredentialHandler
 //   ./auth                                 -> getAccessTokenViaWorkloadIdentityFederation
 //
@@ -188,7 +188,7 @@ function registerHandlersMock(tr: tmrm.TaskMockRunner): void {
     function PersonalAccessTokenCredentialHandler(this: any, _token: string) {
         console.log('[mock-handlers] PersonalAccessTokenCredentialHandler');
     }
-    tr.registerMock('artifact-engine/Providers/typed-rest-client/Handlers', {
+    tr.registerMock('typed-rest-client/Handlers', {
         BasicCredentialHandler,
         PersonalAccessTokenCredentialHandler
     });


### PR DESCRIPTION
**Description**: Complete the Node 20 to Node 24 migration for both ExternalTfs tasks.

- Add the `Node24` execution handler to `DownloadArtifactsTfsGit` and `DownloadExternalBuildArtifacts`.
- Upgrade `azure-devops-node-api` to the Node 24-compatible 17.x line for both tasks.
- Upgrade `artifact-engine` to 2.280.0 for `DownloadExternalBuildArtifacts`.
- Use the public `typed-rest-client/Handlers` API required by artifact-engine 2.
- Replace the Git task's deprecated `url.parse()` / `url.format()` usage with the WHATWG `URL` API.
- Upgrade root `tfx-cli` to 0.24.1 so `Node24` task handlers are accepted by upload validation.
- Synchronize task and extension versions and regenerate package lockfiles.

The task implementation remains functionally unchanged apart from URL handling and the artifact-engine 2 handler import. The migration addresses the Node 24 dependency breakages called out in the runtime migration guide, including `crypto.createDecipher()` and legacy `Buffer` usage in the previous dependency line.

**Documentation changes required:** N

**Added unit tests:** Y

Updated the External Build functional-test mocks for the artifact-engine 2 handler import. Node 24 functional validation passed:
- `DownloadArtifactsTfsGit`: 26 passing.
- `DownloadExternalBuildArtifacts`: 12 passing.

Both task source typechecks and the Git task syntax check pass. The repository-wide test compile still reports an unrelated pre-existing BitBucket `Buffer.from` typing error, but ExternalTfs tests emit and pass. Local installation of the updated tfx CLI was blocked by an expired package-feed authentication token; the root lockfile resolves `tfx-cli` to 0.24.1.

**Attached related issue:** N

**Checklist**:
- [x] Version was bumped - please check that version of the extension, task or library has been bumped.
- [x] Checked that applied changes work as expected.
